### PR TITLE
Display editor label on top borderline

### DIFF
--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -5,6 +5,8 @@ package decredmaterial
 import (
 	"image/color"
 
+	"github.com/planetdecred/godcr/ui/values"
+
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
@@ -114,17 +116,8 @@ func (e Editor) Layout(gtx layout.Context) layout.Dimensions {
 	return layout.UniformInset(e.m2).Layout(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
-				if e.IsTitleLabel {
-					if e.Editor.Focused() && e.ErrorLabel.Text == "" {
-						e.TitleLabel.Color = color.RGBA{41, 112, 255, 255}
-					}
-					return e.TitleLabel.Layout(gtx)
-				}
-				return layout.Dimensions{}
-			}),
-			layout.Rigid(func(gtx C) D {
-				return layout.Flex{}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
+				return layout.Stack{}.Layout(gtx,
+					layout.Stacked(func(gtx C) D {
 						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 							layout.Rigid(func(gtx C) D {
 								return e.editorLayout(gtx)
@@ -143,6 +136,19 @@ func (e Editor) Layout(gtx layout.Context) layout.Dimensions {
 							}),
 						)
 					}),
+					layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+						if e.IsTitleLabel {
+							return layout.Inset{
+								Top:  values.MarginPaddingMinus10,
+								Left: values.MarginPadding10,
+							}.Layout(gtx, func(gtx C) D {
+								return Card{Color: e.t.Color.Surface}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+									return e.TitleLabel.Layout(gtx)
+								})
+							})
+						}
+						return layout.Dimensions{}
+					}),
 				)
 			}),
 		)
@@ -156,7 +162,7 @@ func (e Editor) editorLayout(gtx C) D {
 			inset := layout.Inset{
 				Top:    e.m2,
 				Bottom: e.m2,
-				Left:   e.m5,
+				Left:   values.MarginPadding10,
 				Right:  e.m5,
 			}
 			return inset.Layout(gtx, func(gtx C) D {

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -98,6 +98,11 @@ func (e Editor) Layout(gtx layout.Context) layout.Dimensions {
 	if e.IsVisible {
 		e.flexWidth = 20
 	}
+
+	if e.Editor.Len() > 0 {
+		e.TitleLabel.Text = e.Hint
+	}
+
 	if e.Editor.Focused() {
 		e.TitleLabel.Text = e.Hint
 		e.LineColor = color.RGBA{41, 112, 255, 255}


### PR DESCRIPTION
This PR resolves issue #280 

<img width="791" alt="Screenshot 2020-12-25 at 15 36 16" src="https://user-images.githubusercontent.com/15804688/103137316-387c3600-46c8-11eb-8e1b-1bbf24e2a61f.png">
