### PR TITLE
Limit editor width of Send page

### DIFF
--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -9,6 +9,7 @@ import (
 	"github.com/raedahgroup/godcr/ui/values"
 
 	"gioui.org/layout"
+	"gioui.org/unit"
 	"gioui.org/widget"
 	"github.com/atotto/clipboard"
 	"github.com/decred/dcrd/dcrutil"
@@ -134,6 +135,7 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 
 	page.destinationAddressEditor = common.theme.Editor(new(widget.Editor), "Destination Address")
 	page.destinationAddressEditor.SetRequiredErrorText("")
+	page.destinationAddressEditor.TextSize = unit.Dp(13)
 	page.destinationAddressEditor.IsRequired = true
 	page.destinationAddressEditor.IsVisible = true
 
@@ -290,10 +292,10 @@ func (pg *SendPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensi
 			return pg.drawSelectedAccountSection(gtx)
 		},
 		func(gtx C) D {
-			return pg.destinationAddressEditor.Layout(gtx)
+			return pg.wrapInput(gtx, func(gtx C) D { return pg.destinationAddressEditor.Layout(gtx) })
 		},
 		func(gtx C) D {
-			return pg.sendAmountLayout(gtx)
+			return pg.wrapInput(gtx, func(gtx C) D { return pg.sendAmountLayout(gtx) })
 		},
 		func(gtx C) D {
 			return pg.drawTransactionDetailWidgets(gtx)
@@ -345,6 +347,11 @@ func (pg *SendPage) drawSuccessSection(gtx layout.Context) layout.Dimensions {
 		)
 	}
 	return layout.Dimensions{}
+}
+
+func (pg *SendPage) wrapInput(gtx layout.Context, wg layout.Widget) layout.Dimensions {
+	gtx.Constraints.Max.X = 580
+	return layout.Inset{Top: values.MarginPadding15}.Layout(gtx, wg)
 }
 
 func (pg *SendPage) drawCopiedLabelSection(gtx layout.Context) layout.Dimensions {


### PR DESCRIPTION
### Resolves

Issue #169 

### What's new

Limit editor width of Send page

<img width="912" alt="Screen Shot 2020-07-07 at 21 17 14" src="https://user-images.githubusercontent.com/9800579/86795013-53fe7080-c097-11ea-8c23-48bec1c98c00.png">
