### PR TITLE
Fix navigation when click the cancel button on the send and receive page

### DIFF
--- a/ui/compontents.go
+++ b/ui/compontents.go
@@ -745,6 +745,7 @@ func (page pageCommon) handleNavEvents() {
 
 	for i := range page.appBarNavItems {
 		for page.appBarNavItems[i].clickable.Clicked() {
+			page.setReturnPage(*page.page)
 			page.changePage(page.appBarNavItems[i].page)
 		}
 	}

--- a/ui/receive_page.go
+++ b/ui/receive_page.go
@@ -331,7 +331,7 @@ func (pg *receivePage) Handle(common pageCommon) {
 	}
 
 	if common.subPageBackButton.Button.Clicked() {
-		*common.page = PageOverview
+		*common.page = *common.returnPage
 	}
 
 	if pg.copy.Button.Clicked() {

--- a/ui/receive_page.go
+++ b/ui/receive_page.go
@@ -331,7 +331,7 @@ func (pg *receivePage) Handle(common pageCommon) {
 	}
 
 	if common.subPageBackButton.Button.Clicked() {
-		*common.page = *common.returnPage
+		common.changePage(*common.returnPage)
 	}
 
 	if pg.copy.Button.Clicked() {

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -990,7 +990,7 @@ func (pg *sendPage) Handle(c pageCommon) {
 	pg.sendToOption = pg.accountSwitch.SelectedOption()
 
 	if c.subPageBackButton.Button.Clicked() {
-		*c.page = *c.returnPage
+		c.changePage(*c.returnPage)
 	}
 
 	if c.subPageInfoButton.Button.Clicked() {

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -990,7 +990,7 @@ func (pg *sendPage) Handle(c pageCommon) {
 	pg.sendToOption = pg.accountSwitch.SelectedOption()
 
 	if c.subPageBackButton.Button.Clicked() {
-		*c.page = PageOverview
+		*c.page = *c.returnPage
 	}
 
 	if c.subPageInfoButton.Button.Clicked() {


### PR DESCRIPTION
Resolves #390 
- Currently, when clicking on the cancel button on the send and receive page, it always navigates to the overview page. This modifies the cancel button navigation to return to the previous page.