### PR TITLE
Enforce dynamic modal dimensions

### DIFF
--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -209,7 +209,7 @@ func (pg *createRestore) layout(gtx layout.Context, common pageCommon) layout.Di
 							)
 						},
 					}
-					return pg.createModal.Layout(gtx, w, 1350)
+					return pg.createModal.Layout(gtx, w, 1300)
 				}
 				return layout.Dimensions{}
 			}),
@@ -243,7 +243,7 @@ func (pg *createRestore) layout(gtx layout.Context, common pageCommon) layout.Di
 							})
 						},
 					}
-					return pg.warningModal.Layout(gtx, w, 1350)
+					return pg.warningModal.Layout(gtx, w, 1300)
 				}
 				return layout.Dimensions{}
 			}),

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -69,6 +69,9 @@ type createRestore struct {
 	autoCompleteList *layout.List
 
 	seedSuggestions []decredmaterial.Button
+
+	createModal  *decredmaterial.Modal
+	warningModal *decredmaterial.Modal
 }
 
 // Loading lays out the loading widget with a faded background
@@ -86,6 +89,8 @@ func (win *Window) CreateRestorePage(common pageCommon) layout.Widget {
 		addWallet:             common.theme.Button(new(widget.Clickable), "create wallet"),
 		hideResetModal:        common.theme.Button(new(widget.Clickable), "cancel"),
 		suggestionLimit:       3,
+		createModal:           common.theme.Modal(""),
+		warningModal:          common.theme.Modal(""),
 	}
 
 	pg.matchSpendingPassword.Editor.SingleLine = true
@@ -168,9 +173,9 @@ func (pg *createRestore) layout(gtx layout.Context, common pageCommon) layout.Di
 			}),
 			layout.Rigid(func(gtx C) D {
 				if pg.showPassword {
-					modalTitle := "Create Wallet"
+					pg.createModal.SetTitle("Create Wallet")
 					if pg.showRestore {
-						modalTitle = "Restore Wallet"
+						pg.createModal.SetTitle("Restore Wallet")
 					}
 
 					w := []func(gtx C) D{
@@ -204,13 +209,13 @@ func (pg *createRestore) layout(gtx layout.Context, common pageCommon) layout.Di
 							)
 						},
 					}
-					return pg.theme.Modal(gtx, modalTitle, w)
+					return pg.createModal.Layout(gtx, w, 1350)
 				}
 				return layout.Dimensions{}
 			}),
 			layout.Rigid(func(gtx C) D {
 				if pg.showWarning {
-					modalTitle := "Reset Seed Input"
+					pg.warningModal.SetTitle("Reset Seed Input")
 					var msg = "You are about clearing all the seed input fields. Are you sure you want to proceed with this action?"
 					w := []func(gtx C) D{
 						func(gtx C) D {
@@ -238,7 +243,7 @@ func (pg *createRestore) layout(gtx layout.Context, common pageCommon) layout.Di
 							})
 						},
 					}
-					return pg.theme.Modal(gtx, modalTitle, w)
+					return pg.warningModal.Layout(gtx, w, 1350)
 				}
 				return layout.Dimensions{}
 			}),

--- a/ui/decredmaterial/modal.go
+++ b/ui/decredmaterial/modal.go
@@ -1,29 +1,79 @@
 package decredmaterial
 
 import (
+	"image/color"
+
 	"gioui.org/layout"
+	"gioui.org/unit"
 	"gioui.org/widget"
 )
 
-// Modal lays out a widget Stacked (with Directrion) after a Stacked area filled with Background.
-// The Stacked background is laid out with max Contraints.
 type Modal struct {
-	layout.Direction
+	titleLabel     Label
+	titleSeparator *Line
+
+	overlayColor    color.RGBA
+	backgroundColor color.RGBA
+	list            *layout.List
+	button          *widget.Clickable
 }
 
-// Layout the modal
-func (m Modal) Layout(gtx layout.Context, background, dialog layout.Widget) layout.Dimensions {
-	dims := layout.Stack{Alignment: m.Direction}.Layout(gtx,
-		layout.Stacked(background),
+func (t *Theme) Modal(title string) *Modal {
+	overlayColor := t.Color.Black
+	overlayColor.A = 200
+
+	return &Modal{
+		titleLabel:     t.H6(title),
+		titleSeparator: t.Line(),
+
+		overlayColor:    overlayColor,
+		backgroundColor: t.Color.Surface,
+		list:            &layout.List{Axis: layout.Vertical, Alignment: layout.Middle},
+		button:          new(widget.Clickable),
+	}
+}
+
+func (m *Modal) SetTitle(title string) {
+	m.titleLabel.Text = title
+}
+
+// Layout renders the modal widget to screen. The modal assumes the size of
+// it's content plus padding.
+func (m *Modal) Layout(gtx layout.Context, widgets []func(gtx C) D, margin int) layout.Dimensions {
+	dims := layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
-			return fill(gtx, argb(0x7F444444))
+			fillMax(gtx, m.overlayColor)
+			return m.button.Layout(gtx)
 		}),
 		layout.Stacked(func(gtx C) D {
-			gtx.Constraints.Min.X = gtx.Constraints.Max.X
 			gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
-			return new(widget.Clickable).Layout(gtx)
+			widgetFuncs := []func(gtx C) D{
+				func(gtx C) D {
+					return m.titleLabel.Layout(gtx)
+				},
+				func(gtx C) D {
+					m.titleSeparator.Width = gtx.Constraints.Max.X
+					return m.titleSeparator.Layout(gtx)
+				},
+			}
+			widgetFuncs = append(widgetFuncs, widgets...)
+			scaled := 3840 / float32(gtx.Constraints.Max.X)
+			mg := unit.Px(float32(margin) / scaled)
+
+			return layout.Center.Layout(gtx, func(gtx C) D {
+				return layout.Inset{
+					Left:  mg,
+					Right: mg,
+				}.Layout(gtx, func(gtx C) D {
+					return m.list.Layout(gtx, len(widgetFuncs), func(gtx C, i int) D {
+						gtx.Constraints.Min.X = gtx.Constraints.Max.X
+						fillMax(gtx, m.backgroundColor)
+						return layout.UniformInset(unit.Dp(10)).Layout(gtx, widgetFuncs[i])
+					})
+				})
+			})
 		}),
-		layout.Stacked(dialog),
 	)
+
 	return dims
 }

--- a/ui/decredmaterial/modal.go
+++ b/ui/decredmaterial/modal.go
@@ -38,7 +38,7 @@ func (m *Modal) SetTitle(title string) {
 }
 
 // Layout renders the modal widget to screen. The modal assumes the size of
-// it's content plus padding.
+// its content plus padding.
 func (m *Modal) Layout(gtx layout.Context, widgets []func(gtx C) D, margin int) layout.Dimensions {
 	dims := layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {

--- a/ui/decredmaterial/password.go
+++ b/ui/decredmaterial/password.go
@@ -11,6 +11,7 @@ type Password struct {
 	passwordEditor Editor
 	confirmButton  Button
 	cancelButton   Button
+	modal          *Modal
 }
 
 // Password initializes and returns an instance of Password
@@ -29,6 +30,7 @@ func (t *Theme) Password() *Password {
 		passwordEditor: t.Editor(editorWidget, "Password"),
 		cancelButton:   cancelButton,
 		confirmButton:  confirmButton,
+		modal:          t.Modal("Enter password to confirm"),
 	}
 
 	return p
@@ -70,7 +72,7 @@ func (p *Password) Layout(gtx layout.Context, confirm func([]byte), cancel func(
 			})
 		},
 	}
-	return p.theme.Modal(gtx, "Enter password to confirm", widgets)
+	return p.modal.Layout(gtx, widgets, 1350)
 }
 
 func (p *Password) updateColors() {

--- a/ui/decredmaterial/password.go
+++ b/ui/decredmaterial/password.go
@@ -52,23 +52,24 @@ func (p *Password) Layout(gtx layout.Context, confirm func([]byte), cancel func(
 			return p.passwordEditor.Layout(gtx)
 		},
 		func(gtx C) D {
-			inset := layout.Inset{
-				Top: unit.Dp(20),
-			}
-			return inset.Layout(gtx, func(gtx C) D {
-				return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
-						return p.confirmButton.Layout(gtx)
-					}),
-					layout.Rigid(func(gtx C) D {
-						inset := layout.Inset{
-							Left: unit.Dp(10),
-						}
-						return inset.Layout(gtx, func(gtx C) D {
-							return p.cancelButton.Layout(gtx)
-						})
-					}),
-				)
+			return layout.Center.Layout(gtx, func(gtx C) D {
+				return layout.Inset{
+					Top: unit.Dp(20),
+				}.Layout(gtx, func(gtx C) D {
+					return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							return p.confirmButton.Layout(gtx)
+						}),
+						layout.Rigid(func(gtx C) D {
+							inset := layout.Inset{
+								Left: unit.Dp(10),
+							}
+							return inset.Layout(gtx, func(gtx C) D {
+								return p.cancelButton.Layout(gtx)
+							})
+						}),
+					)
+				})
 			})
 		},
 	}

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -187,7 +187,7 @@ func toPointF(p image.Point) f32.Point {
 	return f32.Point{X: float32(p.X), Y: float32(p.Y)}
 }
 
-func fillMax(gtx layout.Context, col color.RGBA) layout.Dimensions {
+func fillMax(gtx layout.Context, col color.RGBA) {
 	cs := gtx.Constraints
 	d := image.Point{X: cs.Max.X, Y: cs.Max.Y}
 	dr := f32.Rectangle{
@@ -195,7 +195,6 @@ func fillMax(gtx layout.Context, col color.RGBA) layout.Dimensions {
 	}
 	paint.ColorOp{Color: col}.Add(gtx.Ops)
 	paint.PaintOp{Rect: dr}.Add(gtx.Ops)
-	return layout.Dimensions{Size: d}
 }
 
 func fill(gtx layout.Context, col color.RGBA) layout.Dimensions {

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -6,10 +6,6 @@ import (
 	"image"
 	"image/color"
 
-	"golang.org/x/image/draw"
-
-	"gioui.org/widget/material"
-
 	"gioui.org/f32"
 	"gioui.org/layout"
 	"gioui.org/op/clip"
@@ -17,6 +13,11 @@ import (
 	"gioui.org/text"
 	"gioui.org/unit"
 	"gioui.org/widget"
+
+	"gioui.org/widget/material"
+
+	"golang.org/x/image/draw"
+
 	"golang.org/x/exp/shiny/materialdesign/icons"
 )
 
@@ -37,6 +38,12 @@ var (
 type (
 	C = layout.Context
 	D = layout.Dimensions
+)
+
+const (
+	modalTopInset           = 50
+	modalSideInset          = 100
+	estimatedModalRowHeight = 50
 )
 
 type Theme struct {
@@ -103,13 +110,12 @@ func (t *Theme) Modal(gtx layout.Context, title string, wd []func(gtx C) D) layo
 
 	dims := layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
-			new(widget.Clickable).Layout(gtx)
 			return fillMax(gtx, overlayColor)
 		}),
 		layout.Stacked(func(gtx C) D {
 			w := []func(gtx C) D{
 				func(gtx C) D {
-					return t.H4(title).Layout(gtx)
+					return t.H6(title).Layout(gtx)
 				},
 				func(gtx C) D {
 					line := t.Line()
@@ -119,7 +125,12 @@ func (t *Theme) Modal(gtx layout.Context, title string, wd []func(gtx C) D) layo
 			}
 			w = append(w, wd...)
 
-			return layout.UniformInset(unit.Dp(60)).Layout(gtx, func(gtx C) D {
+			return layout.Inset{
+				Top:    unit.Dp(modalTopInset),
+				Bottom: unit.Dp(100),
+				Left:   unit.Dp(modalSideInset),
+				Right:  unit.Dp(modalSideInset),
+			}.Layout(gtx, func(gtx C) D {
 				fillMax(gtx, t.Color.Surface)
 				return (&layout.List{Axis: layout.Vertical, Alignment: layout.Middle}).Layout(gtx, len(w), func(gtx C, i int) D {
 					return layout.UniformInset(unit.Dp(10)).Layout(gtx, w[i])

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -104,43 +104,6 @@ func NewTheme(fontCollection []text.FontFace) *Theme {
 	return t
 }
 
-func (t *Theme) Modal(gtx layout.Context, title string, wd []func(gtx C) D) layout.Dimensions {
-	overlayColor := t.Color.Black
-	overlayColor.A = 200
-
-	dims := layout.Stack{}.Layout(gtx,
-		layout.Expanded(func(gtx C) D {
-			return fillMax(gtx, overlayColor)
-		}),
-		layout.Stacked(func(gtx C) D {
-			w := []func(gtx C) D{
-				func(gtx C) D {
-					return t.H6(title).Layout(gtx)
-				},
-				func(gtx C) D {
-					line := t.Line()
-					line.Width = gtx.Constraints.Max.X
-					return line.Layout(gtx)
-				},
-			}
-			w = append(w, wd...)
-
-			return layout.Inset{
-				Top:    unit.Dp(modalTopInset),
-				Bottom: unit.Dp(100),
-				Left:   unit.Dp(modalSideInset),
-				Right:  unit.Dp(modalSideInset),
-			}.Layout(gtx, func(gtx C) D {
-				fillMax(gtx, t.Color.Surface)
-				return (&layout.List{Axis: layout.Vertical, Alignment: layout.Middle}).Layout(gtx, len(w), func(gtx C, i int) D {
-					return layout.UniformInset(unit.Dp(10)).Layout(gtx, w[i])
-				})
-			})
-		}),
-	)
-	return dims
-}
-
 func (t *Theme) Background(gtx layout.Context, w layout.Widget) {
 	layout.Stack{
 		Alignment: layout.N,

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -40,12 +40,6 @@ type (
 	D = layout.Dimensions
 )
 
-const (
-	modalTopInset           = 50
-	modalSideInset          = 100
-	estimatedModalRowHeight = 50
-)
-
 type Theme struct {
 	Shaper text.Shaper
 	Base   *material.Theme

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"fmt"
+	"image"
 	"image/color"
 	"strconv"
 	"time"
@@ -43,6 +44,8 @@ type SendPage struct {
 	nextButton                   decredmaterial.Button
 	closeConfirmationModalButton decredmaterial.Button
 	confirmButton                decredmaterial.Button
+
+	confirmModal *decredmaterial.Modal
 
 	copyIcon     decredmaterial.IconButton
 	currencySwap decredmaterial.IconButton
@@ -117,6 +120,8 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 		closeConfirmationModalButton: common.theme.Button(new(widget.Clickable), "Close"),
 		nextButton:                   common.theme.Button(new(widget.Clickable), "Next"),
 		confirmButton:                common.theme.Button(new(widget.Clickable), "Confirm"),
+
+		confirmModal: common.theme.Modal("Confirm Send Transaction"),
 
 		copyIcon: common.theme.IconButton(new(widget.Clickable), mustIcon(widget.NewIcon(icons.ContentContentCopy))),
 
@@ -481,11 +486,15 @@ func (pg *SendPage) drawConfirmationModal(gtx layout.Context) layout.Dimensions 
 
 	w := []func(gtx C) D{
 		func(gtx C) D {
+			gtx.Constraints.Min.X = gtx.Constraints.Max.X
 			if pg.sendErrorText != "" {
-				gtx.Constraints.Min.X = gtx.Constraints.Max.X
 				return pg.theme.ErrorAlert(gtx, pg.sendErrorText)
 			}
-			return layout.Dimensions{}
+			return layout.Dimensions{
+				Size: image.Point{
+					X: gtx.Constraints.Max.X,
+				},
+			}
 		},
 		func(gtx C) D {
 			gtx.Constraints.Min.X = gtx.Constraints.Max.X
@@ -538,7 +547,7 @@ func (pg *SendPage) drawConfirmationModal(gtx layout.Context) layout.Dimensions 
 			)
 		},
 	}
-	return pg.theme.Modal(gtx, "Confirm Send Transaction", w)
+	return pg.confirmModal.Layout(gtx, w, 850)
 }
 
 func (pg *SendPage) drawPasswordModal(gtx layout.Context) layout.Dimensions {

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -532,19 +532,21 @@ func (pg *SendPage) drawConfirmationModal(gtx layout.Context) layout.Dimensions 
 			)
 		},
 		func(gtx C) D {
-			return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
-				layout.Rigid(func(gtx C) D {
-					return pg.confirmButton.Layout(gtx)
-				}),
-				layout.Rigid(func(gtx C) D {
-					inset := layout.Inset{
-						Left: values.MarginPadding5,
-					}
-					return inset.Layout(gtx, func(gtx C) D {
-						return pg.closeConfirmationModalButton.Layout(gtx)
-					})
-				}),
-			)
+			return layout.Center.Layout(gtx, func(gtx C) D {
+				return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return pg.confirmButton.Layout(gtx)
+					}),
+					layout.Rigid(func(gtx C) D {
+						inset := layout.Inset{
+							Left: values.MarginPadding5,
+						}
+						return inset.Layout(gtx, func(gtx C) D {
+							return pg.closeConfirmationModalButton.Layout(gtx)
+						})
+					}),
+				)
+			})
 		},
 	}
 	return pg.confirmModal.Layout(gtx, w, 850)


### PR DESCRIPTION
### Resolves

Issue #160 

### What's new

This removes unnecessary white-space  from modals by ensuring that the height of the modal depends entirely on the height of its contents plus padding.

### Relevant screenshots or logs

![Screenshot from 2020-06-26 10-33-01](https://user-images.githubusercontent.com/42093751/85843786-a091a400-b799-11ea-8cc7-c98989cd63e2.png)
![Screenshot from 2020-06-26 10-34-23](https://user-images.githubusercontent.com/42093751/85843789-a1c2d100-b799-11ea-8fee-d95e7966c259.png)
![Screenshot from 2020-06-26 10-34-33](https://user-images.githubusercontent.com/42093751/85843791-a25b6780-b799-11ea-8a75-4ca8dcd77be2.png)
