### PR TITLE
Send amount field

### DIFF
--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -33,7 +33,8 @@ type Editor struct {
 	IsRequired bool
 	//IsTitleLabel if true makes the title label visible.
 	IsTitleLabel bool
-	//IsUnderline if true makes the title lable visible.
+
+	//IsUnderline if true makes the editor underline visible.
 	IsUnderline bool
 
 	requiredErrorText string

--- a/ui/overview_page.go
+++ b/ui/overview_page.go
@@ -538,7 +538,7 @@ func (pg *overviewPage) syncStatusTextRow(gtx layout.Context, inset layout.Inset
 					if pg.walletInfo.Synced {
 						pg.sync.Text = pg.text.disconnect
 					}
-					border := widget.Border{Color: pg.theme.Color.Hint, CornerRadius: values.MarginPadding5, Width: values.MarginPadding2}
+					border := widget.Border{Color: pg.theme.Color.Hint, CornerRadius: values.MarginPadding5, Width: values.MarginPadding1}
 					return border.Layout(gtx, func(gtx C) D {
 						return pg.sync.Layout(gtx)
 					})

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -138,7 +138,7 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 		isPasswordModalOpen:       false,
 		hasCopiedTxHash:           false,
 		isBroadcastingTransaction: false,
-		width:                     27,
+		width:                     29,
 
 		passwordModal:    common.theme.Password(),
 		broadcastErrChan: make(chan error),
@@ -166,7 +166,7 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 	page.sendAmountEditor.IsUnderline = false
 	page.sendAmountEditor.Editor.SingleLine = true
 	page.sendAmountEditor.Editor.SetText("0")
-	page.sendAmountEditorMaterial.TextSize = values.TextSize24
+	page.sendAmountEditor.TextSize = values.TextSize24
 
 	pg.closeConfirmationModalButton.Background = common.theme.Color.Gray
 
@@ -465,6 +465,7 @@ func (pg *SendPage) tableLayout(gtx layout.Context, leftLabel decredmaterial.Lab
 	)
 }
 
+<<<<<<< HEAD
 func (pg *SendPage) destinationAddrSection(gtx layout.Context) layout.Dimensions {
 	main := layout.UniformInset(values.MarginPadding20)
 	return pg.sectionLayout(gtx, main, func(gtx C) D {
@@ -526,53 +527,56 @@ func (pg *SendPage) sendToAddressLayout(gtx layout.Context) layout.Dimensions {
 				return layout.Inset{Bottom: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
 					return pg.sendToButton.Layout(gtx)
 				})
-=======
-func (pg *SendPage) sendAmountLayout(gtx layout.Context) layout.Dimensions {
-	layout.Flex{}.Layout(gtx,
-		layout.Flexed(1, func() {
-			layout.W.Layout(gtx, func() {
-				layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-					layout.Rigid(func() {
-						layout.Flex{}.Layout(gtx,
-							layout.Rigid(func() {
-								gtx.Constraints.Width.Max = pg.width
-								pg.sendAmountEditorMaterial.Layout(gtx, pg.sendAmountEditor)
-							}),
-							layout.Rigid(func() {
-								m := values.MarginPadding5
-								if pg.sendAmountEditor.Len() > 0 {
-									m = values.EditorWidth
-								}
-								layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func() {
-									pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
-								})
-							}),
-						)
-					}),
-					layout.Rigid(func(gtx C) D {
-						return layout.Flex{}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								m := values.MarginPadding10
-								return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
-									return pg.currencySwap.Layout(gtx)
-								})
-							}),
-							layout.Rigid(func() {
-								pg.line.Width = gtx.Constraints.Width.Max - 100
-								layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func() {
-									pg.line.Layout(gtx)
-								})
-							}),
-						)
-					}),
-					layout.Rigid(func(gtx C) D {
-						txt := pg.theme.Body2(pg.inactiveTotalAmount)
-						if pg.LastTradeRate == "" {
-							txt.Color = pg.theme.Color.Danger
-						}
-						return txt.Layout(gtx)
-					}),
-				)
+
+// func (pg *SendPage) sendAmountLayout(gtx layout.Context) layout.Dimensions {
+// 	return layout.Flex{}.Layout(gtx,
+// 		layout.Flexed(1, func(gtx C) D {
+// 			return layout.W.Layout(gtx, func(gtx C) D {
+// 				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+// 					layout.Rigid(func(gtx C) D {
+// 						return layout.Flex{}.Layout(gtx,
+// 							layout.Rigid(func(gtx C) D {
+// 								gtx.Constraints.Max.X = pg.width
+// 								return pg.sendAmountEditor.Layout(gtx)
+// 							}),
+// 							layout.Rigid(func(gtx C) D {
+// 								// this adjusts space between input and currency symbol.
+// 								m := values.MarginPadding5
+// 								e := pg.sendAmountEditor.Editor.Len()
+// 								if e > 0 && e < 7 {
+// 									m = values.EditorWidth
+// 								}
+// 								fmt.Println(pg.width)
+// 								return layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
+// 									return pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
+// 								})
+// 							}),
+// 						)
+// 					}),
+// 					layout.Rigid(func(gtx C) D {
+// 						return layout.Flex{}.Layout(gtx,
+// 							layout.Rigid(func(gtx C) D {
+// 								m := values.MarginPadding10
+// 								return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
+// 									return pg.currencySwap.Layout(gtx)
+// 								})
+// 							}),
+// 							layout.Rigid(func(gtx C) D {
+// 								pg.line.Width = gtx.Constraints.Max.X - 100
+// 								return layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
+// 									return pg.line.Layout(gtx)
+// 								})
+// 							}),
+// 						)
+// 					}),
+// 					layout.Rigid(func(gtx C) D {
+// 						txt := pg.theme.Body2(pg.inactiveTotalAmount)
+// 						if pg.LastTradeRate == "" {
+// 							txt.Color = pg.theme.Color.Danger
+// 						}
+// 						return txt.Layout(gtx)
+// 					}),
+// 				)
 >>>>>>> adjust input field text size and align content
 			})
 		}),
@@ -633,55 +637,54 @@ func (pg *SendPage) amountInputLayout(gtx layout.Context) layout.Dimensions {
 					)
 				}),
 				layout.Rigid(func(gtx C) D {
-					layout.Flex{}.Layout(gtx,
-						layout.Flexed(1, func() {
-							layout.W.Layout(gtx, func() {
-								layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-									layout.Rigid(func() {
-										layout.Flex{}.Layout(gtx,
-											layout.Rigid(func() {
-												gtx.Constraints.Width.Max = pg.width
-												pg.sendAmountEditorMaterial.Layout(gtx, pg.sendAmountEditor)
-											}),
-											layout.Rigid(func() {
-												m := values.MarginPadding5
-												if pg.sendAmountEditor.Len() > 0 {
-													m = values.MarginPadding0
-												}
-												layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func() {
-													pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
-												})
-											}),
-										)
-									}),
-									layout.Rigid(func(gtx C) D {
-										return layout.Flex{}.Layout(gtx,
-											layout.Rigid(func(gtx C) D {
-												m := values.MarginPadding10
-												return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
-													return pg.currencySwap.Layout(gtx)
-												})
-											}),
-											layout.Rigid(func() {
-												pg.line.Width = gtx.Constraints.Width.Max
-												layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func() {
-													pg.line.Layout(gtx)
-												})
-											}),
-										)
-									}),
-									layout.Rigid(func(gtx C) D {
-										txt := pg.theme.Body2(pg.inactiveTotalAmount)
-										if pg.LastTradeRate == "" {
-											txt.Color = pg.theme.Color.Danger
-										}
-										return txt.Layout(gtx)
-									}),
-								)
-							})
-						}),
-					)
-				}
+						return layout.Flex{}.Layout(gtx,
+							layout.Flexed(1, func(gtx C) D {
+								return layout.W.Layout(gtx, func(gtx C) D {
+									return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+										layout.Rigid(func(gtx C) D {
+											return layout.Flex{}.Layout(gtx,
+												layout.Rigid(func(gtx C) D {
+													gtx.Constraints.Max.X = pg.width
+													return pg.sendAmountEditor.Layout(gtx)
+												}),
+												layout.Rigid(func(gtx C) D {
+													// this adjusts space between input and currency symbol.
+													m := values.MarginPadding5
+													e := pg.sendAmountEditor.Editor.Len()
+													if e > 0 && e < 7 {
+														m = values.EditorWidth
+													}
+													fmt.Println(pg.width)
+													return layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
+														return pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
+													})
+												}),
+											)
+										}),
+										layout.Rigid(func(gtx C) D {
+											return layout.Flex{}.Layout(gtx,
+												layout.Rigid(func(gtx C) D {
+													m := values.MarginPadding10
+													return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
+														return pg.currencySwap.Layout(gtx)
+													})
+												}),
+												layout.Rigid(func(gtx C) D {
+													pg.line.Width = gtx.Constraints.Max.X - 100
+													return layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
+														return pg.line.Layout(gtx)
+													})
+												}),
+											)
+										}),
+										layout.Rigid(func(gtx C) D {
+											txt := pg.theme.Body2(pg.inactiveTotalAmount)
+											if pg.LastTradeRate == "" {
+												txt.Color = pg.theme.Color.Danger
+											}
+											return txt.Layout(gtx)
+										}),
+									)
 		}),
 	)
 }
@@ -839,7 +842,7 @@ func (pg *SendPage) validateAmount(ignoreEmpty bool) bool {
 	if amount != "" {
 		_, err := strconv.ParseFloat(amount, 64)
 		if err != nil {
-			pg.sendAmountEditorMaterial.SetError("")
+			pg.sendAmountEditor.SetError("")
 			return false
 		}
 	}
@@ -851,7 +854,7 @@ func (pg *SendPage) calculateValues() {
 	defaultActiveValues := fmt.Sprintf("- %s", pg.activeExchange)
 	defaultInactiveValues := fmt.Sprintf("(- %s)", pg.inactiveExchange)
 	noExchangeText := "Exchange rate not fetched"
-	pg.sendAmountEditorMaterial.Hint = "0"
+	pg.sendAmountEditor.Hint = "0"
 
 	pg.activeTransactionFeeValue = defaultActiveValues
 	pg.activeTotalCostValue = defaultActiveValues
@@ -997,19 +1000,24 @@ func (pg *SendPage) watchForBroadcastResult() {
 
 func (pg *SendPage) changeEvt(evt widget.EditorEvent) {
 	// this adjusts the width of the amount editor per text input.
-	textLength := pg.sendAmountEditor.Len()
+	textLength := pg.sendAmountEditor.Editor.Len()
+	n := 29
+
+	cal := func(val int) int {
+		return n - val
+	}
 	switch evt.(type) {
 	case widget.ChangeEvent:
 		textLength = textLength + 1
 		switch {
 		case pg.width <= 80:
-			pg.width = textLength * 27
-		case pg.width > 80 && pg.width < 140:
-			pg.width = textLength * 26
-		case pg.width > 140 && pg.width < 280:
-			pg.width = textLength * 25
-		case pg.width >= 280:
-			pg.width = textLength * 24
+			pg.width = textLength * cal(0)
+		case pg.width > 80 && pg.width < 137:
+			pg.width = textLength * cal(1)
+		case pg.width > 137 && pg.width < 167:
+			pg.width = textLength * cal(2)
+		case pg.width >= 167:
+			pg.width = textLength * cal(3)
 		}
 		go pg.wallet.GetUSDExchangeValues(&pg)
 	}

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -145,8 +145,8 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 		txAuthorErrChan:  make(chan error),
 		line:             common.theme.Line(),
 	}
-	page.line.Color = common.theme.Color.Gray
-	page.line.Height = 2
+	pg.line.Color = common.theme.Color.Gray
+	pg.line.Height = 2
 
 	pg.balanceAfterSendValue = "- DCR"
 
@@ -163,12 +163,11 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 	pg.sendAmountEditor.SetRequiredErrorText("")
 	pg.sendAmountEditor.IsRequired = true
 	pg.sendAmountEditor.IsTitleLabel = false
-	page.sendAmountEditor.IsUnderline = false
-	page.sendAmountEditor.Editor.SingleLine = true
-	page.sendAmountEditor.Editor.SetText("0")
-	page.sendAmountEditor.TextSize = values.TextSize24
+	pg.sendAmountEditor.IsUnderline = false
+	pg.sendAmountEditor.Editor.SingleLine = true
+	pg.sendAmountEditor.Editor.SetText("0")
+	pg.sendAmountEditor.TextSize = values.TextSize24
 
-<<<<<<< HEAD
 	pg.closeConfirmationModalButton.Background = common.theme.Color.Gray
 
 	pg.copyIcon.Background = common.theme.Color.Background
@@ -190,13 +189,9 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 	pg.sendToButton.Background = color.RGBA{}
 	pg.sendToButton.Color = common.theme.Color.Primary
 	pg.sendToButton.Inset = layout.UniformInset(values.MarginPadding0)
-=======
-	// defualtEditorWidth is the editor text size values.TextSize24
-	page.defualtEditorWidth = 24
 
-	page.closeConfirmationModalButton.Background = common.theme.Color.Gray
-	page.destinationAddressEditor.Editor.SetText("")
->>>>>>> remove switch cases used for updating editor width
+	// defualtEditorWidth is the editor text size values.TextSize24
+	pg.defualtEditorWidth = 24
 
 	pg.txLine.Color = common.theme.Color.Gray
 
@@ -473,7 +468,6 @@ func (pg *SendPage) tableLayout(gtx layout.Context, leftLabel decredmaterial.Lab
 	)
 }
 
-<<<<<<< HEAD
 func (pg *SendPage) destinationAddrSection(gtx layout.Context) layout.Dimensions {
 	main := layout.UniformInset(values.MarginPadding20)
 	return pg.sectionLayout(gtx, main, func(gtx C) D {
@@ -484,8 +478,9 @@ func (pg *SendPage) destinationAddrSection(gtx layout.Context) layout.Dimensions
 			layout.Rigid(func(gtx C) D {
 				return pg.sectionBorder(gtx, values.MarginPadding0, func(gtx C) D {
 					inset := layout.Inset{
-						Left:  values.MarginPadding10,
-						Right: values.TextSize18,
+						Left:   values.MarginPadding10,
+						Right:  values.TextSize18,
+						Bottom: values.MarginPaddingMinus5,
 					}
 					return inset.Layout(gtx, func(gtx C) D {
 						return pg.destinationAddressEditor.Layout(gtx)
@@ -496,7 +491,6 @@ func (pg *SendPage) destinationAddrSection(gtx layout.Context) layout.Dimensions
 	})
 }
 
-<<<<<<< HEAD
 func (pg *SendPage) sendAmountSection(gtx layout.Context) layout.Dimensions {
 	main := layout.UniformInset(values.MarginPadding20)
 	return pg.sectionLayout(gtx, main, func(gtx C) D {
@@ -505,7 +499,7 @@ func (pg *SendPage) sendAmountSection(gtx layout.Context) layout.Dimensions {
 				return pg.spendableBalanceLayout(gtx)
 			}),
 			layout.Rigid(func(gtx C) D {
-				return pg.sectionBorder(gtx, values.MarginPadding10, func(gtx C) D {
+				return pg.sectionBorder(gtx, values.MarginPadding20, func(gtx C) D {
 					return pg.amountInputLayout(gtx)
 				})
 			}),
@@ -531,113 +525,10 @@ func (pg *SendPage) sendToAddressLayout(gtx layout.Context) layout.Dimensions {
 			return amt.Layout(gtx)
 		}),
 		layout.Flexed(1, func(gtx C) D {
-<<<<<<< HEAD
 			return layout.E.Layout(gtx, func(gtx C) D {
 				return layout.Inset{Bottom: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
 					return pg.sendToButton.Layout(gtx)
 				})
-
-// func (pg *SendPage) sendAmountLayout(gtx layout.Context) layout.Dimensions {
-// 	return layout.Flex{}.Layout(gtx,
-// 		layout.Flexed(1, func(gtx C) D {
-// 			return layout.W.Layout(gtx, func(gtx C) D {
-// 				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-// 					layout.Rigid(func(gtx C) D {
-// 						return layout.Flex{}.Layout(gtx,
-// 							layout.Rigid(func(gtx C) D {
-// 								gtx.Constraints.Max.X = pg.width
-// 								return pg.sendAmountEditor.Layout(gtx)
-// 							}),
-// 							layout.Rigid(func(gtx C) D {
-// 								// this adjusts space between input and currency symbol.
-// 								m := values.MarginPadding5
-// 								e := pg.sendAmountEditor.Editor.Len()
-// 								if e > 0 && e < 7 {
-// 									m = values.EditorWidth
-// 								}
-// 								fmt.Println(pg.width)
-// 								return layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
-// 									return pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
-// 								})
-// 							}),
-// 						)
-// 					}),
-// 					layout.Rigid(func(gtx C) D {
-// 						return layout.Flex{}.Layout(gtx,
-// 							layout.Rigid(func(gtx C) D {
-// 								m := values.MarginPadding10
-// 								return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
-// 									return pg.currencySwap.Layout(gtx)
-// 								})
-// 							}),
-// 							layout.Rigid(func(gtx C) D {
-// 								pg.line.Width = gtx.Constraints.Max.X - 100
-// 								return layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
-// 									return pg.line.Layout(gtx)
-// 								})
-// 							}),
-// 						)
-// 					}),
-// 					layout.Rigid(func(gtx C) D {
-// 						txt := pg.theme.Body2(pg.inactiveTotalAmount)
-// 						if pg.LastTradeRate == "" {
-// 							txt.Color = pg.theme.Color.Danger
-// 						}
-// 						return txt.Layout(gtx)
-// 					}),
-// 				)
->>>>>>> adjust input field text size and align content
-=======
-			return layout.W.Layout(gtx, func(gtx C) D {
-				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
-						return layout.Flex{}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								w := pg.defualtEditorWidth
-								if pg.nextEditorWidth != 0 {
-									w = pg.nextEditorWidth
-								}
-								gtx.Constraints.Max.X = w
-								return pg.sendAmountEditor.Layout(gtx)
-							}),
-							layout.Rigid(func(gtx C) D {
-								// this adjusts space between input values and currency symbol.
-								m := values.MarginPadding5
-								e := pg.sendAmountEditor.Editor.Len()
-								if e > 0 {
-									m = values.EditorWidth
-								}
-								return layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
-									return pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
-								})
-							}),
-						)
-					}),
-					layout.Rigid(func(gtx C) D {
-						return layout.Flex{}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								m := values.MarginPadding10
-								return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
-									return pg.currencySwap.Layout(gtx)
-								})
-							}),
-							layout.Rigid(func(gtx C) D {
-								pg.line.Width = gtx.Constraints.Max.X - 100
-								return layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
-									return pg.line.Layout(gtx)
-								})
-							}),
-						)
-					}),
-					layout.Rigid(func(gtx C) D {
-						txt := pg.theme.Body2(pg.inactiveTotalAmount)
-						if pg.LastTradeRate == "" {
-							txt.Color = pg.theme.Color.Danger
-						}
-						return txt.Layout(gtx)
-					}),
-				)
->>>>>>> remove debug code
 			})
 		}),
 	)
@@ -685,66 +576,63 @@ func (pg *SendPage) amountInputLayout(gtx layout.Context) layout.Dimensions {
 		layout.Flexed(1, func(gtx C) D {
 			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					return layout.Flex{}.Layout(gtx,
-						layout.Rigid(func(gtx C) D {
-							return pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
-						}),
-						layout.Flexed(1, func(gtx C) D {
-							return layout.E.Layout(gtx, func(gtx C) D {
-								return pg.maxButton.Layout(gtx)
-							})
-						}),
-					)
+					return layout.W.Layout(gtx, func(gtx C) D {
+						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								return layout.Flex{}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										w := pg.defualtEditorWidth
+										if pg.nextEditorWidth != 0 {
+											w = pg.nextEditorWidth
+										}
+										gtx.Constraints.Max.X = w
+										return pg.sendAmountEditor.Layout(gtx)
+									}),
+									layout.Rigid(func(gtx C) D {
+										// this adjusts space between input values and currency symbol.
+										m := values.MarginPadding5
+										e := pg.sendAmountEditor.Editor.Len()
+										if e > 0 {
+											m = values.MarginPaddingMinus5
+										}
+										return layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
+											return pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
+										})
+									}),
+									layout.Flexed(1, func(gtx C) D {
+										return layout.E.Layout(gtx, func(gtx C) D {
+											return pg.maxButton.Layout(gtx)
+										})
+									}),
+								)
+							}),
+							layout.Rigid(func(gtx C) D {
+								return layout.Flex{}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										m := values.MarginPadding10
+										return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
+											return pg.currencySwap.Layout(gtx)
+										})
+									}),
+									layout.Rigid(func(gtx C) D {
+										pg.line.Width = gtx.Constraints.Max.X
+										return layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
+											return pg.line.Layout(gtx)
+										})
+									}),
+								)
+							}),
+							layout.Rigid(func(gtx C) D {
+								txt := pg.theme.Body2(pg.inactiveTotalAmount)
+								if pg.LastTradeRate == "" {
+									txt.Color = pg.theme.Color.Danger
+								}
+								return txt.Layout(gtx)
+							}),
+						)
+					})
 				}),
-				layout.Rigid(func(gtx C) D {
-						return layout.Flex{}.Layout(gtx,
-							layout.Flexed(1, func(gtx C) D {
-								return layout.W.Layout(gtx, func(gtx C) D {
-									return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-										layout.Rigid(func(gtx C) D {
-											return layout.Flex{}.Layout(gtx,
-												layout.Rigid(func(gtx C) D {
-													gtx.Constraints.Max.X = pg.width
-													return pg.sendAmountEditor.Layout(gtx)
-												}),
-												layout.Rigid(func(gtx C) D {
-													// this adjusts space between input and currency symbol.
-													m := values.MarginPadding5
-													e := pg.sendAmountEditor.Editor.Len()
-													if e > 0 && e < 7 {
-														m = values.EditorWidth
-													}
-													fmt.Println(pg.width)
-													return layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
-														return pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
-													})
-												}),
-											)
-										}),
-										layout.Rigid(func(gtx C) D {
-											return layout.Flex{}.Layout(gtx,
-												layout.Rigid(func(gtx C) D {
-													m := values.MarginPadding10
-													return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
-														return pg.currencySwap.Layout(gtx)
-													})
-												}),
-												layout.Rigid(func(gtx C) D {
-													pg.line.Width = gtx.Constraints.Max.X - 100
-													return layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
-														return pg.line.Layout(gtx)
-													})
-												}),
-											)
-										}),
-										layout.Rigid(func(gtx C) D {
-											txt := pg.theme.Body2(pg.inactiveTotalAmount)
-											if pg.LastTradeRate == "" {
-												txt.Color = pg.theme.Color.Danger
-											}
-											return txt.Layout(gtx)
-										}),
-									)
+			)
 		}),
 	)
 }
@@ -852,7 +740,7 @@ func (pg *SendPage) drawPasswordModal(gtx layout.Context) layout.Dimensions {
 }
 
 func (pg *SendPage) sectionBorder(gtx layout.Context, padding unit.Value, body layout.Widget) layout.Dimensions {
-	border := widget.Border{Color: pg.theme.Color.Hint, CornerRadius: values.MarginPadding5, Width: values.MarginPadding2}
+	border := widget.Border{Color: pg.theme.Color.Hint, CornerRadius: values.MarginPadding5, Width: values.MarginPadding1}
 	return border.Layout(gtx, func(gtx C) D {
 		return layout.UniformInset(padding).Layout(gtx, body)
 	})

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -21,7 +21,6 @@ import (
 )
 
 type amountValue struct {
-	activeTotalAmount           string
 	inactiveTotalAmount         string
 	activeTransactionFeeValue   string
 	inactiveTransactionFeeValue string
@@ -139,7 +138,7 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 		isPasswordModalOpen:       false,
 		hasCopiedTxHash:           false,
 		isBroadcastingTransaction: false,
-		width:                     25,
+		width:                     27,
 
 		passwordModal:    common.theme.Password(),
 		broadcastErrChan: make(chan error),
@@ -167,6 +166,7 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 	page.sendAmountEditor.IsUnderline = false
 	page.sendAmountEditor.Editor.SingleLine = true
 	page.sendAmountEditor.Editor.SetText("0")
+	page.sendAmountEditorMaterial.TextSize = values.TextSize24
 
 	pg.closeConfirmationModalButton.Background = common.theme.Color.Gray
 
@@ -487,6 +487,7 @@ func (pg *SendPage) destinationAddrSection(gtx layout.Context) layout.Dimensions
 	})
 }
 
+<<<<<<< HEAD
 func (pg *SendPage) sendAmountSection(gtx layout.Context) layout.Dimensions {
 	main := layout.UniformInset(values.MarginPadding20)
 	return pg.sectionLayout(gtx, main, func(gtx C) D {
@@ -525,6 +526,54 @@ func (pg *SendPage) sendToAddressLayout(gtx layout.Context) layout.Dimensions {
 				return layout.Inset{Bottom: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
 					return pg.sendToButton.Layout(gtx)
 				})
+=======
+func (pg *SendPage) sendAmountLayout(gtx layout.Context) layout.Dimensions {
+	layout.Flex{}.Layout(gtx,
+		layout.Flexed(1, func() {
+			layout.W.Layout(gtx, func() {
+				layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					layout.Rigid(func() {
+						layout.Flex{}.Layout(gtx,
+							layout.Rigid(func() {
+								gtx.Constraints.Width.Max = pg.width
+								pg.sendAmountEditorMaterial.Layout(gtx, pg.sendAmountEditor)
+							}),
+							layout.Rigid(func() {
+								m := values.MarginPadding5
+								if pg.sendAmountEditor.Len() > 0 {
+									m = values.MarginPadding0
+								}
+								layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func() {
+									pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
+								})
+							}),
+						)
+					}),
+					layout.Rigid(func(gtx C) D {
+						return layout.Flex{}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								m := values.MarginPadding10
+								return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
+									return pg.currencySwap.Layout(gtx)
+								})
+							}),
+							layout.Rigid(func() {
+								pg.line.Width = gtx.Constraints.Width.Max
+								layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func() {
+									pg.line.Layout(gtx)
+								})
+							}),
+						)
+					}),
+					layout.Rigid(func(gtx C) D {
+						txt := pg.theme.Body2(pg.inactiveTotalAmount)
+						if pg.LastTradeRate == "" {
+							txt.Color = pg.theme.Color.Danger
+						}
+						return txt.Layout(gtx)
+					}),
+				)
+>>>>>>> adjust input field text size and align content
 			})
 		}),
 	)
@@ -591,14 +640,17 @@ func (pg *SendPage) amountInputLayout(gtx layout.Context) layout.Dimensions {
 									layout.Rigid(func() {
 										layout.Flex{}.Layout(gtx,
 											layout.Rigid(func() {
-												fmt.Println(pg.width)
 												gtx.Constraints.Width.Max = pg.width
-												layout.Inset{Right: values.MarginPadding5}.Layout(gtx, func() {
-													pg.sendAmountEditorMaterial.Layout(gtx, pg.sendAmountEditor)
-												})
+												pg.sendAmountEditorMaterial.Layout(gtx, pg.sendAmountEditor)
 											}),
 											layout.Rigid(func() {
-												pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
+												m := values.MarginPadding5
+												if pg.sendAmountEditor.Len() > 0 {
+													m = values.MarginPadding0
+												}
+												layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func() {
+													pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
+												})
 											}),
 										)
 									}),
@@ -606,13 +658,13 @@ func (pg *SendPage) amountInputLayout(gtx layout.Context) layout.Dimensions {
 										return layout.Flex{}.Layout(gtx,
 											layout.Rigid(func(gtx C) D {
 												m := values.MarginPadding10
-												return layout.Inset{Left: m, Top: m, Bottom: m}.Layout(gtx, func(gtx C) D {
+												return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
 													return pg.currencySwap.Layout(gtx)
 												})
 											}),
 											layout.Rigid(func() {
 												pg.line.Width = gtx.Constraints.Width.Max
-												layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding30}.Layout(gtx, func() {
+												layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func() {
 													pg.line.Layout(gtx)
 												})
 											}),
@@ -630,7 +682,6 @@ func (pg *SendPage) amountInputLayout(gtx layout.Context) layout.Dimensions {
 						}),
 					)
 				}
-			)
 		}),
 	)
 }
@@ -797,7 +848,7 @@ func (pg *SendPage) validateAmount(ignoreEmpty bool) bool {
 }
 
 func (pg *SendPage) calculateValues() {
-	defaultActiveValues := pg.activeExchange
+	defaultActiveValues := fmt.Sprintf("- %s", pg.activeExchange)
 	defaultInactiveValues := fmt.Sprintf("(- %s)", pg.inactiveExchange)
 	noExchangeText := "Exchange rate not fetched"
 	pg.sendAmountEditorMaterial.Hint = "0"
@@ -808,8 +859,8 @@ func (pg *SendPage) calculateValues() {
 	pg.inactiveTotalCostValue = defaultInactiveValues
 
 	pg.calculateErrorText = ""
-	pg.activeTotalAmount = defaultActiveValues
-	pg.inactiveTotalAmount = fmt.Sprintf("- %s", pg.inactiveExchange)
+	pg.activeTotalAmount = pg.activeExchange
+	pg.inactiveTotalAmount = fmt.Sprintf("0 %s", pg.inactiveExchange)
 
 	// default values when exchange is not available
 	if pg.LastTradeRate == "" {
@@ -817,7 +868,7 @@ func (pg *SendPage) calculateValues() {
 		pg.activeTotalCostValue = defaultActiveValues
 		pg.inactiveTransactionFeeValue = ""
 		pg.inactiveTotalCostValue = ""
-		pg.activeTotalAmount = defaultActiveValues
+		pg.activeTotalAmount = pg.activeExchange
 		pg.inactiveTotalAmount = noExchangeText
 	}
 
@@ -874,7 +925,6 @@ func (pg *SendPage) amountValues() amountValue {
 	switch {
 	case pg.activeExchange == "USD" && pg.LastTradeRate != "":
 		return amountValue{
-			activeTotalAmount:           fmt.Sprintf("%s USD", pg.sendAmountEditor.Editor.Text()),
 			inactiveTotalAmount:         dcrutil.Amount(pg.amountAtoms).String(),
 			activeTransactionFeeValue:   fmt.Sprintf("%f USD", txFeeValueUSD),
 			inactiveTransactionFeeValue: fmt.Sprintf("(%s)", dcrutil.Amount(pg.txFee).String()),
@@ -883,7 +933,6 @@ func (pg *SendPage) amountValues() amountValue {
 		}
 	case pg.activeExchange == "DCR" && pg.LastTradeRate != "":
 		return amountValue{
-			activeTotalAmount:           dcrutil.Amount(pg.amountAtoms).String(),
 			inactiveTotalAmount:         fmt.Sprintf("%s USD", strconv.FormatFloat(pg.amountDCRtoUSD, 'f', 7, 64)),
 			activeTransactionFeeValue:   dcrutil.Amount(pg.txFee).String(),
 			inactiveTransactionFeeValue: fmt.Sprintf("(%f USD)", txFeeValueUSD),
@@ -892,7 +941,6 @@ func (pg *SendPage) amountValues() amountValue {
 		}
 	default:
 		return amountValue{
-			activeTotalAmount:         dcrutil.Amount(pg.amountAtoms).String(),
 			inactiveTotalAmount:       "Exchange rate not fetched",
 			activeTransactionFeeValue: dcrutil.Amount(pg.txFee).String(),
 			activeTotalCostValue:      dcrutil.Amount(pg.totalCostDCR).String(),
@@ -902,7 +950,7 @@ func (pg *SendPage) amountValues() amountValue {
 
 func (pg *SendPage) updateDefaultValues() {
 	v := pg.amountValues()
-	pg.activeTotalAmount = v.activeTotalAmount
+	pg.activeTotalAmount = pg.activeExchange
 	pg.inactiveTotalAmount = v.inactiveTotalAmount
 	pg.activeTransactionFeeValue = v.activeTransactionFeeValue
 	pg.inactiveTransactionFeeValue = v.inactiveTransactionFeeValue
@@ -951,16 +999,14 @@ func (pg *SendPage) changeEvt(evt widget.EditorEvent) {
 	textLength := pg.sendAmountEditor.Len()
 	switch evt.(type) {
 	case widget.ChangeEvent:
-		if textLength == 0 {
-			textLength = textLength + 1
-		}
+		textLength = textLength + 1
 		switch {
-		case pg.width <= 50:
+		case pg.width <= 120:
+			pg.width = textLength * 27
+		case pg.width > 120 && pg.width < 220:
 			pg.width = textLength * 25
-		case pg.width > 50 && pg.width < 83:
-			pg.width = textLength * 20
-		case pg.width >= 83:
-			pg.width = textLength * 18
+		case pg.width >= 220:
+			pg.width = textLength * 24
 		}
 		go pg.wallet.GetUSDExchangeValues(&pg)
 	}

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -540,9 +540,9 @@ func (pg *SendPage) sendAmountLayout(gtx layout.Context) layout.Dimensions {
 							}),
 							layout.Rigid(func() {
 								m := values.MarginPadding5
-								// if pg.sendAmountEditor.Len() > 0 {
-								// 	m = values.MarginPadding0
-								// }
+								if pg.sendAmountEditor.Len() > 0 {
+									m = values.EditorWidth
+								}
 								layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func() {
 									pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
 								})
@@ -558,7 +558,7 @@ func (pg *SendPage) sendAmountLayout(gtx layout.Context) layout.Dimensions {
 								})
 							}),
 							layout.Rigid(func() {
-								pg.line.Width = gtx.Constraints.Width.Max
+								pg.line.Width = gtx.Constraints.Width.Max - 100
 								layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func() {
 									pg.line.Layout(gtx)
 								})
@@ -996,18 +996,19 @@ func (pg *SendPage) watchForBroadcastResult() {
 }
 
 func (pg *SendPage) changeEvt(evt widget.EditorEvent) {
+	// this adjusts the width of the amount editor per text input.
 	textLength := pg.sendAmountEditor.Len()
 	switch evt.(type) {
 	case widget.ChangeEvent:
-		if textLength == 0 {
-			textLength = textLength + 1
-		}
+		textLength = textLength + 1
 		switch {
-		case pg.width <= 120:
+		case pg.width <= 80:
 			pg.width = textLength * 27
-		case pg.width > 120 && pg.width < 220:
+		case pg.width > 80 && pg.width < 140:
+			pg.width = textLength * 26
+		case pg.width > 140 && pg.width < 280:
 			pg.width = textLength * 25
-		case pg.width >= 220:
+		case pg.width >= 280:
 			pg.width = textLength * 24
 		}
 		go pg.wallet.GetUSDExchangeValues(&pg)

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -946,7 +946,7 @@ func (pg *SendPage) watchForBroadcastResult() {
 	}
 }
 
-// handleEditorChange tracks changes on the editor and adjust its width of the send amount input field
+// handleEditorChange handles changes on the editor and adjust its width of the send amount input field
 // it also updates the DCR - USD exchange rate value
 func (pg *SendPage) handleEditorChange(evt widget.EditorEvent) {
 	editorTextLength := pg.sendAmountEditor.Editor.Len()

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -294,9 +294,8 @@ func (pg *SendPage) Handle(c pageCommon) {
 		pg.calculateValues()
 	}
 
-	for _, evt := range pg.destinationAddressEditor.Editor.Events() {
+	for range pg.destinationAddressEditor.Editor.Events() {
 		go pg.calculateValues()
-		pg.handleEditorChange(evt)
 	}
 
 	if pg.destinationAddressEditor.Editor.Len() == 0 || pg.sendAmountEditor.Editor.Len() == 0 {
@@ -951,16 +950,16 @@ func (pg *SendPage) watchForBroadcastResult() {
 func (pg *SendPage) handleEditorChange(evt widget.EditorEvent) {
 	editorTextLength := pg.sendAmountEditor.Editor.Len()
 
-	// calulateNextWidth use the values of the defualtEditorWidth(the editor text size) and
+	// calculateNextWidth use the values of the defualtEditorWidth(the editor text size) and
 	// total number of text in the editor to determine the width of the amount field
-	calulateNextWidth := func() {
+	calculateNextWidth := func() {
 		editorTextLength = editorTextLength + 1
 		pg.nextEditorWidth = pg.defualtEditorWidth * editorTextLength
 	}
 
 	switch evt.(type) {
 	case widget.ChangeEvent:
-		calulateNextWidth()
+		calculateNextWidth()
 		go pg.wallet.GetUSDExchangeValues(&pg)
 	}
 }

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -540,9 +540,9 @@ func (pg *SendPage) sendAmountLayout(gtx layout.Context) layout.Dimensions {
 							}),
 							layout.Rigid(func() {
 								m := values.MarginPadding5
-								if pg.sendAmountEditor.Len() > 0 {
-									m = values.MarginPadding0
-								}
+								// if pg.sendAmountEditor.Len() > 0 {
+								// 	m = values.MarginPadding0
+								// }
 								layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func() {
 									pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
 								})
@@ -999,7 +999,9 @@ func (pg *SendPage) changeEvt(evt widget.EditorEvent) {
 	textLength := pg.sendAmountEditor.Len()
 	switch evt.(type) {
 	case widget.ChangeEvent:
-		textLength = textLength + 1
+		if textLength == 0 {
+			textLength = textLength + 1
+		}
 		switch {
 		case pg.width <= 120:
 			pg.width = textLength * 27

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -523,6 +523,7 @@ func (pg *SendPage) sendToAddressLayout(gtx layout.Context) layout.Dimensions {
 			return amt.Layout(gtx)
 		}),
 		layout.Flexed(1, func(gtx C) D {
+<<<<<<< HEAD
 			return layout.E.Layout(gtx, func(gtx C) D {
 				return layout.Inset{Bottom: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
 					return pg.sendToButton.Layout(gtx)
@@ -578,6 +579,53 @@ func (pg *SendPage) sendToAddressLayout(gtx layout.Context) layout.Dimensions {
 // 					}),
 // 				)
 >>>>>>> adjust input field text size and align content
+=======
+			return layout.W.Layout(gtx, func(gtx C) D {
+				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return layout.Flex{}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								gtx.Constraints.Max.X = pg.width
+								return pg.sendAmountEditor.Layout(gtx)
+							}),
+							layout.Rigid(func(gtx C) D {
+								// this adjusts space between input values and currency symbol.
+								m := values.MarginPadding5
+								e := pg.sendAmountEditor.Editor.Len()
+								if e > 0 && e < 7 {
+									m = values.EditorWidth
+								}
+								return layout.Inset{Left: m, Top: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
+									return pg.theme.H6(pg.activeTotalAmount).Layout(gtx)
+								})
+							}),
+						)
+					}),
+					layout.Rigid(func(gtx C) D {
+						return layout.Flex{}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								m := values.MarginPadding10
+								return layout.Inset{Left: m, Bottom: m}.Layout(gtx, func(gtx C) D {
+									return pg.currencySwap.Layout(gtx)
+								})
+							}),
+							layout.Rigid(func(gtx C) D {
+								pg.line.Width = gtx.Constraints.Max.X - 100
+								return layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
+									return pg.line.Layout(gtx)
+								})
+							}),
+						)
+					}),
+					layout.Rigid(func(gtx C) D {
+						txt := pg.theme.Body2(pg.inactiveTotalAmount)
+						if pg.LastTradeRate == "" {
+							txt.Color = pg.theme.Color.Danger
+						}
+						return txt.Layout(gtx)
+					}),
+				)
+>>>>>>> remove debug code
 			})
 		}),
 	)
@@ -998,11 +1046,13 @@ func (pg *SendPage) watchForBroadcastResult() {
 	}
 }
 
+// changeEvt tracks change event on the editor and adjust its width of the ssend amount input field
+// pg.width is the widith of a single text character
 func (pg *SendPage) changeEvt(evt widget.EditorEvent) {
-	// this adjusts the width of the amount editor per text input.
 	textLength := pg.sendAmountEditor.Editor.Len()
 	n := 29
 
+	// cal decrements the pg.width for a particular range of values
 	cal := func(val int) int {
 		return n - val
 	}

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -31,5 +31,7 @@ var (
 	TextSize14 = unit.Dp(14)
 	TextSize16 = unit.Dp(16)
 	TextSize18 = unit.Dp(18)
+	TextSize22 = unit.Dp(22)
+	TextSize24 = unit.Dp(24)
 	TextSize28 = unit.Dp(28)
 )

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -5,7 +5,6 @@ import "gioui.org/unit"
 var (
 	MarginPadding0       = unit.Dp(0)
 	MarginPadding1       = unit.Dp(1)
-	MarginPadding2       = unit.Dp(2)
 	MarginPadding5       = unit.Dp(5)
 	MarginPaddingMinus5  = unit.Dp(-5)
 	MarginPadding10      = unit.Dp(10)


### PR DESCRIPTION
### Resolves

Issue #178

### What's new

This PR implements the send page amount input field just as the mobile app.
* Moved the  amount input to the front of the currency symbol.
* Made the input amount only as wide as the available amount to be sent.

### Relevant screenshots or logs
<img width="799" alt="image" src="https://user-images.githubusercontent.com/27733432/88959976-b9124400-d29a-11ea-9939-393e98bd26ba.png">

<img width="798" alt="image" src="https://user-images.githubusercontent.com/27733432/88960057-d9420300-d29a-11ea-9211-49e9853c7b01.png">


