### PR TITLE
Align wallet sub pages title and return button

### DIFF
--- a/ui/change_passphrase.go
+++ b/ui/change_passphrase.go
@@ -68,7 +68,7 @@ func (pg *walletPassphrasePage) Layout(gtx layout.Context, common pageCommon) la
 					})
 				}),
 				layout.Rigid(func(gtx C) D {
-					return layout.Inset{Left: values.MarginPadding45}.Layout(gtx, func(gtx C) D {
+					return layout.Inset{Left: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
 						return common.theme.H5("Change Wallet Password").Layout(gtx)
 					})
 				}),

--- a/ui/change_passphrase.go
+++ b/ui/change_passphrase.go
@@ -49,6 +49,7 @@ func (win *Window) WalletPassphrasePage(common pageCommon) layout.Widget {
 
 	pg.backButton.Color = common.theme.Color.Hint
 	pg.backButton.Size = values.MarginPadding30
+	pg.backButton.Inset = layout.UniformInset(values.MarginPadding0)
 
 	return func(gtx C) D {
 		pg.handle(common)

--- a/ui/sign_message_page.go
+++ b/ui/sign_message_page.go
@@ -91,7 +91,7 @@ func (pg *signMessagePage) Layout(gtx layout.Context, common pageCommon) layout.
 					})
 				}),
 				layout.Rigid(func(gtx C) D {
-					return layout.Inset{Left: values.MarginPadding45}.Layout(gtx, func(gtx C) D {
+					return layout.Inset{Left: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
 						return pg.titleLabel.Layout(gtx)
 					})
 				}),

--- a/ui/sign_message_page.go
+++ b/ui/sign_message_page.go
@@ -68,6 +68,7 @@ func (win *Window) SignMessagePage(common pageCommon) layout.Widget {
 	}
 	pg.backButton.Color = common.theme.Color.Hint
 	pg.backButton.Size = values.MarginPadding30
+	pg.backButton.Inset = layout.UniformInset(values.MarginPadding0)
 
 	return func(gtx C) D {
 		pg.handle(common)
@@ -85,7 +86,7 @@ func (pg *signMessagePage) Layout(gtx layout.Context, common pageCommon) layout.
 		func(gtx C) D {
 			return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					return layout.W.Layout(gtx, func(gtx C) D {
+					return layout.NW.Layout(gtx, func(gtx C) D {
 						return pg.backButton.Layout(gtx)
 					})
 				}),

--- a/ui/verify_message_page.go
+++ b/ui/verify_message_page.go
@@ -41,6 +41,7 @@ func (win *Window) VerifyMessagePage(c pageCommon) layout.Widget {
 	pg.clearBtn.Color = c.theme.Color.Primary
 	pg.backButton.Color = c.theme.Color.Hint
 	pg.backButton.Size = values.MarginPadding30
+	pg.backButton.Inset = layout.UniformInset(values.MarginPadding0)
 
 	return func(gtx C) D {
 		pg.handler(c)

--- a/ui/verify_message_page.go
+++ b/ui/verify_message_page.go
@@ -84,7 +84,7 @@ func (pg *verifyMessagePage) header(c *pageCommon) layout.Widget {
 							})
 						}),
 						layout.Rigid(func(gtx C) D {
-							return layout.Inset{Left: values.MarginPadding45}.Layout(gtx, func(gtx C) D {
+							return layout.Inset{Left: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
 								return c.theme.H5("Verify Wallet Message").Layout(gtx)
 							})
 						}),

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -251,7 +251,7 @@ func (pg *walletPage) subRename(gtx layout.Context, common pageCommon) layout.Di
 					return pg.returnBtn(gtx)
 				}),
 				layout.Rigid(func(gtx C) D {
-					return layout.Inset{Left: values.MarginPadding50}.Layout(gtx, func(gtx C) D {
+					return layout.Inset{Left: values.MarginPadding20}.Layout(gtx, func(gtx C) D {
 						return common.theme.H5("Rename Wallet").Layout(gtx)
 					})
 				}),

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -1,7 +1,7 @@
 package ui
 
 import (
-	"image/color"
+	// "image/color"
 	"time"
 
 	"github.com/raedahgroup/godcr/ui/values"
@@ -73,11 +73,11 @@ func (win *Window) WalletPage(common pageCommon) layout.Widget {
 	pg.icons.addAcct = common.theme.IconButton(new(widget.Clickable), common.icons.contentAdd)
 	pg.icons.addAcct.Inset = layout.UniformInset(iconPadding)
 	pg.icons.addAcct.Size = iconSize
-	pg.icons.main = common.theme.IconButton(new(widget.Clickable), common.icons.navigationArrowBack)
-	pg.icons.main.Background = color.RGBA{}
+	pg.icons.main = common.theme.PlainIconButton(new(widget.Clickable), common.icons.navigationArrowBack)
 	pg.icons.main.Color = common.theme.Color.Hint
-	pg.icons.main.Inset = layout.UniformInset(iconPadding)
-	pg.icons.main.Size = iconSize
+	pg.icons.main.Inset = layout.UniformInset(values.MarginPadding0)
+
+	pg.icons.main.Size = values.MarginPadding30
 	pg.icons.delete = common.theme.IconButton(new(widget.Clickable), common.icons.actionDelete)
 	pg.icons.delete.Size = iconSize
 	pg.icons.delete.Inset = layout.UniformInset(iconPadding)
@@ -246,7 +246,7 @@ func (pg *walletPage) subRename(gtx layout.Context, common pageCommon) layout.Di
 	list := layout.List{Axis: layout.Vertical}
 	wdgs := []func(gtx C) D{
 		func(gtx C) D {
-			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			return layout.Flex{}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
 					return pg.returnBtn(gtx)
 				}),
@@ -260,12 +260,12 @@ func (pg *walletPage) subRename(gtx layout.Context, common pageCommon) layout.Di
 		func(gtx C) D {
 			return layout.Flex{}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					return layout.Inset{Top: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
+					return layout.Inset{Top: values.TextSize12}.Layout(gtx, func(gtx C) D {
 						return common.theme.Body1("Your are about to rename").Layout(gtx)
 					})
 				}),
 				layout.Rigid(func(gtx C) D {
-					return layout.Inset{Left: values.MarginPadding5}.Layout(gtx, func(gtx C) D {
+					return layout.Inset{Left: values.MarginPadding5, Top: values.MarginPadding5}.Layout(gtx, func(gtx C) D {
 						txt := common.theme.H5(pg.current.Name)
 						txt.Color = common.theme.Color.Danger
 						return txt.Layout(gtx)

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	// "image/color"
 	"time"
 
 	"github.com/raedahgroup/godcr/ui/values"


### PR DESCRIPTION
### Resolves

Issue #196 

### What's new

This PR Aligns the wallet sub pages title and the return icon.

### Relevant screenshots or logs
<img width="802" alt="image" src="https://user-images.githubusercontent.com/27733432/88022882-facb1e00-cb27-11ea-9c12-dfb982fdaeb2.png">

<img width="764" alt="image" src="https://user-images.githubusercontent.com/27733432/88022912-074f7680-cb28-11ea-88bd-5414277bf515.png">

<img width="773" alt="image" src="https://user-images.githubusercontent.com/27733432/88022958-1d5d3700-cb28-11ea-8257-a9a205a5ebe5.png">

<img width="792" alt="image" src="https://user-images.githubusercontent.com/27733432/88022983-277f3580-cb28-11ea-8722-e75bdee60297.png">
