### PR TITLE
Fix unresponsive tabs on accounts and wallets pages

### DIFF
--- a/ui/decredmaterial/tabs.go
+++ b/ui/decredmaterial/tabs.go
@@ -193,10 +193,6 @@ func NewTabs(th *Theme) *Tabs {
 	}
 }
 
-func (t *Tabs) Tabs() int {
-	return len(t.items)
-}
-
 // SetTabs creates a button widget for each tab item.
 func (t *Tabs) SetTabs(tabs []TabItem) {
 	t.items = tabs

--- a/ui/decredmaterial/tabs.go
+++ b/ui/decredmaterial/tabs.go
@@ -193,6 +193,10 @@ func NewTabs(th *Theme) *Tabs {
 	}
 }
 
+func (t *Tabs) Tabs() int {
+	return len(t.items)
+}
+
 // SetTabs creates a button widget for each tab item.
 func (t *Tabs) SetTabs(tabs []TabItem) {
 	t.items = tabs
@@ -240,7 +244,7 @@ func (t *Tabs) SetTitle(title Label) {
 func (t *Tabs) tabsTitle() layout.FlexChild {
 	return layout.Rigid(func(gtx C) D {
 		if (t.Position == Top || t.Position == Bottom) && t.title.Text != "" {
-			return layout.Inset{Top: values.MarginPadding10, Right: values.MarginPadding5}.Layout(gtx, func(gtx C) D {
+			return layout.Inset{Top: values.MarginPadding20, Right: values.MarginPadding5}.Layout(gtx, func(gtx C) D {
 				return t.title.Layout(gtx)
 			})
 		}

--- a/ui/page.go
+++ b/ui/page.go
@@ -34,11 +34,12 @@ type pageCommon struct {
 	icons           pageIcons
 	page            *string
 	navTab          *decredmaterial.Tabs
-	walletsTab      *decredmaterial.Tabs
-	accountsTab     *decredmaterial.Tabs
+	walletTabs      *decredmaterial.Tabs
+	accountTabs     *decredmaterial.Tabs
 	errorChannels   map[string]chan error
 	keyEvents       chan *key.Event
 	states          *states
+	prevTabs        int
 }
 
 type (
@@ -89,9 +90,6 @@ func (win *Window) addPages(decredIcons map[string]image.Image) {
 		decredmaterial.NewTabItem("Transactions", &ic.transactionIcon),
 	})
 
-	accountsTab := decredmaterial.NewTabs(win.theme)
-	accountsTab.Position = decredmaterial.Top
-	accountsTab.Separator = false
 	common := pageCommon{
 		wallet:          win.wallet,
 		info:            win.walletInfo,
@@ -101,8 +99,8 @@ func (win *Window) addPages(decredIcons map[string]image.Image) {
 		icons:           ic,
 		page:            &win.current,
 		navTab:          tabs,
-		walletsTab:      decredmaterial.NewTabs(win.theme),
-		accountsTab:     accountsTab,
+		walletTabs:      win.walletTabs,
+		accountTabs:     win.accountTabs,
 		errorChannels: map[string]chan error{
 			PageSignMessage:    make(chan error),
 			PageCreateRestore:  make(chan error),
@@ -158,68 +156,35 @@ func (page pageCommon) Modal(gtx layout.Context, body layout.Dimensions, modal l
 }
 
 func (page pageCommon) LayoutWithWallets(gtx layout.Context, body layout.Widget) layout.Dimensions {
-	wallets := make([]decredmaterial.TabItem, len(page.info.Wallets))
-	for i := range page.info.Wallets {
-		wallets[i] = decredmaterial.TabItem{
-			Title: page.info.Wallets[i].Name,
-		}
-	}
-	page.walletsTab.SetTabs(wallets)
-	page.walletsTab.Position = decredmaterial.Top
-	if page.accountsTab.ChangeEvent() {
-		*page.selectedAccount = page.accountsTab.Selected
-	}
-
-	accounts := make([]decredmaterial.TabItem, len(page.info.Wallets[*page.selectedWallet].Accounts))
-	for i, acct := range page.info.Wallets[*page.selectedWallet].Accounts {
-		if acct.Name == "imported" {
-			continue
-		}
-		accounts[i] = decredmaterial.TabItem{
-			Title: page.info.Wallets[*page.selectedWallet].Accounts[i].Name,
-		}
-	}
-	page.accountsTab.SetTabs(accounts)
-	if page.accountsTab.ChangeEvent() {
-		*page.selectedAccount = page.accountsTab.Selected
-	}
-	page.accountsTab.Separator = false
-
 	bd := func(gtx C) D {
-		if page.walletsTab.ChangeEvent() {
-			*page.selectedWallet = page.walletsTab.Selected
+		if page.walletTabs.ChangeEvent() {
+			*page.selectedWallet = page.walletTabs.Selected
 			*page.selectedAccount = 0
-			page.accountsTab.Selected = 0
+			page.accountTabs.Selected = 0
+
+			accounts := make([]decredmaterial.TabItem, len(page.info.Wallets[*page.selectedWallet].Accounts))
+			for i, account := range page.info.Wallets[*page.selectedWallet].Accounts {
+				if account.Name == "imported" {
+					continue
+				}
+				accounts[i] = decredmaterial.TabItem{
+					Title: page.info.Wallets[*page.selectedWallet].Accounts[i].Name,
+				}
+			}
+			page.accountTabs.SetTabs(accounts)
 		}
-		if *page.selectedWallet == 0 {
-			page.walletsTab.Selected = *page.selectedWallet
-		}
-		page.walletsTab.Separator = false
-		return page.walletsTab.Layout(gtx, body)
+		return page.walletTabs.Layout(gtx, body)
 	}
 	return page.Layout(gtx, bd)
 }
 
 func (page pageCommon) LayoutWithAccounts(gtx layout.Context, body layout.Widget) layout.Dimensions {
-	accounts := make([]decredmaterial.TabItem, len(page.info.Wallets[*page.selectedWallet].Accounts))
-	for i, account := range page.info.Wallets[*page.selectedWallet].Accounts {
-		if account.Name == "imported" {
-			continue
-		}
-		accounts[i] = decredmaterial.TabItem{
-			Title: page.info.Wallets[*page.selectedWallet].Accounts[i].Name,
-		}
-	}
-
-	page.accountsTab.SetTitle(page.theme.Label(values.TextSize18, "Accounts:"))
-
-	page.accountsTab.SetTabs(accounts)
-	if page.accountsTab.ChangeEvent() {
-		*page.selectedAccount = page.accountsTab.Selected
+	if page.accountTabs.ChangeEvent() {
+		*page.selectedAccount = page.accountTabs.Selected
 	}
 
 	return page.LayoutWithWallets(gtx, func(gtx C) D {
-		return page.accountsTab.Layout(gtx, body)
+		return page.accountTabs.Layout(gtx, body)
 	})
 }
 

--- a/ui/page.go
+++ b/ui/page.go
@@ -39,7 +39,6 @@ type pageCommon struct {
 	errorChannels   map[string]chan error
 	keyEvents       chan *key.Event
 	states          *states
-	prevTabs        int
 }
 
 type (

--- a/ui/state.go
+++ b/ui/state.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/raedahgroup/dcrlibwallet"
+	"github.com/raedahgroup/godcr/ui/decredmaterial"
 	"github.com/raedahgroup/godcr/wallet"
 )
 
@@ -21,6 +22,29 @@ func (win *Window) updateStates(update interface{}) {
 		}
 		*win.walletInfo = e
 		win.states.loading = false
+
+		// set wallets and accounts tab when wallet info is updated
+		go func() {
+			wallets := make([]decredmaterial.TabItem, len(e.Wallets))
+			for i := range e.Wallets {
+				wallets[i] = decredmaterial.TabItem{
+					Title: e.Wallets[i].Name,
+				}
+			}
+			win.walletTabs.SetTabs(wallets)
+
+			accounts := make([]decredmaterial.TabItem, len(e.Wallets[win.selected].Accounts))
+			for i, account := range e.Wallets[win.selected].Accounts {
+				if account.Name == "imported" {
+					continue
+				}
+				accounts[i] = decredmaterial.TabItem{
+					Title: e.Wallets[win.selected].Accounts[i].Name,
+				}
+			}
+			win.accountTabs.SetTabs(accounts)
+		}()
+
 		return
 	case *wallet.Transactions:
 		win.walletTransactions = e

--- a/ui/window.go
+++ b/ui/window.go
@@ -5,6 +5,8 @@ import (
 	"image"
 	"time"
 
+	"github.com/raedahgroup/godcr/ui/values"
+
 	"gioui.org/font/gofont"
 	"gioui.org/op"
 
@@ -44,8 +46,9 @@ type Window struct {
 
 	err string
 
-	pages     map[string]layout.Widget
-	keyEvents chan *key.Event
+	pages                   map[string]layout.Widget
+	walletTabs, accountTabs *decredmaterial.Tabs
+	keyEvents               chan *key.Event
 }
 
 // CreateWindow creates and initializes a new window with start
@@ -71,6 +74,13 @@ func CreateWindow(wal *wallet.Wallet, decredIcons map[string]image.Image) (*Wind
 	win.states.loading = true
 	win.current = PageOverview
 	win.keyEvents = make(chan *key.Event)
+
+	win.walletTabs, win.accountTabs = decredmaterial.NewTabs(win.theme), decredmaterial.NewTabs(win.theme)
+	win.walletTabs.Position, win.accountTabs.Position = decredmaterial.Top, decredmaterial.Top
+	win.walletTabs.Separator, win.walletTabs.Separator = false, false
+	win.accountTabs.SetTitle(win.theme.Label(values.TextSize18, "Accounts:"))
+	win.walletTabs.SetTabs([]decredmaterial.TabItem{})
+	win.accountTabs.SetTabs([]decredmaterial.TabItem{})
 
 	win.addPages(decredIcons)
 	return win, nil


### PR DESCRIPTION
### Resolves

Issue #188 

### What's new

This PR fixes the unresponsiveness of the accounts and wallets tabs when clicked. The SetTab method  was made to only be called when wallet info is updated rather than being set on every frame.
