### PR TITLE
move change password to new layout

### DIFF
--- a/ui/change_passphrase.go
+++ b/ui/change_passphrase.go
@@ -1,0 +1,229 @@
+package ui
+
+import (
+	"image/color"
+	"strings"
+
+	"gioui.org/layout"
+	"gioui.org/unit"
+	"gioui.org/widget"
+
+	"github.com/raedahgroup/dcrlibwallet"
+	"github.com/raedahgroup/godcr/ui/decredmaterial"
+)
+
+const PageWalletPassphrase = "walletPassphrase"
+
+type walletPassphrasePage struct {
+	container                     layout.List
+	newPassW, confPassW, oldPassW widget.Editor
+	newPass, confPass, oldPass    decredmaterial.Editor
+	passwordBar                   *decredmaterial.ProgressBar
+	backButtonW, savePasswordW    widget.Button
+	backButton                    decredmaterial.IconButton
+	savePassword                  decredmaterial.Button
+	errorLabel                    decredmaterial.Label
+}
+
+func (win *Window) WalletPassphrasePage(common pageCommon) layout.Widget {
+	page := &walletPassphrasePage{
+		container: layout.List{
+			Axis: layout.Vertical,
+		},
+		oldPass:      common.theme.Editor("Enter old password"),
+		newPass:      common.theme.Editor("Enter new password"),
+		confPass:     common.theme.Editor("Confirm new password"),
+		savePassword: common.theme.Button("Change"),
+		errorLabel:   common.theme.Caption(""),
+		backButton:   common.theme.PlainIconButton(common.icons.navigationArrowBack),
+	}
+	page.oldPass.IsRequired = true
+	page.oldPassW.SingleLine = true
+	page.newPass.IsRequired = true
+	page.newPassW.SingleLine = true
+	page.confPass.IsRequired = true
+	page.confPassW.SingleLine = true
+	page.savePassword.TextSize = unit.Dp(11)
+	page.passwordBar = common.theme.ProgressBar(0)
+	page.errorLabel.Color = common.theme.Color.Danger
+
+	page.backButton.Color = common.theme.Color.Hint
+	page.backButton.Size = unit.Dp(32)
+
+	return func() {
+		page.Layout(common)
+		page.handle(common)
+	}
+}
+
+// Layout lays out the widgets for the change wallet passphrase page.
+func (page *walletPassphrasePage) Layout(common pageCommon) {
+	gtx := common.gtx
+	wdgs := []func(){
+		func() {
+			layout.W.Layout(common.gtx, func() {
+				page.backButton.Layout(common.gtx, &page.backButtonW)
+			})
+			layout.Inset{Left: unit.Dp(44)}.Layout(common.gtx, func() {
+				common.theme.H5("Change Wallet Password").Layout(gtx)
+			})
+		},
+		func() {
+			layout.Flex{}.Layout(gtx,
+				layout.Rigid(func() {
+					layout.Inset{Top: unit.Dp(8)}.Layout(gtx, func() {
+						common.theme.Body1("Are about changing the passphrase for").Layout(gtx)
+					})
+				}),
+				layout.Rigid(func() {
+					layout.Inset{Left: unit.Dp(5)}.Layout(gtx, func() {
+						txt := common.theme.H5(common.info.Wallets[*common.selectedWallet].Name)
+						txt.Color = common.theme.Color.Danger
+						txt.Layout(gtx)
+					})
+				}),
+			)
+		},
+		func() {
+			page.errorLabel.Layout(gtx)
+		},
+		func() {
+			page.oldPass.Layout(gtx, &page.oldPassW)
+		},
+		func() {
+			page.passwordStrength(common)
+		},
+		func() {
+			page.newPass.Layout(gtx, &page.newPassW)
+		},
+		func() {
+			page.confPass.Layout(gtx, &page.confPassW)
+		},
+		func() {
+			layout.Inset{Top: unit.Dp(20)}.Layout(gtx, func() {
+				page.savePassword.Layout(gtx, &page.savePasswordW)
+			})
+		},
+	}
+
+	common.Layout(gtx, func() {
+		layout.UniformInset(unit.Dp(20)).Layout(gtx, func() {
+			page.container.Layout(gtx, len(wdgs), func(i int) {
+				layout.UniformInset(unit.Dp(3)).Layout(gtx, wdgs[i])
+			})
+		})
+	})
+}
+
+func (page *walletPassphrasePage) passwordStrength(common pageCommon) {
+	layout.Inset{Top: unit.Dp(10)}.Layout(common.gtx, func() {
+		common.gtx.Constraints.Height.Max = 20
+		page.passwordBar.Layout(common.gtx)
+	})
+}
+
+// Handle handles all widget inputs on the main wallets page.
+func (page *walletPassphrasePage) handle(common pageCommon) {
+	gtx := common.gtx
+
+	page.handlerEditorEvents(common, &page.confPassW)
+	page.handlerEditorEvents(common, &page.newPassW)
+	page.handlerEditorEvents(common, &page.oldPassW)
+
+	if page.savePasswordW.Clicked(gtx) && page.validateInputs(common) {
+		op := page.oldPassW.Text()
+		np := page.newPassW.Text()
+
+		err := common.wallet.ChangeWalletPassphrase(common.info.Wallets[*common.selectedWallet].ID, op, np)
+		if err != nil {
+			log.Debug("Error changing wallet password " + err.Error())
+			if err.Error() == dcrlibwallet.ErrInvalidPassphrase {
+				page.errorLabel.Text = "Passphrase is incorrect"
+			} else {
+				page.errorLabel.Text = err.Error()
+			}
+			return
+		}
+
+		page.errorLabel.Text = "Password changed successfully"
+		page.errorLabel.Color = common.theme.Color.Success
+		page.savePassword.Text = "Changed"
+		page.savePassword.Background = common.theme.Color.Success
+		page.resetFields(common)
+	}
+
+	if strings.Trim(page.newPassW.Text(), " ") != "" {
+		strength := dcrlibwallet.ShannonEntropy(page.newPassW.Text()) / 4.0
+		switch {
+		case strength > 0.6:
+			page.passwordBar.ProgressColor = common.theme.Color.Success
+		case strength > 0.3 && strength <= 0.6:
+			page.passwordBar.ProgressColor = color.RGBA{248, 231, 27, 255}
+		default:
+			page.passwordBar.ProgressColor = common.theme.Color.Danger
+		}
+
+		page.passwordBar.Progress = strength * 100
+	}
+
+	if page.backButtonW.Clicked(common.gtx) {
+		page.clear(common)
+		*common.page = PageWallet
+	}
+}
+
+func (page *walletPassphrasePage) validateInputs(common pageCommon) bool {
+	page.errorLabel.Text = ""
+	page.oldPass.ErrorLabel.Text = ""
+	page.newPass.ErrorLabel.Text = ""
+	page.confPass.ErrorLabel.Text = ""
+	page.savePassword.Background = common.theme.Color.Hint
+
+	if page.oldPassW.Text() == "" {
+		page.oldPass.ErrorLabel.Text = "Please wallet old password"
+		return false
+	}
+	if page.newPassW.Text() == "" {
+		page.newPass.ErrorLabel.Text = "Please wallet new password"
+		return false
+	}
+	if page.confPassW.Text() == "" {
+		page.confPass.ErrorLabel.Text = "Please wallet new password again"
+		return false
+	}
+
+	if page.confPassW.Text() != page.newPassW.Text() {
+		page.errorLabel.Text = "New wallet passwords does no match. Try again."
+		return false
+	}
+
+	page.savePassword.Background = common.theme.Color.Primary
+	return true
+}
+
+func (page *walletPassphrasePage) handlerEditorEvents(common pageCommon, w *widget.Editor) {
+	for _, evt := range w.Events(common.gtx) {
+		switch evt.(type) {
+		case widget.ChangeEvent:
+			page.validateInputs(common)
+			return
+		}
+	}
+}
+
+func (page *walletPassphrasePage) resetFields(common pageCommon) {
+	page.oldPassW.SetText("")
+	page.newPassW.SetText("")
+	page.confPassW.SetText("")
+	page.passwordBar.Progress = 0
+}
+
+func (page *walletPassphrasePage) clear(common pageCommon) {
+	page.savePassword.Background = common.theme.Color.Hint
+	page.oldPassW.SetText("")
+	page.newPassW.SetText("")
+	page.confPassW.SetText("")
+	page.errorLabel.Text = ""
+	page.savePassword.Text = "Change"
+	page.passwordBar.Progress = 0
+}

--- a/ui/change_passphrase.go
+++ b/ui/change_passphrase.go
@@ -91,7 +91,7 @@ func (page *walletPassphrasePage) Layout(common pageCommon) {
 			page.oldPass.Layout(gtx, &page.oldPassW)
 		},
 		func() {
-			page.passwordStrength(common)
+			// page.passwordStrength(common)
 		},
 		func() {
 			page.newPass.Layout(gtx, &page.newPassW)

--- a/ui/change_passphrase.go
+++ b/ui/change_passphrase.go
@@ -149,7 +149,7 @@ func (page *walletPassphrasePage) handle(common pageCommon) {
 		page.errorLabel.Color = common.theme.Color.Success
 		page.savePassword.Text = "Changed"
 		page.savePassword.Background = common.theme.Color.Success
-		page.resetFields(common)
+		page.resetFields()
 	}
 
 	if strings.Trim(page.newPassW.Text(), " ") != "" {
@@ -211,7 +211,7 @@ func (page *walletPassphrasePage) handlerEditorEvents(common pageCommon, w *widg
 	}
 }
 
-func (page *walletPassphrasePage) resetFields(common pageCommon) {
+func (page *walletPassphrasePage) resetFields() {
 	page.oldPassW.SetText("")
 	page.newPassW.SetText("")
 	page.confPassW.SetText("")

--- a/ui/dialogs.go
+++ b/ui/dialogs.go
@@ -2,7 +2,6 @@ package ui
 
 import (
 	"gioui.org/layout"
-	"gioui.org/unit"
 )
 
 func (win *Window) AddAccountDiag() {
@@ -11,7 +10,7 @@ func (win *Window) AddAccountDiag() {
 		layout.Flex{Axis: layout.Vertical, Spacing: layout.SpaceBetween}.Layout(win.gtx,
 			layout.Rigid(func() {
 				layout.E.Layout(win.gtx, func() {
-					win.outputs.cancelDiag.Layout(win.gtx, &win.cancelDialog)
+					// win.outputs.cancelDiag.Layout(win.gtx, &win.cancelDialog)
 				})
 			}),
 			layout.Rigid(func() {
@@ -31,93 +30,5 @@ func (win *Window) AddAccountDiag() {
 				win.outputs.addAccount.Layout(win.gtx, &win.inputs.addAccount)
 			}),
 		)
-	})
-}
-
-func (win *Window) editPasswordDiag() {
-	win.theme.Surface(win.gtx, func() {
-		win.gtx.Constraints.Width.Min = win.gtx.Px(unit.Dp(450))
-		win.gtx.Constraints.Width.Max = win.gtx.Constraints.Width.Min
-		layout.UniformInset(unit.Dp(20)).Layout(win.gtx, func() {
-			win.vFlex(
-				rigid(func() {
-					win.hFlex(
-						rigid(func() {
-							win.theme.H5("Change Wallet Password").Layout(win.gtx)
-						}),
-						layout.Flexed(1, func() {
-							layout.E.Layout(win.gtx, func() {
-								win.outputs.cancelDiag.Layout(win.gtx, &win.cancelDialog)
-							})
-						}),
-					)
-				}),
-				rigid(func() {
-					win.Err()
-				}),
-				rigid(func() {
-					win.vFlexSB(
-						rigid(func() {
-							inset := layout.Inset{
-								Top: unit.Dp(10),
-							}
-							inset.Layout(win.gtx, func() {
-								win.vFlexSB(
-									rigid(func() {
-										win.theme.Body1("Old Password").Layout(win.gtx)
-									}),
-									rigid(func() {
-										win.hFlexSB(
-											layout.Flexed(1, func() {
-												win.outputs.oldSpendingPassword.Layout(win.gtx, &win.inputs.oldSpendingPassword)
-											}),
-										)
-									}),
-								)
-							})
-						}),
-						rigid(func() {
-							win.vFlexSB(
-								rigid(func() {
-									win.passwordStrength()
-								}),
-								rigid(func() {
-									win.theme.Body1("New Password").Layout(win.gtx)
-								}),
-								rigid(func() {
-									win.hFlexSB(
-										layout.Flexed(1, func() {
-											win.outputs.spendingPassword.Layout(win.gtx, &win.inputs.spendingPassword)
-										}),
-									)
-								}),
-							)
-						}),
-						rigid(func() {
-							win.theme.Body1("Confirm New Password").Layout(win.gtx)
-						}),
-						rigid(func() {
-							win.hFlexSB(
-								layout.Flexed(1, func() {
-									win.outputs.matchSpending.Layout(win.gtx, &win.inputs.matchSpending)
-								}),
-							)
-						}),
-						rigid(func() {
-							layout.Inset{Top: unit.Dp(20), Bottom: unit.Dp(15)}.Layout(win.gtx, func() {
-								win.outputs.savePassword.Layout(win.gtx, &win.inputs.savePassword)
-							})
-						}),
-					)
-				}),
-			)
-		})
-	})
-}
-
-func (win *Window) passwordStrength() {
-	layout.Inset{Top: unit.Dp(10), Bottom: unit.Dp(8)}.Layout(win.gtx, func() {
-		win.gtx.Constraints.Height.Max = 20
-		win.outputs.passwordBar.Layout(win.gtx)
 	})
 }

--- a/ui/handle_input.go
+++ b/ui/handle_input.go
@@ -183,15 +183,6 @@ func (win *Window) HandleInputs() {
 		return
 	}
 
-	if win.inputs.cancelDialog.Clicked(win.gtx) {
-		win.states.dialog = false
-		win.err = ""
-		win.resetButton()
-		win.resetPasswords()
-		log.Debug("Cancel dialog clicked")
-		return
-	}
-
 	// RECEIVE PAGE
 	if win.inputs.receiveIcons.more.Clicked(win.gtx) {
 		newAddr = !newAddr

--- a/ui/handle_input.go
+++ b/ui/handle_input.go
@@ -99,51 +99,6 @@ func (win *Window) HandleInputs() {
 		}
 	}
 
-	// VERIFY MESSAGE
-
-	if win.inputs.verifyMessDiag.Clicked(win.gtx) {
-		win.current = PageVerifyMessage
-		return
-	}
-
-	// CHANGE WALLET PASSWORD
-
-	for win.inputs.changePasswordDiag.Clicked(win.gtx) {
-		win.err = ""
-		win.dialog = win.editPasswordDiag
-		win.states.dialog = true
-	}
-
-	for win.inputs.savePassword.Clicked(win.gtx) {
-		op := win.inputs.oldSpendingPassword.Text()
-		if op == "" {
-			win.outputs.oldSpendingPassword.HintColor = win.theme.Color.Danger
-			win.err = "Old Wallet password required and cannot be empty"
-			return
-		}
-		np := win.validatePasswords()
-		if np == "" {
-			return
-		}
-
-		err := win.wallet.ChangeWalletPassphrase(win.walletInfo.Wallets[win.selected].ID, op, np)
-		if err != nil {
-			log.Debug("Error changing wallet password " + err.Error())
-			if err.Error() == dcrlibwallet.ErrInvalidPassphrase {
-				win.err = "Passphrase is incorrect"
-			} else {
-				win.err = err.Error()
-			}
-			return
-		}
-
-		win.err = "Password changed successfully"
-		win.outputs.err.Color = win.theme.Color.Success
-		win.outputs.savePassword.Text = "Changed"
-		win.outputs.savePassword.Background = win.theme.Color.Success
-		win.resetPasswords()
-	}
-
 	// ADD ACCOUNT
 
 	if win.inputs.addAcctDiag.Clicked(win.gtx) {

--- a/ui/handle_input.go
+++ b/ui/handle_input.go
@@ -193,7 +193,6 @@ func (win *Window) HandleInputs() {
 	}
 
 	// RECEIVE PAGE
-
 	if win.inputs.receiveIcons.more.Clicked(win.gtx) {
 		newAddr = !newAddr
 	}

--- a/ui/page.go
+++ b/ui/page.go
@@ -122,6 +122,7 @@ func (win *Window) addPages() {
 	win.pages[PageTransactionDetails] = win.TransactionPage(common)
 	win.pages[PageSignMessage] = win.SignMessagePage(common)
 	win.pages[PageVerifyMessage] = win.VerifyMessagePage(common)
+	win.pages[PageWalletPassphrase] = win.WalletPassphrasePage(common)
 }
 
 func (page pageCommon) Layout(gtx *layout.Context, body layout.Widget) {

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -377,6 +377,10 @@ func (page *walletPage) Handle(common pageCommon) {
 		return
 	}
 
+	if page.walletPasshrase.Clicked(gtx) {
+		*common.page = PageWalletPassphrase
+	}
+
 	if page.rename.Clicked(gtx) {
 		name := page.editor.Text()
 		if name == "" {

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -368,6 +368,11 @@ func (page *walletPage) Handle(common pageCommon) {
 		return
 	}
 
+	if page.icons.changePass.Clicked(gtx) {
+		*common.page = PageWalletPassphrase
+		return
+	}
+
 	if page.icons.sign.Clicked(gtx) {
 		*common.page = PageSignMessage
 	}
@@ -375,10 +380,6 @@ func (page *walletPage) Handle(common pageCommon) {
 	if page.icons.verify.Clicked(gtx) {
 		*common.page = PageVerifyMessage
 		return
-	}
-
-	if page.walletPasshrase.Clicked(gtx) {
-		*common.page = PageWalletPassphrase
 	}
 
 	if page.rename.Clicked(gtx) {

--- a/ui/widgets.go
+++ b/ui/widgets.go
@@ -12,14 +12,11 @@ import (
 )
 
 type inputs struct {
-	cancelDialog                                                         widget.Button
 	renameWallet                                                         widget.Button
 	addAccount, toggleWalletRename                                       widget.Button
 	toOverview, toWallets, toTransactions, toSend, toSettings            widget.Button
 	toReceive                                                            widget.Button
-	changePasswordDiag, signMessageDiag                                  widget.Button
 	spendingPassword, matchSpending, oldSpendingPassword, rename, dialog widget.Editor
-	verifyMessDiag                                                       widget.Button
 	addAcctDiag, savePassword                                            widget.Button
 
 	receiveIcons struct {


### PR DESCRIPTION
### Resolves

Issue #113 

### What's new
move the change password page to the new wallet layout.
![ezgif com-video-to-gif(6)](https://user-images.githubusercontent.com/27733432/82899213-81adb100-9f52-11ea-8332-172b70e0d635.gif)

<img width="800" alt="image" src="https://user-images.githubusercontent.com/27733432/82898895-f3392f80-9f51-11ea-8722-688e63c755e8.png">


