### PR TITLE
Fix wallet page

### DIFF
--- a/ui/page.go
+++ b/ui/page.go
@@ -167,6 +167,9 @@ func (page pageCommon) LayoutWithWallets(gtx *layout.Context, body layout.Widget
 			*page.selectedAccount = 0
 			page.accountsTab.Selected = 0
 		}
+		if *page.selectedWallet == 0 {
+			page.walletsTab.Selected = *page.selectedWallet
+		}
 		page.walletsTab.Separator = false
 		page.walletsTab.Layout(gtx, body)
 	}

--- a/ui/state.go
+++ b/ui/state.go
@@ -45,10 +45,10 @@ func (win *Window) updateStates(update interface{}) {
 		win.states.creating = false
 		win.window.Invalidate()
 	case wallet.DeletedWallet:
+		win.selected = 0
 		win.current = PageWallet
 		win.states.dialog = false
 		win.states.deleted = true
-		win.reloadTabs()
 		win.window.Invalidate()
 	case wallet.AddedAccount:
 		win.states.dialog = false

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -121,6 +121,7 @@ func (page *walletPage) Layout(common pageCommon) {
 	}
 	if common.states.deleted {
 		page.subPage = subWalletMain
+		common.states.deleted = false
 	}
 }
 
@@ -333,9 +334,7 @@ func (page *walletPage) subDelete(common pageCommon) {
 		})
 	})
 	if page.isPasswordModalOpen {
-		common.Layout(gtx, func() {
-			page.passwordModal.Layout(gtx, page.confirm, page.cancel)
-		})
+		page.passwordModal.Layout(gtx, page.confirm, page.cancel)
 	}
 }
 


### PR DESCRIPTION
### Resolves

Issue #135 

### What's new
*Fix issues with page crashing when a wallet is deleted
*Password modal not occupying the full screen
*Selected wallet mismatch after wallet deletion as the selected wallet tab and displayed selected wallet details are different.
