### PR TITLE
Fix inaccurate wallet balance on send page

### DIFF
--- a/ui/page.go
+++ b/ui/page.go
@@ -203,6 +203,7 @@ func (page pageCommon) LayoutWithAccounts(gtx *layout.Context, body layout.Widge
 	}
 
 	page.LayoutWithWallets(gtx, func() {
+		width := gtx.Constraints.Width.Max
 		layout.Flex{}.Layout(gtx,
 			layout.Rigid(func() {
 				layout.Inset{Top: unit.Dp(10), Right: unit.Dp(10)}.Layout(gtx, func() {
@@ -210,7 +211,9 @@ func (page pageCommon) LayoutWithAccounts(gtx *layout.Context, body layout.Widge
 				})
 			}),
 			layout.Rigid(func() {
-				page.accountsTab.Layout(gtx, body)
+				page.accountsTab.Layout(gtx, func() {
+					layout.Inset{Left: unit.Dp(float32(gtx.Constraints.Width.Max-width-20) / 2)}.Layout(gtx, body)
+				})
 			}),
 		)
 	})

--- a/ui/page.go
+++ b/ui/page.go
@@ -203,7 +203,7 @@ func (page pageCommon) LayoutWithAccounts(gtx *layout.Context, body layout.Widge
 	}
 
 	page.LayoutWithWallets(gtx, func() {
-		width := gtx.Constraints.Width.Max
+		bodyWidth := gtx.Constraints.Width.Max
 		layout.Flex{}.Layout(gtx,
 			layout.Rigid(func() {
 				layout.Inset{Top: unit.Dp(10), Right: unit.Dp(10)}.Layout(gtx, func() {
@@ -212,7 +212,8 @@ func (page pageCommon) LayoutWithAccounts(gtx *layout.Context, body layout.Widge
 			}),
 			layout.Rigid(func() {
 				page.accountsTab.Layout(gtx, func() {
-					layout.Inset{Left: unit.Dp(float32(gtx.Constraints.Width.Max-width-20) / 2)}.Layout(gtx, body)
+					leftInset := unit.Dp(-float32(bodyWidth-gtx.Constraints.Width.Max) / 2)
+					layout.Inset{Left: leftInset}.Layout(gtx, body)
 				})
 			}),
 		)

--- a/ui/recieve_page.go
+++ b/ui/recieve_page.go
@@ -76,29 +76,23 @@ func (win *Window) ReceivePage(common pageCommon) layout.Widget {
 
 func (p *receivePage) Layout(common pageCommon) {
 	body := func() {
-		inset := layout.Inset{
-			Left: unit.Dp(-110),
-		}
-		inset.Layout(common.gtx, func() {
-			layout.Stack{Alignment: layout.NE}.Layout(p.gtx,
-				layout.Expanded(func() {
-					layout.Inset{Top: unit.Dp(15)}.Layout(p.gtx, func() {
-						layout.Flex{}.Layout(p.gtx,
-							layout.Flexed(1, func() {
-								p.ReceivePageContents(common)
-							}),
-						)
-					})
-				}),
-				layout.Stacked(func() {
-					layout.Inset{Right: unit.Dp(30)}.Layout(p.gtx, func() {
-						p.rightNav()
-					})
-				}),
-			)
-		})
+		layout.Stack{Alignment: layout.NE}.Layout(p.gtx,
+			layout.Expanded(func() {
+				layout.Inset{Top: unit.Dp(15)}.Layout(p.gtx, func() {
+					layout.Flex{}.Layout(p.gtx,
+						layout.Flexed(1, func() {
+							p.ReceivePageContents(common)
+						}),
+					)
+				})
+			}),
+			layout.Stacked(func() {
+				layout.Inset{Right: unit.Dp(30)}.Layout(p.gtx, func() {
+					p.rightNav()
+				})
+			}),
+		)
 	}
-
 	common.LayoutWithAccounts(p.gtx, body)
 }
 

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -294,11 +294,6 @@ func (pg *SendPage) Handle(c pageCommon) {
 
 func (pg *SendPage) Layout(common pageCommon) {
 	if len(common.info.Wallets) == 0 {
-		common.Layout(common.gtx, func() {
-			layout.Center.Layout(common.gtx, func() {
-				common.theme.H3("No wallet loaded").Layout(common.gtx)
-			})
-		})
 		return
 	}
 
@@ -335,7 +330,7 @@ func (pg *SendPage) Layout(common pageCommon) {
 
 	common.LayoutWithWallets(common.gtx, func() {
 		common.accountTab(common.gtx, func() {
-			layout.UniformInset(unit.Dp(7)).Layout(common.gtx, func() {
+			layout.Inset{Right: unit.Dp(110)}.Layout(common.gtx, func() {
 				pg.pageContainer.Layout(common.gtx, len(pageContent), func(i int) {
 					layout.Inset{Top: unit.Dp(5)}.Layout(common.gtx, pageContent[i])
 				})

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -328,12 +328,10 @@ func (pg *SendPage) Layout(common pageCommon) {
 		},
 	}
 
-	common.LayoutWithWallets(common.gtx, func() {
-		common.accountTab(common.gtx, func() {
-			layout.Inset{Right: unit.Dp(110)}.Layout(common.gtx, func() {
-				pg.pageContainer.Layout(common.gtx, len(pageContent), func(i int) {
-					layout.Inset{Top: unit.Dp(5)}.Layout(common.gtx, pageContent[i])
-				})
+	common.LayoutWithAccounts(common.gtx, func() {
+		layout.Inset{Right: unit.Dp(110)}.Layout(common.gtx, func() {
+			pg.pageContainer.Layout(common.gtx, len(pageContent), func(i int) {
+				layout.Inset{Top: unit.Dp(5)}.Layout(common.gtx, pageContent[i])
 			})
 		})
 	})

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -329,7 +329,7 @@ func (pg *SendPage) Layout(common pageCommon) {
 	}
 
 	common.LayoutWithAccounts(common.gtx, func() {
-		layout.Inset{Right: unit.Dp(110)}.Layout(common.gtx, func() {
+		layout.UniformInset(unit.Dp(10)).Layout(common.gtx, func() {
 			pg.pageContainer.Layout(common.gtx, len(pageContent), func(i int) {
 				layout.Inset{Top: unit.Dp(5)}.Layout(common.gtx, pageContent[i])
 			})


### PR DESCRIPTION
Resolve #149 

Page's wallet didn't update state when the wallet tabs at other pages switched
Also the Send Page implements it own walletTabs, accountTabs, this isn't consistent with other, eg: Recive, Transactions Pages
PR implements walletsTab, accountTabs from pageCommon upstream
