### PR TITLE
sort wallet order

### DIFF
--- a/wallet/commands.go
+++ b/wallet/commands.go
@@ -297,7 +297,7 @@ func (wal *Wallet) GetMultiWalletInfo() {
 		var completeTotal int64
 		infos := make([]InfoShort, len(wallets))
 		i := 0
-		for id, wall := range wallets {
+		for _, wall := range wallets {
 			iter, err := wall.AccountsIterator(wal.confirms)
 			if err != nil {
 				resp.Err = err
@@ -312,7 +312,7 @@ func (wal *Wallet) GetMultiWalletInfo() {
 					var er error
 					addr, er = wall.CurrentAddress(acct.Number)
 					if er != nil {
-						log.Error("Could not get current address for wallet ", id, "account", acct.Number)
+						log.Error("Could not get current address for wallet ", wall.ID, "account", acct.Number)
 					}
 				}
 				accts = append(accts, Account{

--- a/wallet/commands.go
+++ b/wallet/commands.go
@@ -341,6 +341,14 @@ func (wal *Wallet) GetMultiWalletInfo() {
 			}
 			i++
 		}
+
+		// sort infos by wallet ids
+		if len(infos) > 0 {
+			sort.SliceStable(infos, func(i, j int) bool {
+				return infos[i].ID < infos[j].ID
+			})
+		}
+
 		best := wal.multi.GetBestBlock()
 
 		if best == nil {

--- a/wallet/commands.go
+++ b/wallet/commands.go
@@ -206,7 +206,7 @@ func (wal *Wallet) GetAllTransactions(offset, limit, txfilter int32) {
 					Txn:           txnRaw,
 					Status:        status,
 					Balance:       dcrutil.Amount(txnRaw.Amount).String(),
-					WalletName:    wallets[txnRaw.WalletID].Name,
+					WalletName:    wall.Name,
 					Confirmations: confirmations,
 				}
 				recentTxs = append(recentTxs, txn)

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -113,7 +113,7 @@ func (wal *Wallet) wallets() ([]dcrlibwallet.Wallet, error) {
 	}
 
 	// sort wallet by ids
-	if wallets != nil && len(wallets) > 0 {
+	if len(wallets) > 0 {
 		sort.SliceStable(wallets, func(i, j int) bool {
 			return wallets[i].ID < wallets[j].ID
 		})

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -4,6 +4,7 @@ package wallet
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/raedahgroup/dcrlibwallet"
 )
@@ -91,15 +92,14 @@ func (wal *Wallet) LoadWallets() {
 }
 
 // wallets returns an up-to-date map of all opened wallets
-func (wal *Wallet) wallets() (map[int]*dcrlibwallet.Wallet, error) {
+func (wal *Wallet) wallets() ([]dcrlibwallet.Wallet, error) {
 	if wal.multi == nil {
 		return nil, MultiWalletError{
 			Message: "No MultiWallet loaded",
 		}
 	}
 
-	wallets := make(map[int]*dcrlibwallet.Wallet, len(wal.multi.OpenedWalletIDsRaw()))
-
+	wallets := []dcrlibwallet.Wallet{}
 	for _, j := range wal.multi.OpenedWalletIDsRaw() {
 		w := wal.multi.WalletWithID(j)
 		if w == nil {
@@ -109,8 +109,16 @@ func (wal *Wallet) wallets() (map[int]*dcrlibwallet.Wallet, error) {
 				Affected: []int{j},
 			}
 		}
-		wallets[j] = w
+		wallets = append(wallets, *w)
 	}
+
+	// sort wallet by ids
+	if wallets != nil && len(wallets) > 0 {
+		sort.SliceStable(wallets, func(i, j int) bool {
+			return wallets[i].ID < wallets[j].ID
+		})
+	}
+
 	return wallets, nil
 }
 


### PR DESCRIPTION
### Resolves

Issue #121 

### What's new

This sorts the wallet slice returned by "GetMultiWalletInfo" such that the order of wallets returned is always maintained.