### PR TITLE
use universal suggestion widgets for all editors

### DIFF
--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -379,14 +379,8 @@ func (pg *createRestore) onSuggestionSeedsClicked() {
 }
 
 func (pg *createRestore) editorSeedsEventsHandler() {
-	var focused []int
-
 	for i := 0; i < len(pg.seedEditorWidgets.editors); i++ {
 		editor := &pg.seedEditorWidgets.editors[i]
-
-		if editor.Focused() && editor.Text() == "" {
-			focused = append(focused, i)
-		}
 
 		for _, e := range editor.Events(pg.gtx) {
 			switch e.(type) {
@@ -405,14 +399,6 @@ func (pg *createRestore) editorSeedsEventsHandler() {
 				}
 			case widget.SubmitEvent:
 			}
-		}
-	}
-
-	if focused != nil {
-		if len(focused) > 1 && pg.seedEditorWidgets.focusIndex != currentFocus(focused) {
-			pg.seedEditorWidgets.focusIndex = -1
-		} else if len(focused) == 1 && pg.seedEditorWidgets.focusIndex != focused[0] {
-			pg.seedEditorWidgets.focusIndex = -1
 		}
 	}
 }

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -379,6 +379,9 @@ func (pg *createRestore) onSuggestionSeedsClicked() {
 			pg.seedEditorWidgets.editors[index].SetText(b.skin.Text)
 			pg.seedEditorWidgets.editors[index].Move(len(b.skin.Text))
 			pg.seedClicked = true
+			if index != 32 {
+				pg.seedEditorWidgets.editors[index+1].Focus()
+			}
 		}
 	}
 }
@@ -456,6 +459,10 @@ func (pg *createRestore) editorSeedsEventsHandler() {
 				pg.suggestions = pg.suggestionSeeds(editor.Text())
 				for k, s := range pg.suggestions {
 					pg.seedSuggestions[k].skin.Text = s
+				}
+			case widget.SubmitEvent:
+				if i != 32 {
+					pg.seedEditorWidgets.editors[i+1].Focus()
 				}
 			}
 		}
@@ -600,6 +607,7 @@ func (pg *createRestore) handle(common pageCommon) {
 
 		if pg.showRestore {
 			pg.wal.RestoreWallet(pg.seedPhrase, pass, pg.errChan)
+			pg.resetSeeds()
 		} else {
 			pg.wal.CreateWallet(pass, pg.errChan)
 		}

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -55,7 +55,6 @@ type createRestore struct {
 	hidePasswordModal     decredmaterial.Button
 	showRestoreWallet     decredmaterial.Button
 	seedEditors           []decredmaterial.Editor
-	seedSuggestionButtons []decredmaterial.Button
 	spendingPassword      decredmaterial.Editor
 	matchSpendingPassword decredmaterial.Editor
 	addWallet             decredmaterial.Button


### PR DESCRIPTION
### Resolves

Issue #126 

### What's new

This PR replaces the previous seed suggestion implementation. Rather than defining suggestion seeds for each editor, it uses the same suggestion widgets for all editors only displaying them on active editors. It fixes the flickering of the restore page on scroll. It also fixes briefly displayed suggestions for the previously active editor when selecting another one.

