### PR TITLE
Fix max button on send page

### DIFF
--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -108,6 +108,8 @@ type sendPage struct {
 
 	txAuthorErrChan  chan error
 	broadcastErrChan chan error
+
+	walletSelected int
 }
 
 func (win *Window) SendPage(common pageCommon) layout.Widget {
@@ -140,6 +142,8 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 		broadcastErrChan: make(chan error),
 		txAuthorErrChan:  make(chan error),
 	}
+
+	pg.walletSelected = common.wallAcctSelector.selectedSendWallet
 
 	pg.accountSwitch = common.theme.SwitchButtonText([]decredmaterial.SwitchItem{{Text: "Address"}, {Text: "My account"}})
 
@@ -1139,6 +1143,11 @@ func (pg *sendPage) Handle(c pageCommon) {
 
 	if pg.amountErrorText != "" {
 		pg.leftAmountEditor.SetError(pg.amountErrorText)
+	}
+
+	if pg.walletSelected != c.wallAcctSelector.selectedSendWallet {
+		pg.shouldInitializeTxAuthor = true
+		pg.walletSelected = c.wallAcctSelector.selectedSendWallet
 	}
 
 	if pg.shouldInitializeTxAuthor {

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -1003,27 +1003,32 @@ func (pg *sendPage) setMaxAmount(c pageCommon) {
 	sendAcct := sendWallet.Accounts[c.wallAcctSelector.selectedSendAccount]
 	atomValue := sendAcct.SpendableBalance
 
-	// Estimate max send value
-	amount, err := pg.txAuthor.EstimateMaxSendAmount()
-	if err == nil {
-		atomValue = amount.AtomValue
-		dcrValue := amount.DcrValue
-		pg.updateAmountField(dcrValue)
-		pg.calculateValues(c, false)
-	}
+	pg.updateAmountField(dcrutil.Amount(0).ToCoin())
+	pg.calculateValues(c, false)
 
-	// Adjust value
-	step := int64(10)
-	for {
-		_, err := pg.txAuthor.EstimateFeeAndSize()
-		if err != nil {
-			atomValue -= step
-			pg.updateAmountField(dcrutil.Amount(atomValue).ToCoin())
+	if atomValue > 0 {
+		// Estimate max send value
+		amount, err := pg.txAuthor.EstimateMaxSendAmount()
+		if err == nil {
+			atomValue = amount.AtomValue
+			dcrValue := amount.DcrValue
+			pg.updateAmountField(dcrValue)
 			pg.calculateValues(c, false)
-		} else {
-			pg.updateAmountField(dcrutil.Amount(atomValue).ToCoin())
-			pg.calculateValues(c, false)
-			break
+		}
+
+		// Adjust value
+		step := int64(10)
+		for {
+			_, err := pg.txAuthor.EstimateFeeAndSize()
+			if err != nil {
+				atomValue -= step
+				pg.updateAmountField(dcrutil.Amount(atomValue).ToCoin())
+				pg.calculateValues(c, false)
+			} else {
+				pg.updateAmountField(dcrutil.Amount(atomValue).ToCoin())
+				pg.calculateValues(c, false)
+				break
+			}
 		}
 	}
 }

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -990,7 +990,7 @@ func (pg *sendPage) fetchExchangeValue() {
 	}()
 }
 
-func (pg *sendPage) setMaxAmount(c pageCommon){
+func (pg *sendPage) setMaxAmount(c pageCommon) {
 	sendWallet := c.info.Wallets[c.wallAcctSelector.selectedSendWallet]
 	sendAcct := sendWallet.Accounts[c.wallAcctSelector.selectedSendAccount]
 	spendableBalance := sendAcct.SpendableBalance
@@ -1001,7 +1001,7 @@ func (pg *sendPage) setMaxAmount(c pageCommon){
 	spendableBalanceDCR := dcrutil.Amount(spendableBalance - fee).ToCoin()
 
 	if !pg.usdExchangeSet {
-		pg.leftAmountEditor.Editor.SetText(fmt.Sprintf("%s", strconv.FormatFloat(spendableBalanceDCR, 'f', 7, 64)))
+		pg.leftAmountEditor.Editor.SetText(strconv.FormatFloat(spendableBalanceDCR, 'f', 7, 64))
 	} else {
 		pg.fetchExchangeValue()
 		pg.usdExchangeRate, _ = strconv.ParseFloat(pg.LastTradeRate, 64)
@@ -1009,11 +1009,11 @@ func (pg *sendPage) setMaxAmount(c pageCommon){
 
 		switch {
 		case pg.leftExchangeValue == "USD":
-			pg.leftAmountEditor.Editor.SetText(fmt.Sprintf("%s", strconv.FormatFloat(spendableBalanceUSD, 'f', 7, 64)))
-			pg.rightAmountEditor.Editor.SetText(fmt.Sprintf("%s", strconv.FormatFloat(spendableBalanceDCR, 'f', 7, 64)))
+			pg.leftAmountEditor.Editor.SetText(strconv.FormatFloat(spendableBalanceUSD, 'f', 7, 64))
+			pg.rightAmountEditor.Editor.SetText(strconv.FormatFloat(spendableBalanceDCR, 'f', 7, 64))
 		case pg.leftExchangeValue == "DCR":
-			pg.leftAmountEditor.Editor.SetText(fmt.Sprintf("%s", strconv.FormatFloat(spendableBalanceDCR, 'f', 7, 64)))
-			pg.rightAmountEditor.Editor.SetText(fmt.Sprintf("%s", strconv.FormatFloat(spendableBalanceUSD, 'f', 7, 64)))
+			pg.leftAmountEditor.Editor.SetText(strconv.FormatFloat(spendableBalanceDCR, 'f', 7, 64))
+			pg.rightAmountEditor.Editor.SetText(strconv.FormatFloat(spendableBalanceUSD, 'f', 7, 64))
 		}
 	}
 
@@ -1187,7 +1187,7 @@ func (pg *sendPage) Handle(c pageCommon) {
 		pg.leftAmountEditor.Editor.Focus()
 		pg.setMaxAmount(c)
 	}
-	if pg.rightAmountEditor.CustomButton.Button.Clicked(){
+	if pg.rightAmountEditor.CustomButton.Button.Clicked() {
 		pg.rightAmountEditor.Editor.Focus()
 		pg.setMaxAmount(c)
 	}

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -760,7 +760,7 @@ func (pg *sendPage) inputsNotEmpty(editors ...*widget.Editor) bool {
 	return true
 }
 
-func (pg *sendPage) calculateValues(c pageCommon) {
+func (pg *sendPage) calculateValues(c pageCommon, isUpdateAmountInput bool) {
 	defaultLeftValues := fmt.Sprintf("- %s", "DCR")
 	defaultRightValues := "($ -)"
 
@@ -790,13 +790,13 @@ func (pg *sendPage) calculateValues(c pageCommon) {
 		pg.amountDCRtoUSD = pg.inputAmount * pg.usdExchangeRate
 	}
 
-	pg.updateAmountInputsValues(c)
+	pg.updateAmountInputsValues(c, isUpdateAmountInput)
 	pg.getTxFee()
 	pg.updateDefaultValues()
 	pg.balanceAfterSend(false, c)
 }
 
-func (pg *sendPage) updateAmountInputsValues(c pageCommon) {
+func (pg *sendPage) updateAmountInputsValues(c pageCommon, isUpdateAmountInput bool) {
 	switch {
 	case pg.leftExchangeValue == "USD" && pg.LastTradeRate != "" && pg.leftAmountEditor.Editor.Focused():
 		pg.rightAmountEditor.Editor.SetText(fmt.Sprintf("%f", pg.amountUSDtoDCR))
@@ -811,10 +811,12 @@ func (pg *sendPage) updateAmountInputsValues(c pageCommon) {
 		pg.rightAmountEditor.Editor.SetText(fmt.Sprintf("%f", pg.amountDCRtoUSD))
 		pg.setDestinationAddr(pg.inputAmount, c)
 	default:
-		if pg.rightAmountEditor.Editor.Focused() {
-			pg.leftAmountEditor.Editor.SetText(pg.rightAmountEditor.Editor.Text())
-		} else {
-			pg.rightAmountEditor.Editor.SetText(pg.leftAmountEditor.Editor.Text())
+		if isUpdateAmountInput {
+			if pg.rightAmountEditor.Editor.Focused() {
+				pg.leftAmountEditor.Editor.SetText(pg.rightAmountEditor.Editor.Text())
+			} else {
+				pg.rightAmountEditor.Editor.SetText(pg.leftAmountEditor.Editor.Text())
+			}
 		}
 		pg.setDestinationAddr(pg.inputAmount, c)
 	}
@@ -939,7 +941,7 @@ func (pg *sendPage) watchForBroadcastResult(c pageCommon) {
 		pg.resetFields()
 		c.modalLoad.setLoading(false)
 		pg.broadcastResult.TxHash = ""
-		pg.calculateValues(c)
+		pg.calculateValues(c, true)
 		pg.destinationAddressEditor.Editor.SetText("")
 	}
 }
@@ -948,7 +950,7 @@ func (pg *sendPage) handleEditorChange(evt widget.EditorEvent, c pageCommon) {
 	switch evt.(type) {
 	case widget.ChangeEvent:
 		pg.fetchExchangeValue()
-		pg.calculateValues(c)
+		pg.calculateValues(c, true)
 	}
 }
 
@@ -1017,7 +1019,7 @@ func (pg *sendPage) setMaxAmount(c pageCommon) {
 		}
 	}
 
-	pg.calculateValues(c)
+	pg.calculateValues(c, false)
 }
 
 func (pg *sendPage) Handle(c pageCommon) {
@@ -1031,13 +1033,13 @@ func (pg *sendPage) Handle(c pageCommon) {
 	if pg.LastTradeRate == "" && pg.count == 0 {
 		pg.count = 1
 		pg.shouldInitializeTxAuthor = true
-		pg.calculateValues(c)
+		pg.calculateValues(c, true)
 	}
 
 	if (pg.LastTradeRate != "" && pg.count == 0) || (pg.LastTradeRate != "" && pg.count == 1) {
 		pg.count = 2
 		pg.shouldInitializeTxAuthor = true
-		pg.calculateValues(c)
+		pg.calculateValues(c, true)
 	}
 
 	pg.updateExchangeError()
@@ -1076,7 +1078,7 @@ func (pg *sendPage) Handle(c pageCommon) {
 	}
 
 	for range pg.destinationAddressEditor.Editor.Events() {
-		pg.calculateValues(c)
+		pg.calculateValues(c, true)
 	}
 
 	for pg.currencySwap.Clicked() {
@@ -1090,7 +1092,7 @@ func (pg *sendPage) Handle(c pageCommon) {
 			}
 		}
 
-		pg.calculateValues(c)
+		pg.calculateValues(c, true)
 	}
 
 	for _, evt := range pg.leftAmountEditor.Editor.Events() {


### PR DESCRIPTION
Resolves #393 
- Fill max amount when clicking the max button
- Clear the Dollar Equivalence field when the DCR Amount field is also cleared, and vice versa
- Clear input field error when exit send page
- Show the spendable balance in the account selector widget