### PR TITLE
Add Seed reset button to restore page.

### DIFF
--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -59,7 +59,6 @@ type createRestore struct {
 	hidePasswordModal  decredmaterial.Button
 	showRestoreWallet  decredmaterial.Button
 	showReset          decredmaterial.Button
-	hideResetModal     decredmaterial.Button
 
 	seedEditors           []decredmaterial.Editor
 	spendingPassword      decredmaterial.Editor
@@ -78,7 +77,6 @@ type createRestore struct {
 	matchSpendingPasswordWidget *editor.Editor
 	addWalletWidget             *widget.Button
 	showResetWidget             *widget.Button
-	hideResetModalWidget        *widget.Button
 
 	seedListLeft     *layout.List
 	seedListRight    *layout.List
@@ -106,13 +104,11 @@ func (win *Window) CreateRestorePage(common pageCommon) layout.Widget {
 		matchSpendingPasswordWidget: new(editor.Editor),
 		addWalletWidget:             new(widget.Button),
 		showResetWidget:             new(widget.Button),
-		hideResetModalWidget:        new(widget.Button),
 
 		errLabel:              common.theme.Body1(""),
 		spendingPassword:      common.theme.Editor("Enter password"),
 		matchSpendingPassword: common.theme.Editor("Enter password again"),
 		addWallet:             common.theme.Button("create wallet"),
-		hideResetModal:        common.theme.Button("cancel"),
 		suggestionLimit:       3,
 	}
 

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -42,6 +42,7 @@ type createRestore struct {
 	showRestore     bool
 	restoring       bool
 	showPassword    bool
+	showWarning     bool
 	seedPhrase      string
 	suggestionLimit int
 	suggestions     []string
@@ -51,12 +52,16 @@ type createRestore struct {
 	lastOffsetLeft  int
 	focused         []int
 
-	closeCreateRestore    decredmaterial.IconButton
-	hideRestoreWallet     decredmaterial.IconButton
-	create                decredmaterial.Button
-	showPasswordModal     decredmaterial.Button
-	hidePasswordModal     decredmaterial.Button
-	showRestoreWallet     decredmaterial.Button
+	closeCreateRestore decredmaterial.IconButton
+	hideRestoreWallet  decredmaterial.IconButton
+	create             decredmaterial.Button
+	showPasswordModal  decredmaterial.Button
+	hidePasswordModal  decredmaterial.Button
+	showRestoreWallet  decredmaterial.Button
+	showresetModal     decredmaterial.Button
+	resetSeedFields    decredmaterial.Button
+	hideResetModal     decredmaterial.Button
+
 	seedEditors           []decredmaterial.Editor
 	spendingPassword      decredmaterial.Editor
 	matchSpendingPassword decredmaterial.Editor
@@ -73,6 +78,9 @@ type createRestore struct {
 	spendingPasswordWidget      *editor.Editor
 	matchSpendingPasswordWidget *editor.Editor
 	addWalletWidget             *widget.Button
+	showResetModalWidget        *widget.Button
+	hideResetModalWidget        *widget.Button
+	resetSeedFieldsWidget       *widget.Button
 
 	seedListLeft     *layout.List
 	seedListRight    *layout.List
@@ -99,13 +107,16 @@ func (win *Window) CreateRestorePage(common pageCommon) layout.Widget {
 		spendingPasswordWidget:      new(editor.Editor),
 		matchSpendingPasswordWidget: new(editor.Editor),
 		addWalletWidget:             new(widget.Button),
+		showResetModalWidget:        new(widget.Button),
+		hideResetModalWidget:        new(widget.Button),
+		resetSeedFieldsWidget:       new(widget.Button),
 
 		errLabel:              common.theme.Body1(""),
 		spendingPassword:      common.theme.Editor("Enter password"),
 		matchSpendingPassword: common.theme.Editor("Enter password again"),
 		addWallet:             common.theme.Button("create wallet"),
-
-		suggestionLimit: 3,
+		hideResetModal:        common.theme.Button("cancel"),
+		suggestionLimit:       3,
 	}
 
 	pg.matchSpendingPasswordWidget.SingleLine = true
@@ -126,6 +137,13 @@ func (win *Window) CreateRestorePage(common pageCommon) layout.Widget {
 	pg.hidePasswordModal = common.theme.Button("cancel")
 	pg.hidePasswordModal.Color = common.theme.Color.Danger
 	pg.hidePasswordModal.Background = color.RGBA{R: 238, G: 238, B: 238, A: 255}
+
+	pg.showresetModal = common.theme.Button("reset")
+	pg.showresetModal.Color = common.theme.Color.Hint
+	pg.showresetModal.Background = color.RGBA{}
+
+	pg.resetSeedFields = common.theme.Button("Yes Reset")
+	pg.resetSeedFields.Background = common.theme.Color.Danger
 
 	pg.errLabel.Color = pg.theme.Color.Danger
 
@@ -210,12 +228,41 @@ func (pg *createRestore) layout(common pageCommon) {
 						}),
 						layout.Rigid(func() {
 							layout.UniformInset(unit.Dp(5)).Layout(pg.gtx, func() {
+								pg.hidePasswordModal.Color = common.theme.Color.Primary
 								pg.hidePasswordModal.Layout(pg.gtx, pg.hidePasswordModalWidget)
 							})
 						}),
 					)
 				},
 			}
+			pg.theme.Modal(pg.gtx, modalTitle, w)
+		}
+
+		if pg.showWarning {
+			modalTitle := "Warning !!!"
+			var msg = "You are about clearing all the seed input fields. \nAre you sure you want to proceed with this action?."
+			w := []func(){
+				func() {
+					txt := common.theme.Body1(msg)
+					txt.Color = common.theme.Color.Danger
+					txt.Layout(pg.gtx)
+				},
+				func() {
+					layout.Flex{Axis: layout.Horizontal}.Layout(pg.gtx,
+						layout.Rigid(func() {
+							layout.UniformInset(unit.Dp(5)).Layout(pg.gtx, func() {
+								pg.resetSeedFields.Layout(pg.gtx, pg.resetSeedFieldsWidget)
+							})
+						}),
+						layout.Rigid(func() {
+							layout.UniformInset(unit.Dp(5)).Layout(pg.gtx, func() {
+								pg.hidePasswordModal.Layout(pg.gtx, pg.hidePasswordModalWidget)
+							})
+						}),
+					)
+				},
+			}
+
 			pg.theme.Modal(pg.gtx, modalTitle, w)
 		}
 	})
@@ -302,9 +349,16 @@ func (pg *createRestore) restore() layout.Widget {
 			}),
 			layout.Rigid(func() {
 				layout.Center.Layout(pg.gtx, func() {
-					layout.Inset{Top: unit.Dp(15), Bottom: unit.Dp(15)}.Layout(pg.gtx, func() {
-						pg.showPasswordModal.Layout(pg.gtx, pg.showPasswordModalWidget)
-					})
+					layout.Flex{Alignment: layout.Middle}.Layout(pg.gtx,
+						layout.Rigid(func() {
+							layout.Inset{Top: unit.Dp(15), Bottom: unit.Dp(15), Right: unit.Dp(10)}.Layout(pg.gtx, func() {
+								pg.showPasswordModal.Layout(pg.gtx, pg.showPasswordModalWidget)
+							})
+						}),
+						layout.Rigid(func() {
+							pg.showresetModal.Layout(pg.gtx, pg.showResetModalWidget)
+						}),
+					)
 				})
 			}),
 		)
@@ -595,8 +649,13 @@ func (pg *createRestore) handle(common pageCommon) {
 
 	for pg.hidePasswordModalWidget.Clicked(gtx) {
 		pg.showPassword = false
+		pg.showWarning = false
 		pg.errLabel.Text = ""
 		pg.resetPasswords()
+	}
+
+	for pg.showResetModalWidget.Clicked(gtx) {
+		pg.showWarning = true
 	}
 
 	if pg.addWalletWidget.Clicked(gtx) {

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -56,7 +56,7 @@ type createRestore struct {
 	hideRestoreWallet  decredmaterial.IconButton
 	create             decredmaterial.Button
 	showPasswordModal  decredmaterial.Button
-	hideModal          decredmaterial.Button
+	hidePasswordModal  decredmaterial.Button
 	showRestoreWallet  decredmaterial.Button
 	showReset          decredmaterial.Button
 	hideResetModal     decredmaterial.Button
@@ -70,7 +70,7 @@ type createRestore struct {
 	seedEditorWidgets           seedEditors
 	toCreateWalletWidget        *widget.Button
 	showPasswordModalWidget     *widget.Button
-	hideModalWidget             *widget.Button
+	hidePasswordModalWidget     *widget.Button
 	backCreateRestoreWidget     *widget.Button
 	showRestoreWidget           *widget.Button
 	hideRestoreWidget           *widget.Button
@@ -101,7 +101,7 @@ func (win *Window) CreateRestorePage(common pageCommon) layout.Widget {
 		showRestoreWidget:           new(widget.Button),
 		hideRestoreWidget:           new(widget.Button),
 		showPasswordModalWidget:     new(widget.Button),
-		hideModalWidget:             new(widget.Button),
+		hidePasswordModalWidget:     new(widget.Button),
 		spendingPasswordWidget:      new(editor.Editor),
 		matchSpendingPasswordWidget: new(editor.Editor),
 		addWalletWidget:             new(widget.Button),
@@ -131,9 +131,9 @@ func (win *Window) CreateRestorePage(common pageCommon) layout.Widget {
 	pg.hideRestoreWallet.Background = color.RGBA{}
 	pg.hideRestoreWallet.Color = common.theme.Color.Hint
 
-	pg.hideModal = common.theme.Button("cancel")
-	pg.hideModal.Color = common.theme.Color.Danger
-	pg.hideModal.Background = color.RGBA{R: 238, G: 238, B: 238, A: 255}
+	pg.hidePasswordModal = common.theme.Button("cancel")
+	pg.hidePasswordModal.Color = common.theme.Color.Danger
+	pg.hidePasswordModal.Background = color.RGBA{R: 238, G: 238, B: 238, A: 255}
 
 	pg.showReset = common.theme.Button("reset")
 	pg.showReset.Color = common.theme.Color.Hint
@@ -222,8 +222,8 @@ func (pg *createRestore) layout(common pageCommon) {
 						}),
 						layout.Rigid(func() {
 							layout.UniformInset(unit.Dp(5)).Layout(pg.gtx, func() {
-								pg.hideModal.Color = common.theme.Color.Primary
-								pg.hideModal.Layout(pg.gtx, pg.hideModalWidget)
+								pg.hidePasswordModal.Color = common.theme.Color.Primary
+								pg.hidePasswordModal.Layout(pg.gtx, pg.hidePasswordModalWidget)
 							})
 						}),
 					)
@@ -632,7 +632,7 @@ func (pg *createRestore) handle(common pageCommon) {
 		pg.showPassword = true
 	}
 
-	for pg.hideModalWidget.Clicked(gtx) {
+	for pg.hidePasswordModalWidget.Clicked(gtx) {
 		pg.showPassword = false
 		pg.showWarning = false
 		pg.errLabel.Text = ""

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -142,7 +142,7 @@ func (win *Window) CreateRestorePage(common pageCommon) layout.Widget {
 	pg.showresetModal.Color = common.theme.Color.Hint
 	pg.showresetModal.Background = color.RGBA{}
 
-	pg.resetSeedFields = common.theme.Button("yes reset")
+	pg.resetSeedFields = common.theme.Button("yes, reset")
 	pg.resetSeedFields.Color = common.theme.Color.Danger
 	pg.resetSeedFields.Background = color.RGBA{R: 238, G: 238, B: 238, A: 255}
 
@@ -663,6 +663,12 @@ func (pg *createRestore) handle(common pageCommon) {
 
 	for pg.showResetModalWidget.Clicked(gtx) {
 		pg.showWarning = true
+	}
+
+	for pg.resetSeedFieldsWidget.Clicked(gtx) {
+		pg.resetSeeds()
+		pg.seedEditorWidgets.focusIndex = -1
+		pg.showWarning = false
 	}
 
 	if pg.addWalletWidget.Clicked(gtx) {

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -102,14 +102,17 @@ func (t *Theme) Modal(gtx *layout.Context, title string, wd []func()) {
 					t.H4(title).Layout(gtx)
 				},
 				func() {
-					t.Line().Layout(gtx)
+					line := t.Line()
+					// line.Color = t.Color.Text
+					line.Width = gtx.Constraints.Width.Max
+					line.Layout(gtx)
 				},
 			}
 			w = append(w, wd...)
 
 			layout.UniformInset(unit.Dp(60)).Layout(gtx, func() {
 				fillMax(gtx, t.Color.Surface)
-				(&layout.List{Axis: layout.Vertical}).Layout(gtx, len(w), func(i int) {
+				(&layout.List{Axis: layout.Vertical, Alignment: layout.Middle}).Layout(gtx, len(w), func(i int) {
 					layout.UniformInset(unit.Dp(10)).Layout(gtx, w[i])
 				})
 			})

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -103,7 +103,6 @@ func (t *Theme) Modal(gtx *layout.Context, title string, wd []func()) {
 				},
 				func() {
 					line := t.Line()
-					// line.Color = t.Color.Text
 					line.Width = gtx.Constraints.Width.Max
 					line.Layout(gtx)
 				},


### PR DESCRIPTION
### Resolves

Issue #148 

### What's new

This PR adds a reset button to the restore page to enable users reset the seed fields in the event he makes a mistake.


### Relevant screenshots or logs
<img width="803" alt="image" src="https://user-images.githubusercontent.com/27733432/84353574-57e1c480-abb7-11ea-889a-7bcf0ee737d8.png">

<img width="800" alt="image" src="https://user-images.githubusercontent.com/27733432/84353789-b1e28a00-abb7-11ea-879f-b4cf3ba6db45.png">


