### PR TITLE
fix wallet tab title not updating after wallet rename

### DIFF
--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -310,10 +310,6 @@ func (pg *SendPage) Handle(c pageCommon) {
 }
 
 func (pg *SendPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
-	// if len(common.info.Wallets) == 0 {
-	// 	return layout.Dimensions{}
-	// }
-
 	pageContent := []func(gtx C) D{
 		func(gtx C) D {
 			return pg.drawAlertSection(gtx)

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -310,9 +310,9 @@ func (pg *SendPage) Handle(c pageCommon) {
 }
 
 func (pg *SendPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
-	if len(common.info.Wallets) == 0 {
-		return layout.Dimensions{}
-	}
+	// if len(common.info.Wallets) == 0 {
+	// 	return layout.Dimensions{}
+	// }
 
 	pageContent := []func(gtx C) D{
 		func(gtx C) D {

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -425,15 +425,11 @@ func (pg *walletPage) Handle(common pageCommon) {
 			return
 		}
 
-		err := common.wallet.RenameWallet(pg.current.ID, name)
-		if err != nil {
-			log.Error(err)
-			pg.errorLabel.Text = err.Error()
-			return
-		}
+		common.wallet.RenameWallet(pg.current.ID, name, pg.errChann)
 
 		common.info.Wallets[*common.selectedWallet].Name = name
 		pg.subPage = subWalletMain
+		pg.walletNameEditor.Editor.SetText("")
 	}
 
 	if pg.walletNameEditor.Editor.Text() == "" {

--- a/wallet/responses.go
+++ b/wallet/responses.go
@@ -85,7 +85,7 @@ type LoadedWallets struct {
 // Restored is sent when the Wallet is done restoring a wallet
 type Restored struct{}
 
-// Restored is sent when the Wallet is done restoring a wallet
+// Renamed is sent when the Wallet is done renaming a wallet
 type Renamed struct {
 	ID int
 }

--- a/wallet/responses.go
+++ b/wallet/responses.go
@@ -85,6 +85,11 @@ type LoadedWallets struct {
 // Restored is sent when the Wallet is done restoring a wallet
 type Restored struct{}
 
+// Restored is sent when the Wallet is done restoring a wallet
+type Renamed struct {
+	ID int
+}
+
 // CreatedSeed is sent when the Wallet is done creating a wallet
 type CreatedSeed struct {
 	Seed string

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -65,7 +65,8 @@ var _ = Describe("Wallet", func() {
 		Expect(inf.Synced).To(Equal(false))
 	})
 	It("can rename a wallet", func() {
-		err := wal.RenameWallet(1, "random")
+		tempChan := make(chan error)
+		err := wal.RenameWallet(1, "random", tempChan)
 		Expect(err).To(BeNil())
 	})
 	It("can get the current address", func() {

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -71,8 +71,8 @@ var _ = Describe("Wallet", func() {
 			err := <-tempChan
 			Expect(err).To(BeNil())
 		}()
-		resp = <-wal.Send
-		Expect(err).To(BeNil())
+		resp := <-wal.Send
+		Expect(resp.Resp).To(BeAssignableToTypeOf(Renamed{}))
 	})
 	It("can get the current address", func() {
 		addr, err := wal.CurrentAddress(1, 0)

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -66,7 +66,12 @@ var _ = Describe("Wallet", func() {
 	})
 	It("can rename a wallet", func() {
 		tempChan := make(chan error)
-		err := wal.RenameWallet(1, "random", tempChan)
+		wal.RenameWallet(1, "random", tempChan)
+		go func() {
+			err := <-tempChan
+			Expect(err).To(BeNil())
+		}()
+		resp = <-wal.Send
 		Expect(err).To(BeNil())
 	})
 	It("can get the current address", func() {


### PR DESCRIPTION
### Resolves

Issue #225

### What's new

This PR fixes the issue with wallet name not updating the name of the wallet after wallet name is successfully renamed.