### PR TITLE
error handling on page level

### DIFF
--- a/ui/handle_input.go
+++ b/ui/handle_input.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"fmt"
 	"image/color"
 	"strings"
 	"time"
@@ -416,7 +415,6 @@ func (win *Window) HandleInputs() {
 	}
 
 	if win.inputs.signMessageDiag.Clicked(win.gtx) {
-		fmt.Println("Ddd")
 		win.current = PageSignMessage
 		return
 	}

--- a/ui/page.go
+++ b/ui/page.go
@@ -30,6 +30,7 @@ type pageCommon struct {
 	navTab          *decredmaterial.Tabs
 	walletsTab      *decredmaterial.Tabs
 	accountsTab     *decredmaterial.Tabs
+	errorChannels   map[string]chan error
 }
 
 func (win *Window) addPages() {
@@ -89,11 +90,13 @@ func (win *Window) addPages() {
 		navTab:          tabs,
 		walletsTab:      decredmaterial.NewTabs(),
 		accountsTab:     accountsTab,
+		errorChannels: map[string]chan error{
+			PageSignMessage: make(chan error),
+		},
 		//cancelDialogW:  win.theme.PlainIconButton(icons.contentClear),
 	}
 
 	win.pages = make(map[string]layout.Widget)
-
 	win.pages[PageWallet] = win.WalletPage(common)
 	win.pages[PageOverview] = win.OverviewPage
 	win.pages[PageTransactions] = win.TransactionsPage(common)
@@ -101,7 +104,7 @@ func (win *Window) addPages() {
 	win.pages[PageRestore] = win.RestorePage
 	win.pages[PageSend] = win.SendPage
 	win.pages[PageTransactionDetails] = win.TransactionPage(common)
-	win.pages[PageSignMessage] = win.SignMessagePage
+	win.pages[PageSignMessage] = win.SignMessagePage(common)
 }
 
 func (page pageCommon) Layout(gtx *layout.Context, body layout.Widget) {

--- a/wallet/commands.go
+++ b/wallet/commands.go
@@ -344,7 +344,7 @@ func (wal *Wallet) GetMultiWalletInfo() {
 	}()
 }
 
-func (wal *Wallet) SignMessage(walletID int, passphrase []byte, address, message string) {
+func (wal *Wallet) SignMessage(walletID int, passphrase []byte, address, message string, errChan chan error) {
 	go func() {
 		var resp Response
 
@@ -355,13 +355,15 @@ func (wal *Wallet) SignMessage(walletID int, passphrase []byte, address, message
 					Message: "No wallet found",
 				},
 			}
-
 			wal.Send <- resp
 			return
 		}
 
 		signedMessageBytes, err := wall.SignMessage(passphrase, address, message)
 		if err != nil {
+			go func() {
+				errChan <- err
+			}()
 			resp.Resp = &Signature{
 				Err: fmt.Errorf("error signing message: %s", err.Error()),
 			}


### PR DESCRIPTION
This PR adds error handling on individual page level. Wallet commands that are called from pages are passed a pre-created channel for the calling page. The returned error is passed to the channel and handled on the page's "handle" method using a select. 

The error handling was applied to the sign message page. A quick restructure was done on the page for a working example of the page error handling system.
