### PR TITLE
move error alert to main send page

### DIFF
--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -144,7 +144,6 @@ func (t *Theme) alert(gtx layout.Context, txt string, bgColor color.RGBA) layout
 			return fill(gtx, bgColor)
 		}),
 		layout.Stacked(func(gtx C) D {
-			gtx.Constraints.Min.X = gtx.Constraints.Max.X
 			return layout.UniformInset(unit.Dp(8)).Layout(gtx, func(gtx C) D {
 				lbl := t.Body2(txt)
 				lbl.Color = t.Color.Surface

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -10,7 +10,6 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 
-	"github.com/atotto/clipboard"
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/raedahgroup/dcrlibwallet"
 	"github.com/raedahgroup/godcr/ui/decredmaterial"
@@ -151,11 +150,6 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 	pg.closeConfirmationModalButton.Background = common.theme.Color.Gray
 	pg.destinationAddressEditor.Editor.SetText("")
 	pg.destinationAddressEditor.Editor.SingleLine = true
-
-	pg.copyIcon.Background = common.theme.Color.Background
-	pg.copyIcon.Color = common.theme.Color.Text
-	pg.copyIcon.Size = values.MarginPadding35
-	pg.copyIcon.Inset = layout.UniformInset(values.MarginPadding5)
 
 	pg.currencySwap = common.theme.IconButton(new(widget.Clickable), common.icons.actionSwapVert)
 	pg.currencySwap.Background = color.RGBA{}

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -206,6 +206,12 @@ func (pg *SendPage) Handle(c pageCommon) {
 		pg.selectedWallet = c.info.Wallets[*c.selectedWallet]
 	}
 
+	if pg.broadcastResult.TxHash != "" {
+		time.AfterFunc(time.Second*3, func() {
+			pg.sendSuccessText = ""
+		})
+	}
+
 	if pg.shouldInitializeTxAuthor {
 		pg.shouldInitializeTxAuthor = false
 		pg.sendAmountEditor.Editor.SetText("")
@@ -884,10 +890,6 @@ func (pg *SendPage) watchForBroadcastResult() {
 		pg.isConfirmationModalOpen = false
 		pg.isBroadcastingTransaction = false
 		pg.broadcastResult.TxHash = ""
-
-		time.AfterFunc(time.Second*3, func() {
-			pg.sendSuccessText = ""
-		})
 	}
 }
 

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -597,10 +597,6 @@ func (pg *SendPage) txFeeLayout(gtx layout.Context) layout.Dimensions {
 }
 
 func (pg *SendPage) drawConfirmationModal(gtx layout.Context) layout.Dimensions {
-	if !pg.isConfirmationModalOpen {
-		return layout.Dimensions{}
-	}
-
 	w := []func(gtx C) D{
 		func(gtx C) D {
 			gtx.Constraints.Min.X = gtx.Constraints.Max.X
@@ -672,9 +668,6 @@ func (pg *SendPage) drawConfirmationModal(gtx layout.Context) layout.Dimensions 
 }
 
 func (pg *SendPage) drawPasswordModal(gtx layout.Context) layout.Dimensions {
-	if !(pg.isPasswordModalOpen) {
-		return layout.Dimensions{}
-	}
 	return pg.passwordModal.Layout(gtx, func(password []byte) {
 		pg.isBroadcastingTransaction = true
 		pg.isPasswordModalOpen = false


### PR DESCRIPTION
### Resolves

Issue #177 

### What's new
This does the following: 

- Changes the send success alert message from ```transaction hash``` to "Transaction Sent"
- Clears the send success alert message after 3 seconds 
- Resizes the alert messages to take up the width of it's content plus padding 
- Moves the error message alert from the confirmation modal to the send page itself