### PR TITLE
Tab indicator change

### DIFF
--- a/ui/decredmaterial/tabs.go
+++ b/ui/decredmaterial/tabs.go
@@ -4,7 +4,6 @@ import (
 	"image"
 	"image/color"
 
-	"github.com/raedahgroup/godcr/ui/values"
 	"golang.org/x/exp/shiny/materialdesign/icons"
 
 	"gioui.org/font"
@@ -170,7 +169,6 @@ type Tabs struct {
 	Selected    int
 	previousSelected int
 	events           []widget.ChangeEvent
-	prevEvents       int
 	changed     bool
 	btns        []*widget.Button
 	title       Label
@@ -296,7 +294,6 @@ func (t *Tabs) ChangeTab(index int) {
 		t.events = append(t.events, widget.ChangeEvent{})
 		t.previousSelected = index
 	}
-	return
 }
 
 // ChangeEvent returns the last change event

--- a/ui/decredmaterial/tabs.go
+++ b/ui/decredmaterial/tabs.go
@@ -5,6 +5,7 @@ import (
 	"image/color"
 
 	"golang.org/x/exp/shiny/materialdesign/icons"
+	"golang.org/x/image/draw"
 
 	"gioui.org/font"
 	"gioui.org/text"
@@ -15,7 +16,8 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
-	"golang.org/x/image/draw"
+
+	"github.com/raedahgroup/godcr/ui/values"
 )
 
 const (
@@ -163,20 +165,19 @@ func (t *TabItem) Layout(gtx *layout.Context, selected int, btn *widget.Button, 
 // Tabs displays succession of TabItems. Using the Position option, Tabs can be displayed on any four sides
 // of a rendered page.
 type Tabs struct {
-	flex        layout.Flex
-	Size        float32
-	items       []TabItem
-	Selected    int
+	flex             layout.Flex
+	Size             float32
+	items            []TabItem
+	Selected         int
 	previousSelected int
 	events           []widget.ChangeEvent
-	changed     bool
-	btns        []*widget.Button
-	title       Label
-	list        *layout.List
-	Position    Position
-	Separator   bool
-	scrollLeft  *widget.Button
-	scrollRight *widget.Button
+	btns             []*widget.Button
+	title            Label
+	list             *layout.List
+	Position         Position
+	Separator        bool
+	scrollLeft       *widget.Button
+	scrollRight      *widget.Button
 }
 
 func NewTabs() *Tabs {
@@ -333,11 +334,6 @@ func (t *Tabs) Layout(gtx *layout.Context, body layout.Widget) {
 
 	for t.scrollLeft.Clicked(gtx) {
 		t.list.Position.Offset -= 60
-	}
-
-	if t.previousSelected != t.Selected {
-		t.changed = true
-		t.previousSelected = t.Selected
 	}
 
 	t.processChangeEvent(gtx)

--- a/ui/overview_page.go
+++ b/ui/overview_page.go
@@ -66,6 +66,8 @@ type overviewPage struct {
 	listContainer, walletSyncList *layout.List
 	gtx                           *layout.Context
 	theme                         *decredmaterial.Theme
+	tab  					      *decredmaterial.Tabs
+
 	walletInfo                    *wallet.MultiWalletInfo
 	walletSyncStatus              *wallet.SyncStatus
 	walletTransactions            **wallet.Transactions
@@ -86,13 +88,15 @@ func (win *Window) OverviewPage(c pageCommon) layout.Widget {
 	page := overviewPage{
 		gtx:                c.gtx,
 		theme:              c.theme,
+		tab:				c.navTab,
+
 		walletInfo:         win.walletInfo,
 		walletSyncStatus:   win.walletSyncStatus,
 		walletTransactions: &win.walletTransactions,
 		walletTransaction:  &win.walletTransaction,
 		listContainer:      &layout.List{Axis: layout.Vertical},
 		walletSyncList:     &layout.List{Axis: layout.Horizontal},
-		toTransactions:     c.theme.Button("more"),
+		toTransactions:     c.theme.Button("see all"),
 
 		syncButtonHeight: 70,
 		syncButtonWidth:  145,
@@ -124,6 +128,8 @@ func (win *Window) OverviewPage(c pageCommon) layout.Widget {
 		cancel:               "Cancel",
 	}
 	page.toTransactions.TextSize = values.TextSize10
+	page.toTransactions.Background = color.RGBA{}
+	page.toTransactions.Color = c.theme.Color.Primary
 	page.sync = c.theme.Button(page.text.reconnect)
 	page.sync.TextSize = values.TextSize10
 
@@ -249,7 +255,7 @@ func (page *overviewPage) recentTransactionsColumn(c pageCommon) {
 				})
 			}),
 			layout.Rigid(func() {
-				if len(transactionRows) > 5 {
+				if (*page.walletTransactions).Total > 5 {
 					layout.Center.Layout(page.gtx, func() {
 						layout.Inset{Top: values.MarginPadding5}.Layout(page.gtx, func() {
 							layout.Stack{}.Layout(page.gtx,
@@ -576,7 +582,7 @@ func (page *overviewPage) Handler(c pageCommon) {
 		}
 	}
 	if page.toTransactionsW.Clicked(page.gtx) {
-		*c.page = PageTransactions
+		page.tab.ChangeTab(4)
 	}
 
 	for index, click := range page.toTransactionDetails {

--- a/ui/overview_page.go
+++ b/ui/overview_page.go
@@ -96,7 +96,7 @@ func (win *Window) OverviewPage(c pageCommon) layout.Widget {
 		walletTransaction:  &win.walletTransaction,
 		listContainer:      &layout.List{Axis: layout.Vertical},
 		walletSyncList:     &layout.List{Axis: layout.Horizontal},
-		toTransactions:     c.theme.Button("see all"),
+		toTransactions:     c.theme.Button("See all"),
 
 		syncButtonHeight: 70,
 		syncButtonWidth:  145,

--- a/ui/overview_page.go
+++ b/ui/overview_page.go
@@ -66,15 +66,15 @@ type overviewPage struct {
 	listContainer, walletSyncList *layout.List
 	gtx                           *layout.Context
 	theme                         *decredmaterial.Theme
-	tab  					      *decredmaterial.Tabs
+	tab                           *decredmaterial.Tabs
 
-	walletInfo                    *wallet.MultiWalletInfo
-	walletSyncStatus              *wallet.SyncStatus
-	walletTransactions            **wallet.Transactions
-	walletTransaction             **wallet.Transaction
-	toTransactions, sync          decredmaterial.Button
-	toTransactionsW, syncW        widget.Button
-	toTransactionDetails          []*gesture.Click
+	walletInfo             *wallet.MultiWalletInfo
+	walletSyncStatus       *wallet.SyncStatus
+	walletTransactions     **wallet.Transactions
+	walletTransaction      **wallet.Transaction
+	toTransactions, sync   decredmaterial.Button
+	toTransactionsW, syncW widget.Button
+	toTransactionDetails   []*gesture.Click
 
 	text             overviewPageText
 	syncButtonHeight int
@@ -86,9 +86,9 @@ type overviewPage struct {
 
 func (win *Window) OverviewPage(c pageCommon) layout.Widget {
 	page := overviewPage{
-		gtx:                c.gtx,
-		theme:              c.theme,
-		tab:				c.navTab,
+		gtx:   c.gtx,
+		theme: c.theme,
+		tab:   c.navTab,
 
 		walletInfo:         win.walletInfo,
 		walletSyncStatus:   win.walletSyncStatus,
@@ -127,7 +127,7 @@ func (win *Window) OverviewPage(c pageCommon) layout.Widget {
 		disconnect:           "Disconnect",
 		cancel:               "Cancel",
 	}
-	page.toTransactions.TextSize = values.TextSize10
+	page.toTransactions.TextSize = values.TextSize14
 	page.toTransactions.Background = color.RGBA{}
 	page.toTransactions.Color = c.theme.Color.Primary
 	page.sync = c.theme.Button(page.text.reconnect)

--- a/ui/page.go
+++ b/ui/page.go
@@ -145,7 +145,7 @@ func (page pageCommon) Layout(gtx *layout.Context, body layout.Widget) {
 		})
 	})
 
-	if page.navTab.Changed() {
+	for range page.navTab.ChangeEvent(gtx) {
 		*page.page = navs[page.navTab.Selected]
 	}
 }
@@ -159,7 +159,7 @@ func (page pageCommon) LayoutWithWallets(gtx *layout.Context, body layout.Widget
 	}
 	page.walletsTab.SetTabs(wallets)
 	page.walletsTab.Position = decredmaterial.Top
-	if page.accountsTab.Changed() {
+	for range page.accountsTab.ChangeEvent(gtx) {
 		*page.selectedAccount = page.accountsTab.Selected
 	}
 
@@ -173,13 +173,13 @@ func (page pageCommon) LayoutWithWallets(gtx *layout.Context, body layout.Widget
 		}
 	}
 	page.accountsTab.SetTabs(accounts)
-	if page.accountsTab.Changed() {
+	for range page.accountsTab.ChangeEvent(gtx) {
 		*page.selectedAccount = page.accountsTab.Selected
 	}
 	page.accountsTab.Separator = false
 
 	bd := func() {
-		if page.walletsTab.Changed() {
+		for range page.walletsTab.ChangeEvent(gtx) {
 			*page.selectedWallet = page.walletsTab.Selected
 			*page.selectedAccount = 0
 			page.accountsTab.Selected = 0
@@ -207,7 +207,7 @@ func (page pageCommon) LayoutWithAccounts(gtx *layout.Context, body layout.Widge
 	page.accountsTab.SetTitle(page.theme.Label(values.TextSize18, "Accounts:"))
 
 	page.accountsTab.SetTabs(accounts)
-	if page.accountsTab.Changed() {
+	for range page.accountsTab.ChangeEvent(gtx) {
 		*page.selectedAccount = page.accountsTab.Selected
 	}
 

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -356,7 +356,12 @@ func (page *walletPage) subDelete(common pageCommon) {
 // Handle handles all widget inputs on the main wallets page.
 func (page *walletPage) Handle(common pageCommon) {
 	gtx := common.gtx
-	if common.walletsTab.Changed() || common.navTab.Changed() { // reset everything
+
+	for range common.walletsTab.ChangeEvent(gtx) {
+		page.subPage = subWalletMain
+	}
+
+	for range common.navTab.ChangeEvent(gtx) {
 		page.subPage = subWalletMain
 	}
 


### PR DESCRIPTION
####  Resolves
Issue #171. 

This PR replaces the previous tab change event implementation that was based on change variable with a slice implementation. Whenever there's a change event on the tab widget, the event is added to the event slice. The event slice is cleared on the next frame, enough time for every part of the app watching the event. 

