### PR TITLE
Clear error messages on verify message page

### DIFF
--- a/ui/sign_message_page.go
+++ b/ui/sign_message_page.go
@@ -40,7 +40,6 @@ func (win *Window) SignMessagePage(common pageCommon) layout.Widget {
 	errorLabel := common.theme.Caption("")
 	errorLabel.Color = common.theme.Color.Danger
 	copyIcon := common.icons.copyIcon
-	copyIcon.Scale = 1
 
 	pg := &signMessagePage{
 		container: layout.List{
@@ -176,6 +175,7 @@ func (pg *signMessagePage) drawResult() layout.Widget {
 										return layout.E.Layout(gtx, func(gtx C) D {
 											return layout.Inset{Top: values.MarginPadding7}.Layout(gtx, func(gtx C) D {
 												return decredmaterial.Clickable(gtx, pg.copySignature, func(gtx C) D {
+													pg.copyIcon.Scale = 1.0
 													return pg.copyIcon.Layout(gtx)
 												})
 											})

--- a/ui/verify_message_page.go
+++ b/ui/verify_message_page.go
@@ -155,6 +155,7 @@ func (pg *verifyMessagePage) handle(c pageCommon) {
 				pg.signInput.SetError("Invalid signature")
 				return
 			}
+			pg.signInput.SetError("")
 
 			if !valid {
 				pg.verifyMessageStatus = c.icons.navigationCancel
@@ -203,6 +204,7 @@ func (pg *verifyMessagePage) validateAddress(c pageCommon) bool {
 		return false
 	}
 
+	pg.addressInput.SetError("")
 	return true
 }
 


### PR DESCRIPTION
Resolves #392 
- This modifies the error messages clear after correct values have been inputted and the verify message button is clicked.