### PR TITLE
add profiling using pprof

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ In the root directory, run
 
 Then `go build`.
 
+## Profiling 
+Godcr uses [pprof](https://github.com/google/pprof) for profiling. It creates a web server which you can use to save your profiles. To setup a profiling web server, run godcr with the --profile flag and pass a server port to it as an argument.
+
+So, after running the build command above, run the command
+
+`./godcr --profile=6060`
+
+You should now have a local web server running on 127.0.0.1:6060.
+
+To save a profile, you can simply use
+
+`curl -O localhost:6060/debug/pprof/profile`
+
+
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/raedahgroup/godcr/blob/master/.github/CONTRIBUTING.md)

--- a/config.go
+++ b/config.go
@@ -39,6 +39,7 @@ type config struct {
 	DebugLevel       string `short:"d" long:"debuglevel" description:"Logging level {trace, debug, info, warn, error, critical}"`
 	Quiet            bool   `short:"q" long:"quiet" description:"Easy way to set debuglevel to error"`
 	SpendUnconfirmed bool   `long:"spendunconfirmed" description:"Allow the multiwallet to use transactions that have not been confirmed"`
+	Profile          int    `long:"profile" description:"Runs local web server for profiling"`
 }
 
 var defaultConfig = config{

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/decred/dcrd/chaincfg/chainhash v1.0.2
 	github.com/decred/dcrd/dcrutil v1.4.0
 	github.com/decred/dcrd/dcrutil/v2 v2.0.1
-	github.com/decred/dcrutil v0.8.0
 	github.com/decred/slog v1.0.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0

--- a/main.go
+++ b/main.go
@@ -3,9 +3,12 @@ package main
 import (
 	"fmt"
 	"image"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
+
+	_ "net/http/pprof"
 
 	app "gioui.org/app"
 	"gioui.org/font"
@@ -25,6 +28,13 @@ func main() {
 	if err != nil {
 		fmt.Printf("Error: %s\n", err.Error())
 		return
+	}
+
+	if cfg.Profile > 0 {
+		go func() {
+			log.Info(fmt.Sprintf("Starting profiling server on port %d", cfg.Profile))
+			log.Error(http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", cfg.Profile), nil))
+		}()
 	}
 
 	dcrlibwallet.SetLogLevels(cfg.DebugLevel)


### PR DESCRIPTION
This PR adds profiling to godcr using pprof. It also adds instructions on how to start the local web server for profiling.