### PR TITLE
Reduce the max width of send page Editors.

### DIFF
--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -933,14 +933,8 @@ func (pg *SendPage) handleEditorChange(evt widget.EditorEvent) {
 
 // drawlayout wraps the pg tx and sync section in a card layout
 func (pg *SendPage) sectionLayout(gtx layout.Context, inset layout.Inset, body layout.Widget) layout.Dimensions {
+	gtx.Constraints.Max.X = gtx.Px(values.MarginPadding450)
 	return decredmaterial.Card{Color: pg.theme.Color.Surface}.Layout(gtx, func(gtx C) D {
 		return inset.Layout(gtx, body)
-	})
-}
-
-// drawlayout wraps the pg tx and sync section in a card layout
-func (pg *SendPage) sectionOutlineLayout(gtx layout.Context, body layout.Widget) layout.Dimensions {
-	return decredmaterial.Card{Color: pg.theme.Color.Hint}.Layout(gtx, func(gtx C) D {
-		return layout.UniformInset(values.MarginPadding1).Layout(gtx, body)
 	})
 }

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -330,17 +330,20 @@ func (pg *SendPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensi
 			return pg.sendAmountSection(gtx)
 		},
 		func(gtx C) D {
+			gtx.Constraints.Max.X = gtx.Px(values.MarginPadding450)
 			return pg.drawTransactionDetailWidgets(gtx)
 		},
 		func(gtx C) D {
 			if pg.calculateErrorText != "" {
 				gtx.Constraints.Min.X = gtx.Constraints.Max.X
-				return pg.theme.ErrorAlert(gtx, pg.calculateErrorText)
+				return pg.centralize(gtx, func(gtx C) D {
+					return pg.theme.ErrorAlert(gtx, pg.calculateErrorText)
+				})
 			}
 			return layout.Dimensions{}
 		},
 		func(gtx C) D {
-			gtx.Constraints.Min.X = gtx.Constraints.Max.X
+			gtx.Constraints.Min.X = gtx.Px(values.MarginPadding450)
 			return pg.nextButton.Layout(gtx)
 		},
 	}
@@ -652,6 +655,11 @@ func (pg *SendPage) drawConfirmationModal(gtx layout.Context) layout.Dimensions 
 			)
 		},
 		func(gtx C) D {
+			return layout.Inset{Right: values.MarginPadding15, Bottom: values.MarginPaddingMinus10}.Layout(gtx, func(gtx C) D {
+				return pg.txFeeLayout(gtx)
+			})
+		},
+		func(gtx C) D {
 			return pg.drawTransactionDetailWidgets(gtx)
 		},
 		func(gtx C) D {
@@ -937,4 +945,12 @@ func (pg *SendPage) sectionLayout(gtx layout.Context, inset layout.Inset, body l
 	return decredmaterial.Card{Color: pg.theme.Color.Surface}.Layout(gtx, func(gtx C) D {
 		return inset.Layout(gtx, body)
 	})
+}
+
+func (pg *SendPage) centralize(gtx layout.Context, content layout.Widget) layout.Dimensions {
+	return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+		layout.Flexed(1, func(gtx C) D {
+			return layout.Center.Layout(gtx, content)
+		}),
+	)
 }

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -24,6 +24,7 @@ var (
 	MarginPadding150     = unit.Dp(150)
 	MarginPadding280     = unit.Dp(280)
 	MarginPadding350     = unit.Dp(350)
+	MarginPadding450     = unit.Dp(450)
 
 	TextSize10 = unit.Dp(10)
 	TextSize12 = unit.Dp(12)


### PR DESCRIPTION
### Resolves

Issue #215

### What's new

This PR reduces the maximum width of the send page editors to that of the maximum text length.

### Relevant screenshots or logs

<img width="791" alt="image" src="https://user-images.githubusercontent.com/27733432/89373184-ed916000-d6df-11ea-815c-1503b6ff1666.png">

<img width="798" alt="image" src="https://user-images.githubusercontent.com/27733432/89373234-10bc0f80-d6e0-11ea-9921-f7f6716b8be2.png">

