### PR TITLE
Resize icons on wallet page and receive page

### DIFF
--- a/ui/recieve_page.go
+++ b/ui/recieve_page.go
@@ -35,11 +35,11 @@ type receivePage struct {
 
 func (win *Window) ReceivePage(common pageCommon) layout.Widget {
 	moreBtn := common.theme.IconButton(new(widget.Clickable), mustIcon(widget.NewIcon(icons.NavigationMoreVert)))
-	moreBtn.Inset, moreBtn.Size = layout.UniformInset(values.MarginPadding5), values.MarginPadding35
+	moreBtn.Inset, moreBtn.Size = layout.UniformInset(values.MarginPadding5), values.MarginPadding20
 	infoBtn := common.theme.IconButton(new(widget.Clickable), mustIcon(widget.NewIcon(icons.ActionInfo)))
-	infoBtn.Inset, infoBtn.Size = layout.UniformInset(values.MarginPadding5), values.MarginPadding35
+	infoBtn.Inset, infoBtn.Size = layout.UniformInset(values.MarginPadding5), values.MarginPadding20
 	copyBtn := common.theme.IconButton(new(widget.Clickable), mustIcon(widget.NewIcon(icons.ContentContentCopy)))
-	copyBtn.Inset, copyBtn.Size = layout.UniformInset(values.MarginPadding5), values.MarginPadding35
+	copyBtn.Inset, copyBtn.Size = layout.UniformInset(values.MarginPadding5), values.MarginPadding20
 	copyBtn.Background = common.theme.Color.Background
 	copyBtn.Color = common.theme.Color.Text
 	receiveAddressLabel := common.theme.H6("")
@@ -223,7 +223,7 @@ func (pg *receivePage) receiveAddressColumn(gtx layout.Context) layout.Dimension
 			return pg.receiveAddressLabel.Layout(gtx)
 		}),
 		layout.Rigid(func(gtx C) D {
-			return layout.Inset{Left: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
+			return layout.Inset{Left: values.MarginPadding10, Top: values.CopyBtnAlignment}.Layout(gtx, func(gtx C) D {
 				return pg.copyBtn.Layout(gtx)
 			})
 		}),

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -27,6 +27,7 @@ var (
 	TextSize18 = unit.Dp(18)
 	TextSize28 = unit.Dp(28)
 
+	CopyBtnAlignment          = unit.Dp(-5)
 	WalletSyncBoxContentWidth = unit.Dp(280)
 	AccountLineWidth          = unit.Dp(350)
 )

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -68,7 +68,7 @@ func (win *Window) WalletPage(common pageCommon) layout.Widget {
 	pg.errorLabel.Color = common.theme.Color.Danger
 
 	var iconPadding = values.MarginPadding5
-	var iconSize = values.MarginPadding30
+	var iconSize = values.MarginPadding20
 
 	pg.icons.addAcct = common.theme.IconButton(new(widget.Clickable), common.icons.contentAdd)
 	pg.icons.addAcct.Inset = layout.UniformInset(iconPadding)


### PR DESCRIPTION
### Resolves

Issue #189 

### What's new

This PR resize the icons on the wallet and receive page.

### Relevant screenshots or logs
<img width="739" alt="image" src="https://user-images.githubusercontent.com/27733432/87994413-c08c5d00-cae4-11ea-9aee-c6bf8ee88494.png">

<img width="798" alt="image" src="https://user-images.githubusercontent.com/27733432/87994435-cd10b580-cae4-11ea-82db-9db33a32759f.png">
