### PR TITLE
fix unknown format on image decode

### DIFF
--- a/ui/decredmaterial/icon.go
+++ b/ui/decredmaterial/icon.go
@@ -7,6 +7,7 @@ import (
 	"image"
 	"image/color"
 	"image/draw"
+	_ "image/png"
 
 	"gioui.org/f32"
 	"gioui.org/layout"


### PR DESCRIPTION
This PR fixes unknown format error when trying to decode png images. The bug won't be observed until the qrcode import in receive_page.go is removed.
