### PR TITLE
fix issue that prevents page from scrolling when wallet menu is open

### DIFF
--- a/ui/about_page.go
+++ b/ui/about_page.go
@@ -11,6 +11,7 @@ import (
 const PageAbout = "About"
 
 type aboutPage struct {
+	common    pageCommon
 	theme     *decredmaterial.Theme
 	card      decredmaterial.Card
 	container *layout.List
@@ -26,8 +27,9 @@ type aboutPage struct {
 	chevronRightIcon *widget.Icon
 }
 
-func (win *Window) AboutPage(common pageCommon) layout.Widget {
+func (win *Window) AboutPage(common pageCommon) Page {
 	pg := &aboutPage{
+		common:           common,
 		theme:            common.theme,
 		card:             common.theme.Card(),
 		container:        &layout.List{Axis: layout.Vertical},
@@ -46,17 +48,15 @@ func (win *Window) AboutPage(common pageCommon) layout.Widget {
 	pg.networkValue.Color = pg.theme.Color.Gray
 	pg.chevronRightIcon.Color = pg.theme.Color.Gray
 
-	return func(gtx C) D {
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *aboutPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *aboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	body := func(gtx C) D {
 		page := SubPage{
 			title: "About",
 			back: func() {
-				common.changePage(PageMore)
+				pg.common.changePage(PageMore)
 			},
 			body: func(gtx C) D {
 				return pg.card.Layout(gtx, func(gtx C) D {
@@ -64,11 +64,11 @@ func (pg *aboutPage) Layout(gtx layout.Context, common pageCommon) layout.Dimens
 				})
 			},
 		}
-		return common.SubPageLayout(gtx, page)
+		return pg.common.SubPageLayout(gtx, page)
 	}
 
-	return common.Layout(gtx, func(gtx C) D {
-		return common.UniformPadding(gtx, body)
+	return pg.common.Layout(gtx, func(gtx C) D {
+		return pg.common.UniformPadding(gtx, body)
 	})
 }
 
@@ -117,3 +117,6 @@ func (pg *aboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 		})
 	})
 }
+
+func (pg *aboutPage) handle()  {}
+func (pg *aboutPage) onClose() {}

--- a/ui/account_details_page.go
+++ b/ui/account_details_page.go
@@ -16,6 +16,7 @@ import (
 const PageAccountDetails = "AccountDetails"
 
 type acctDetailsPage struct {
+	common                   pageCommon
 	wallet                   *wallet.Wallet
 	current                  wallet.InfoShort
 	theme                    *decredmaterial.Theme
@@ -26,11 +27,12 @@ type acctDetailsPage struct {
 	errorReceiver            chan error
 }
 
-func (win *Window) AcctDetailsPage(common pageCommon) layout.Widget {
+func (win *Window) AcctDetailsPage(common pageCommon) Page {
 	pg := &acctDetailsPage{
 		acctDetailsPageContainer: layout.List{
 			Axis: layout.Vertical,
 		},
+		common:        common,
 		wallet:        common.wallet,
 		acctInfo:      &win.walletAccount,
 		theme:         common.theme,
@@ -42,13 +44,12 @@ func (win *Window) AcctDetailsPage(common pageCommon) layout.Widget {
 	pg.backButton.Color = common.theme.Color.Text
 	pg.backButton.Inset = layout.UniformInset(values.MarginPadding0)
 
-	return func(gtx C) D {
-		pg.Handler(gtx, common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *acctDetailsPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *acctDetailsPage) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.common
+
 	widgets := []func(gtx C) D{
 		func(gtx C) D {
 			return pg.accountBalanceLayout(gtx, &common)
@@ -279,3 +280,6 @@ func (pg *acctDetailsPage) Handler(gtx layout.Context, common pageCommon) {
 		}()
 	}
 }
+
+func (pg *acctDetailsPage) handle()  {}
+func (pg *acctDetailsPage) onClose() {}

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -35,6 +35,7 @@ type seedItemMenu struct {
 }
 
 type createRestore struct {
+	common          pageCommon
 	theme           *decredmaterial.Theme
 	info            *wallet.MultiWalletInfo
 	wal             *wallet.Wallet
@@ -84,8 +85,9 @@ type createRestore struct {
 }
 
 // Loading lays out the loading widget with a faded background
-func (win *Window) CreateRestorePage(common pageCommon) layout.Widget {
-	pg := createRestore{
+func (win *Window) CreateRestorePage(common pageCommon) Page {
+	pg := &createRestore{
+		common:        common,
 		theme:         common.theme,
 		wal:           common.wallet,
 		info:          common.info,
@@ -169,17 +171,17 @@ func (win *Window) CreateRestorePage(common pageCommon) layout.Widget {
 
 	pg.allSuggestions = dcrlibwallet.PGPWordList()
 
-	return func(gtx C) D {
-		pg.handle(common)
-		return pg.layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *createRestore) layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *createRestore) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.common
+
 	if pg.info.LoadedWallets > 0 {
 		pg.restoring = true
 		pg.showRestore = true
 	}
+
 	return common.Layout(gtx, func(gtx C) D {
 		pd := values.MarginPadding15
 		dims := layout.Flex{Axis: layout.Vertical, Spacing: layout.SpaceBetween}.Layout(gtx,
@@ -774,7 +776,9 @@ func (pg *createRestore) centralize(gtx layout.Context, content layout.Widget) l
 	)
 }
 
-func (pg *createRestore) handle(common pageCommon) {
+func (pg *createRestore) handle() {
+	common := pg.common
+
 	for pg.hideRestoreWallet.Button.Clicked() {
 		if pg.info.LoadedWallets <= 0 {
 			pg.showRestore = false
@@ -896,3 +900,5 @@ func (pg *createRestore) handle(common pageCommon) {
 	pg.editorSeedsEventsHandler()
 	pg.onSuggestionSeedsClicked()
 }
+
+func (pg *createRestore) onClose() {}

--- a/ui/debug_page.go
+++ b/ui/debug_page.go
@@ -19,9 +19,10 @@ type debugItem struct {
 type debugPage struct {
 	theme      *decredmaterial.Theme
 	debugItems []debugItem
+	common     pageCommon
 }
 
-func (win *Window) DebugPage(common pageCommon) layout.Widget {
+func (win *Window) DebugPage(common pageCommon) Page {
 	debugItems := []debugItem{
 		{
 			clickable: new(widget.Clickable),
@@ -33,21 +34,21 @@ func (win *Window) DebugPage(common pageCommon) layout.Widget {
 	pg := &debugPage{
 		theme:      common.theme,
 		debugItems: debugItems,
+		common:     common,
 	}
 
-	return func(gtx C) D {
-		pg.handle(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *debugPage) handle(common pageCommon) {
+func (pg *debugPage) handle() {
 	for i := range pg.debugItems {
 		for pg.debugItems[i].clickable.Clicked() {
-			common.changePage(pg.debugItems[i].page)
+			pg.common.changePage(pg.debugItems[i].page)
 		}
 	}
 }
+
+func (pg *debugPage) onClose() {}
 
 func (pg *debugPage) debugItem(gtx C, i int, common pageCommon) D {
 	return decredmaterial.Clickable(gtx, pg.debugItems[i].clickable, func(gtx C) D {
@@ -80,22 +81,22 @@ func (pg *debugPage) layoutDebugItems(gtx C, common pageCommon) {
 	})
 }
 
-func (pg *debugPage) Layout(gtx C, common pageCommon) D {
+func (pg *debugPage) Layout(gtx C) D {
 	container := func(gtx C) D {
 		page := SubPage{
 			title: "Debug",
 			back: func() {
-				common.changePage(PageMore)
+				pg.common.changePage(PageMore)
 			},
 			body: func(gtx C) D {
-				pg.layoutDebugItems(gtx, common)
+				pg.layoutDebugItems(gtx, pg.common)
 				return layout.Dimensions{Size: gtx.Constraints.Max}
 			},
 		}
-		return common.SubPageLayout(gtx, page)
+		return pg.common.SubPageLayout(gtx, page)
 
 	}
-	return common.Layout(gtx, func(gtx C) D {
-		return common.UniformPadding(gtx, container)
+	return pg.common.Layout(gtx, func(gtx C) D {
+		return pg.common.UniformPadding(gtx, container)
 	})
 }

--- a/ui/help_page.go
+++ b/ui/help_page.go
@@ -15,41 +15,40 @@ const PageHelp = "Help"
 type helpPage struct {
 	theme         *decredmaterial.Theme
 	documentation *widget.Clickable
+	common        pageCommon
 }
 
-func (win *Window) HelpPage(common pageCommon) layout.Widget {
+func (win *Window) HelpPage(common pageCommon) Page {
 	pg := &helpPage{
 		theme:         common.theme,
 		documentation: new(widget.Clickable),
+		common:        common,
 	}
 
-	return func(gtx C) D {
-		pg.handle(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
 // main settings layout
-func (pg *helpPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *helpPage) Layout(gtx layout.Context) layout.Dimensions {
 	body := func(gtx C) D {
 		page := SubPage{
 			title:    "Help",
 			subTitle: "For more information, please visit the Decred documentation.",
 			back: func() {
-				*common.page = PageMore
+				pg.common.changePage(PageMore)
 			},
 			body: func(gtx C) D {
 				return layout.Inset{Top: values.MarginPadding5}.Layout(gtx, func(gtx C) D {
 					return layout.Flex{Spacing: layout.SpaceBetween, WeightSum: 2}.Layout(gtx,
-						layout.Flexed(1, pg.document(common)),
+						layout.Flexed(1, pg.document(pg.common)),
 					)
 				})
 			},
 		}
-		return common.SubPageLayout(gtx, page)
+		return pg.common.SubPageLayout(gtx, page)
 	}
-	return common.Layout(gtx, func(gtx C) D {
-		return common.UniformPadding(gtx, body)
+	return pg.common.Layout(gtx, func(gtx C) D {
+		return pg.common.UniformPadding(gtx, body)
 	})
 }
 
@@ -88,6 +87,5 @@ func (pg *helpPage) pageSections(gtx layout.Context, icon *widget.Image, action 
 	})
 }
 
-func (pg *helpPage) handle(common pageCommon) {
-
-}
+func (pg *helpPage) handle()  {}
+func (pg *helpPage) onClose() {}

--- a/ui/log_page.go
+++ b/ui/log_page.go
@@ -14,7 +14,8 @@ import (
 const PageLog = "Log"
 
 type logPage struct {
-	theme *decredmaterial.Theme
+	theme  *decredmaterial.Theme
+	common pageCommon
 
 	copyLog  *widget.Clickable
 	copyIcon *widget.Image
@@ -25,9 +26,10 @@ type logPage struct {
 	entriesLock sync.Mutex
 }
 
-func (win *Window) LogPage(common pageCommon) layout.Widget {
+func (win *Window) LogPage(common pageCommon) Page {
 	pg := &logPage{
-		theme: common.theme,
+		common: common,
+		theme:  common.theme,
 		entriesList: layout.List{
 			Axis:        layout.Vertical,
 			ScrollToEnd: true,
@@ -41,10 +43,7 @@ func (win *Window) LogPage(common pageCommon) layout.Widget {
 
 	go pg.watchLogs(win.internalLog)
 
-	return func(gtx C) D {
-		//pg.handle(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
 func (pg *logPage) copyLogEntries(gtx C) {
@@ -65,7 +64,9 @@ func (pg *logPage) watchLogs(internalLog chan string) {
 	}
 }
 
-func (pg *logPage) Layout(gtx C, common pageCommon) D {
+func (pg *logPage) Layout(gtx C) D {
+	common := pg.common
+
 	container := func(gtx C) D {
 		page := SubPage{
 			title: "Wallet log",
@@ -108,3 +109,6 @@ func (pg *logPage) Layout(gtx C, common pageCommon) D {
 	}
 	return common.Layout(gtx, container)
 }
+
+func (pg *logPage) handle()  {}
+func (pg *logPage) onClose() {}

--- a/ui/more_page.go
+++ b/ui/more_page.go
@@ -17,12 +17,13 @@ type morePageHandler struct {
 }
 
 type morePage struct {
+	common            pageCommon
 	container         layout.Flex
 	morePageListItems []morePageHandler
 	page              *string
 }
 
-func (win *Window) MorePage(common pageCommon) layout.Widget {
+func (win *Window) MorePage(common pageCommon) Page {
 	morePageListItems := []morePageHandler{
 		{
 			clickable: new(widget.Clickable),
@@ -55,16 +56,14 @@ func (win *Window) MorePage(common pageCommon) layout.Widget {
 		morePageListItems[i].image.Scale = 1
 	}
 
-	pg := morePage{
+	pg := &morePage{
 		container:         layout.Flex{Axis: layout.Vertical},
 		morePageListItems: morePageListItems,
 		page:              &win.current,
+		common:            common,
 	}
 
-	return func(gtx C) D {
-		pg.Handle(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
 func (pg *morePage) handleClickEvents(common pageCommon) {
@@ -75,7 +74,8 @@ func (pg *morePage) handleClickEvents(common pageCommon) {
 	}
 }
 
-func (pg *morePage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *morePage) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.common
 	pg.handleClickEvents(common)
 
 	container := func(gtx C) D {
@@ -135,6 +135,5 @@ func (pg *morePage) layoutMoreItems(gtx layout.Context, common pageCommon) layou
 	)
 }
 
-func (pg *morePage) Handle(common pageCommon) {
-
-}
+func (pg *morePage) handle()  {}
+func (pg *morePage) onClose() {}

--- a/ui/page.go
+++ b/ui/page.go
@@ -46,6 +46,12 @@ type pageIcons struct {
 	ticketUnminedIcon *widget.Image
 }
 
+type Page interface {
+	Layout(layout.Context) layout.Dimensions
+	handle()
+	onClose()
+}
+
 type navHandler struct {
 	clickable     *widget.Clickable
 	image         *widget.Image
@@ -350,7 +356,7 @@ func (win *Window) loadPage(ic pageIcons) {
 
 	common.modalTemplate = win.LoadModalTemplates()
 
-	win.pages = make(map[string]layout.Widget)
+	win.pages = make(map[string]Page)
 	win.pages[PageWallet] = win.WalletPage(common)
 	win.pages[PageOverview] = win.OverviewPage(common)
 	win.pages[PageTransactions] = win.TransactionsPage(common)

--- a/ui/privacy_page.go
+++ b/ui/privacy_page.go
@@ -18,6 +18,7 @@ const PagePrivacy = "Privacy"
 
 type privacyPage struct {
 	theme                                *decredmaterial.Theme
+	common                               pageCommon
 	pageContainer                        layout.List
 	toggleMixer, allowUnspendUnmixedAcct *widget.Bool
 	infoBtn                              decredmaterial.IconButton
@@ -27,9 +28,10 @@ type privacyPage struct {
 	acctMixerStatus                      *chan *wallet.AccountMixer
 }
 
-func (win *Window) PrivacyPage(common pageCommon) layout.Widget {
+func (win *Window) PrivacyPage(common pageCommon) Page {
 	pg := &privacyPage{
 		theme:                   common.theme,
+		common:                  common,
 		pageContainer:           layout.List{Axis: layout.Vertical},
 		toggleMixer:             new(widget.Bool),
 		allowUnspendUnmixedAcct: new(widget.Bool),
@@ -44,13 +46,11 @@ func (win *Window) PrivacyPage(common pageCommon) layout.Widget {
 	pg.infoBtn.Background = common.theme.Color.Surface
 	pg.infoBtn.Inset = layout.UniformInset(values.MarginPadding0)
 
-	return func(gtx C) D {
-		pg.Handler(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *privacyPage) Layout(gtx layout.Context, c pageCommon) layout.Dimensions {
+func (pg *privacyPage) Layout(gtx layout.Context) layout.Dimensions {
+	c := pg.common
 	d := func(gtx C) D {
 		load := SubPage{
 			title:      "Privacy",
@@ -348,7 +348,8 @@ func (pg *privacyPage) gutter(gtx layout.Context) layout.Dimensions {
 	})
 }
 
-func (pg *privacyPage) Handler(common pageCommon) {
+func (pg *privacyPage) handle() {
+	common := pg.common
 	if pg.toPrivacySetup.Button.Clicked() {
 		go pg.showModalSetupMixerInfo(&common)
 	}
@@ -434,3 +435,5 @@ func (pg *privacyPage) showModalPasswordStartAccountMixer(common *pageCommon) {
 		},
 	}
 }
+
+func (pg *privacyPage) onClose() {}

--- a/ui/proposal_details_page.go
+++ b/ui/proposal_details_page.go
@@ -29,6 +29,7 @@ type proposalItemWidgets struct {
 type proposalDetails struct {
 	theme               *decredmaterial.Theme
 	loadingDescription  bool
+	common              pageCommon
 	descriptionCard     decredmaterial.Card
 	proposalItems       map[string]proposalItemWidgets
 	descriptionList     *layout.List
@@ -47,10 +48,11 @@ type proposalDetails struct {
 	refreshWindow       func()
 }
 
-func (win *Window) ProposalDetailsPage(common pageCommon) layout.Widget {
+func (win *Window) ProposalDetailsPage(common pageCommon) Page {
 	pg := &proposalDetails{
 		theme:               common.theme,
 		loadingDescription:  false,
+		common:              common,
 		descriptionCard:     common.theme.Card(),
 		descriptionList:     &layout.List{Axis: layout.Vertical},
 		selectedProposal:    &win.selectedProposal,
@@ -71,10 +73,7 @@ func (win *Window) ProposalDetailsPage(common pageCommon) layout.Widget {
 
 	pg.downloadIcon.Scale = 1
 
-	return func(gtx C) D {
-		pg.handle()
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
 func (pg *proposalDetails) handle() {
@@ -361,7 +360,16 @@ func (pg *proposalDetails) lineSeparator(inset layout.Inset) layout.Widget {
 	}
 }
 
-func (pg *proposalDetails) Layout(gtx C, common pageCommon) D {
+func (pg *proposalDetails) layoutParsingState(gtx C) D {
+	gtx.Constraints.Min.X = gtx.Constraints.Max.X
+	return layout.Center.Layout(gtx, func(gtx C) D {
+		return pg.theme.Body1("Preparing document...").Layout(gtx)
+	})
+}
+
+func (pg *proposalDetails) Layout(gtx C) D {
+	common := pg.common
+
 	proposal := *pg.selectedProposal
 	_, ok := pg.proposalItems[proposal.Token]
 	if !ok && !pg.loadingDescription {
@@ -427,3 +435,5 @@ func (pg *proposalDetails) Layout(gtx C, common pageCommon) D {
 	})
 
 }
+
+func (pg *proposalDetails) onClose() {}

--- a/ui/proposals_page.go
+++ b/ui/proposals_page.go
@@ -49,6 +49,7 @@ type tabs struct {
 
 type proposalsPage struct {
 	theme            *decredmaterial.Theme
+	common           pageCommon
 	wallet           *wallet.Wallet
 	selectedProposal **dcrlibwallet.Proposal
 	proposals        **wallet.Proposals
@@ -80,8 +81,9 @@ var (
 	}
 )
 
-func (win *Window) ProposalsPage(common pageCommon) layout.Widget {
+func (win *Window) ProposalsPage(common pageCommon) Page {
 	pg := &proposalsPage{
+		common:           common,
 		theme:            common.theme,
 		wallet:           win.wallet,
 		proposalsList:    &layout.List{},
@@ -119,13 +121,11 @@ func (win *Window) ProposalsPage(common pageCommon) layout.Widget {
 		)
 	}
 
-	return func(gtx C) D {
-		pg.Handle(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *proposalsPage) Handle(common pageCommon) {
+func (pg *proposalsPage) handle() {
+	common := pg.common
 	for i := range pg.tabs.tabs {
 		if pg.tabs.tabs[i].btn.Clicked() {
 			pg.tabs.selected = i
@@ -526,7 +526,9 @@ func (pg *proposalsPage) initializeProposaltabItems() {
 	}
 }
 
-func (pg *proposalsPage) Layout(gtx C, common pageCommon) D {
+func (pg *proposalsPage) Layout(gtx C) D {
+	common := pg.common
+
 	if !pg.proposalsItemSet {
 		pg.initializeProposaltabItems()
 	}
@@ -566,6 +568,8 @@ func (pg *proposalsPage) Layout(gtx C, common pageCommon) D {
 		)
 	})
 }
+
+func (pg *proposalsPage) onClose() {}
 
 func timeAgo(timestamp int64) string {
 	timeAgo, _ := timeago.TimeAgoWithTime(time.Now(), time.Unix(timestamp, 0))

--- a/ui/receive_page.go
+++ b/ui/receive_page.go
@@ -24,6 +24,7 @@ import (
 const PageReceive = "Receive"
 
 type receivePage struct {
+	common            pageCommon
 	pageContainer     layout.List
 	theme             *decredmaterial.Theme
 	isNewAddr, isInfo bool
@@ -32,15 +33,17 @@ type receivePage struct {
 	info, more        decredmaterial.IconButton
 	card              decredmaterial.Card
 	receiveAddress    decredmaterial.Label
+	gtx               *layout.Context
 
 	backdrop *widget.Clickable
 }
 
-func (win *Window) ReceivePage(common pageCommon) layout.Widget {
+func (win *Window) ReceivePage(common pageCommon) Page {
 	page := &receivePage{
 		pageContainer: layout.List{
 			Axis: layout.Vertical,
 		},
+		common:         common,
 		theme:          common.theme,
 		info:           common.theme.IconButton(new(widget.Clickable), mustIcon(widget.NewIcon(icons.ActionInfo))),
 		copy:           common.theme.Button(new(widget.Clickable), "Copy"),
@@ -72,13 +75,14 @@ func (win *Window) ReceivePage(common pageCommon) layout.Widget {
 	page.newAddr.Background = common.theme.Color.Surface
 	page.newAddr.TextSize = values.TextSize16
 
-	return func(gtx C) D {
-		page.Handle(gtx, common)
-		return page.Layout(gtx, common)
-	}
+	return page
 }
 
-func (pg *receivePage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *receivePage) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.common
+	if pg.gtx == nil {
+		pg.gtx = &gtx
+	}
 	pg.pageBackdropLayout(gtx)
 
 	pageContent := []func(gtx C) D{
@@ -281,7 +285,9 @@ func (pg *receivePage) addressQRCodeLayout(gtx layout.Context, common pageCommon
 	return img.Layout(gtx)
 }
 
-func (pg *receivePage) Handle(gtx C, common pageCommon) {
+func (pg *receivePage) handle() {
+	common := pg.common
+	gtx := *pg.gtx
 	if pg.backdrop.Clicked() {
 		pg.isNewAddr = false
 	}
@@ -344,3 +350,5 @@ func (pg *receivePage) Handle(gtx C, common pageCommon) {
 		return
 	}
 }
+
+func (pg *receivePage) onClose() {}

--- a/ui/security_tools_page.go
+++ b/ui/security_tools_page.go
@@ -16,23 +16,23 @@ type securityToolsPage struct {
 	theme           *decredmaterial.Theme
 	verifyMessage   *widget.Clickable
 	validateAddress *widget.Clickable
+	common          pageCommon
 }
 
-func (win *Window) SecurityToolsPage(common pageCommon) layout.Widget {
+func (win *Window) SecurityToolsPage(common pageCommon) Page {
 	pg := &securityToolsPage{
 		theme:           common.theme,
 		verifyMessage:   new(widget.Clickable),
 		validateAddress: new(widget.Clickable),
+		common:          common,
 	}
 
-	return func(gtx C) D {
-		pg.handle(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
 // main settings layout
-func (pg *securityToolsPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *securityToolsPage) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.common
 	body := func(gtx C) D {
 		page := SubPage{
 			title: "Security Tools",
@@ -107,7 +107,8 @@ func (pg *securityToolsPage) pageSections(gtx layout.Context, icon *widget.Image
 	})
 }
 
-func (pg *securityToolsPage) handle(common pageCommon) {
+func (pg *securityToolsPage) handle() {
+	common := pg.common
 	if pg.verifyMessage.Clicked() {
 		*common.returnPage = PageSecurityTools
 		common.setReturnPage(PageSecurityTools)
@@ -120,3 +121,5 @@ func (pg *securityToolsPage) handle(common pageCommon) {
 		common.changePage(ValidateAddress)
 	}
 }
+
+func (pg *securityToolsPage) onClose() {}

--- a/ui/seed_backup_page.go
+++ b/ui/seed_backup_page.go
@@ -43,9 +43,10 @@ type (
 )
 
 type backupPage struct {
-	theme *decredmaterial.Theme
-	wal   *wallet.Wallet
-	info  *wallet.MultiWalletInfo
+	theme  *decredmaterial.Theme
+	common pageCommon
+	wal    *wallet.Wallet
+	info   *wallet.MultiWalletInfo
 
 	backButton     decredmaterial.IconButton
 	title          decredmaterial.Label
@@ -75,11 +76,12 @@ type backupPage struct {
 	privpass       []byte
 }
 
-func (win *Window) BackupPage(c pageCommon) layout.Widget {
+func (win *Window) BackupPage(c pageCommon) Page {
 	b := &backupPage{
-		theme: c.theme,
-		wal:   c.wallet,
-		info:  c.info,
+		theme:  c.theme,
+		wal:    c.wallet,
+		info:   c.info,
+		common: c,
 
 		action:         c.theme.Button(new(widget.Clickable), "View seed phrase"),
 		backButton:     c.theme.PlainIconButton(new(widget.Clickable), c.icons.navigationArrowBack),
@@ -140,10 +142,7 @@ func (win *Window) BackupPage(c pageCommon) layout.Widget {
 	b.seedPhraseListRight = &layout.List{Axis: layout.Vertical}
 	b.verifyList = &layout.List{Axis: layout.Vertical}
 
-	return func(gtx C) layout.Dimensions {
-		b.handle(c)
-		return b.layout(gtx, c)
-	}
+	return b
 }
 
 func (pg *backupPage) activeButton() {
@@ -156,7 +155,8 @@ func (pg *backupPage) clearButton() {
 	pg.action.Color = pg.theme.Color.Primary
 }
 
-func (pg *backupPage) layout(gtx layout.Context, c pageCommon) layout.Dimensions {
+func (pg *backupPage) Layout(gtx layout.Context) layout.Dimensions {
+	c := pg.common
 	dims := pg.theme.Surface(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Vertical, Alignment: layout.Start}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
@@ -516,7 +516,8 @@ func (pg *backupPage) cancel() {
 	pg.isPasswordModalOpen = false
 }
 
-func (pg *backupPage) handle(c pageCommon) {
+func (pg *backupPage) handle() {
+	c := pg.common
 	if pg.backButton.Button.Clicked() {
 		pg.resetPage(c)
 	}
@@ -563,3 +564,5 @@ func (pg *backupPage) handle(c pageCommon) {
 		}
 	}
 }
+
+func (pg *backupPage) onClose() {}

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -36,6 +36,7 @@ type amountValue struct {
 
 type sendPage struct {
 	pageContainer layout.List
+	common        pageCommon
 	theme         *decredmaterial.Theme
 
 	txAuthor        *dcrlibwallet.TxAuthor
@@ -112,13 +113,14 @@ type sendPage struct {
 	walletSelected int
 }
 
-func (win *Window) SendPage(common pageCommon) layout.Widget {
+func (win *Window) SendPage(common pageCommon) Page {
 	pg := &sendPage{
 		pageContainer: layout.List{
 			Axis:      layout.Vertical,
 			Alignment: layout.Middle,
 		},
 
+		common:          common,
 		theme:           common.theme,
 		wallet:          common.wallet,
 		txAuthor:        &win.txAuthor,
@@ -203,13 +205,11 @@ func (win *Window) SendPage(common pageCommon) layout.Widget {
 
 	pg.fetchExchangeValue()
 
-	return func(gtx C) D {
-		pg.Handle(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *sendPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *sendPage) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.common
 	pageContent := []func(gtx C) D{
 		func(gtx C) D {
 			return pg.pageSections(gtx, "From", func(gtx C) D {
@@ -1060,7 +1060,8 @@ func (pg *sendPage) sendFund(c pageCommon) {
 	pg.wallet.BroadcastTransaction(pg.txAuthor, []byte(pg.passwordEditor.Editor.Text()), pg.broadcastErrChan)
 }
 
-func (pg *sendPage) Handle(c pageCommon) {
+func (pg *sendPage) handle() {
+	c := pg.common
 	sendWallet := c.info.Wallets[c.wallAcctSelector.selectedSendWallet]
 	sendAcct := sendWallet.Accounts[c.wallAcctSelector.selectedSendAccount]
 
@@ -1238,3 +1239,5 @@ func (pg *sendPage) Handle(c pageCommon) {
 		pg.setMaxAmount(c)
 	}
 }
+
+func (pg *sendPage) onClose() {}

--- a/ui/sign_message_page.go
+++ b/ui/sign_message_page.go
@@ -14,6 +14,7 @@ import (
 const PageSignMessage = "SignMessage"
 
 type signMessagePage struct {
+	common        pageCommon
 	theme         *decredmaterial.Theme
 	container     layout.List
 	wallet        *wallet.Wallet
@@ -27,9 +28,10 @@ type signMessagePage struct {
 	result                                     **wallet.Signature
 	copySignature                              *widget.Clickable
 	copyIcon                                   *widget.Image
+	gtx                                        *layout.Context
 }
 
-func (win *Window) SignMessagePage(common pageCommon) layout.Widget {
+func (win *Window) SignMessagePage(common pageCommon) Page {
 	addressEditor := common.theme.Editor(new(widget.Editor), "Address")
 	addressEditor.Editor.SingleLine, addressEditor.Editor.Submit = true, true
 	messageEditor := common.theme.Editor(new(widget.Editor), "Message")
@@ -45,6 +47,7 @@ func (win *Window) SignMessagePage(common pageCommon) layout.Widget {
 		container: layout.List{
 			Axis: layout.Vertical,
 		},
+		common: common,
 		theme:  common.theme,
 		wallet: common.wallet,
 
@@ -65,15 +68,14 @@ func (win *Window) SignMessagePage(common pageCommon) layout.Widget {
 
 	pg.signedMessageLabel.Color = common.theme.Color.Gray
 
-	return func(gtx C) D {
-		pg.handle(gtx, common)
-		pg.updateColors(common)
-		pg.validate(true)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *signMessagePage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *signMessagePage) Layout(gtx layout.Context) layout.Dimensions {
+	if pg.gtx == nil {
+		pg.gtx = &gtx
+	}
+	common := pg.common
 	pg.walletID = common.info.Wallets[*common.selectedWallet].ID
 
 	body := func(gtx C) D {
@@ -211,7 +213,12 @@ func (pg *signMessagePage) updateColors(common pageCommon) {
 	}
 }
 
-func (pg *signMessagePage) handle(gtx C, common pageCommon) {
+func (pg *signMessagePage) handle() {
+	gtx := *pg.gtx
+	common := pg.common
+	pg.updateColors(common)
+	pg.validate(true)
+
 	for pg.clearButton.Button.Clicked() {
 		pg.clearForm()
 	}
@@ -303,3 +310,5 @@ func (pg *signMessagePage) clearForm() {
 	pg.signedMessageLabel.Text = ""
 	pg.errorLabel.Text = ""
 }
+
+func (pg *signMessagePage) onClose() {}

--- a/ui/tickets_list_page.go
+++ b/ui/tickets_list_page.go
@@ -27,11 +27,13 @@ type ticketPageList struct {
 	ticketTypeDropDown *decredmaterial.DropDown
 	walletDropDown     *decredmaterial.DropDown
 	isGridView         bool
+	common             pageCommon
 }
 
-func (win *Window) TicketPageList(c pageCommon) layout.Widget {
+func (win *Window) TicketPageList(c pageCommon) Page {
 	pg := &ticketPageList{
 		th:             c.theme,
+		common:         c,
 		tickets:        &win.walletTickets,
 		ticketsList:    layout.List{Axis: layout.Vertical},
 		toggleViewType: new(widget.Clickable),
@@ -49,13 +51,11 @@ func (win *Window) TicketPageList(c pageCommon) layout.Widget {
 		{Text: "Revoked"},
 	}, 1)
 
-	return func(gtx C) D {
-		pg.handler(c)
-		return pg.layout(gtx, c)
-	}
+	return pg
 }
 
-func (pg *ticketPageList) layout(gtx layout.Context, c pageCommon) layout.Dimensions {
+func (pg *ticketPageList) Layout(gtx layout.Context) layout.Dimensions {
+	c := pg.common
 	body := func(gtx C) D {
 		page := SubPage{
 			title: "All tickets",
@@ -314,7 +314,8 @@ func (pg *ticketPageList) initWalletDropDown(common pageCommon) {
 	pg.walletDropDown = common.theme.DropDown(walletDropDownItems, 2)
 }
 
-func (pg *ticketPageList) handler(c pageCommon) {
+func (pg *ticketPageList) handle() {
+	c := pg.common
 	pg.initWalletDropDown(c)
 
 	if pg.toggleViewType.Clicked() {
@@ -338,3 +339,5 @@ func (pg *ticketPageList) handler(c pageCommon) {
 		}
 	}
 }
+
+func (pg *ticketPageList) onClose() {}

--- a/ui/tickets_page.go
+++ b/ui/tickets_page.go
@@ -25,9 +25,10 @@ import (
 const PageTickets = "Tickets"
 
 type ticketPage struct {
-	th   *decredmaterial.Theme
-	wal  *wallet.Wallet
-	vspd *dcrlibwallet.VSPD
+	th     *decredmaterial.Theme
+	wal    *wallet.Wallet
+	vspd   *dcrlibwallet.VSPD
+	common pageCommon
 
 	ticketPageContainer layout.List
 	ticketsLive         layout.List
@@ -69,11 +70,12 @@ type ticketPage struct {
 	isPurchaseLoading bool
 }
 
-func (win *Window) TicketPage(c pageCommon) layout.Widget {
+func (win *Window) TicketPage(c pageCommon) Page {
 	pg := &ticketPage{
 		th:      c.theme,
 		wal:     win.wallet,
 		tickets: &win.walletTickets,
+		common:  c,
 
 		ticketsLive:           layout.List{Axis: layout.Horizontal},
 		ticketsActivity:       layout.List{Axis: layout.Vertical},
@@ -114,13 +116,11 @@ func (win *Window) TicketPage(c pageCommon) layout.Widget {
 	pg.toTicketsActivity.Color = c.theme.Color.Primary
 	pg.toTicketsActivity.BackgroundColor = c.theme.Color.Surface
 
-	return func(gtx C) D {
-		pg.handler(c)
-		return pg.layout(gtx, c)
-	}
+	return pg
 }
 
-func (pg *ticketPage) layout(gtx layout.Context, c pageCommon) layout.Dimensions {
+func (pg *ticketPage) Layout(gtx layout.Context) layout.Dimensions {
+	c := pg.common
 	dims := c.Layout(gtx, func(gtx C) D {
 		return c.UniformPadding(gtx, func(gtx layout.Context) layout.Dimensions {
 			sections := []func(gtx C) D{
@@ -814,7 +814,8 @@ func (pg *ticketPage) createNewVSPD(c pageCommon) {
 	pg.vspd = vspd
 }
 
-func (pg *ticketPage) handler(c pageCommon) {
+func (pg *ticketPage) handle() {
+	c := pg.common
 	// TODO: frefresh when ticket price update from remote
 	if len(c.info.Wallets) > 0 && pg.ticketPrice == "" {
 		_, priceText := c.wallet.TicketPrice()
@@ -925,3 +926,5 @@ func (pg *ticketPage) handler(c pageCommon) {
 	default:
 	}
 }
+
+func (pg *ticketPage) onClose() {}

--- a/ui/transactions_page.go
+++ b/ui/transactions_page.go
@@ -37,14 +37,16 @@ type transactionsPage struct {
 	toTxnDetails                []*gesture.Click
 	separator                   decredmaterial.Line
 	theme                       *decredmaterial.Theme
+	common                      pageCommon
 
 	orderDropDown  *decredmaterial.DropDown
 	txTypeDropDown *decredmaterial.DropDown
 	walletDropDown *decredmaterial.DropDown
 }
 
-func (win *Window) TransactionsPage(common pageCommon) layout.Widget {
-	pg := transactionsPage{
+func (win *Window) TransactionsPage(common pageCommon) Page {
+	pg := &transactionsPage{
+		common:             common,
 		container:          layout.Flex{Axis: layout.Vertical},
 		txsList:            layout.List{Axis: layout.Vertical},
 		walletTransactions: &win.walletTransactions,
@@ -73,10 +75,7 @@ func (win *Window) TransactionsPage(common pageCommon) layout.Widget {
 		},
 	}, 1)
 
-	return func(gtx C) D {
-		pg.Handle(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
 func (pg *transactionsPage) setWallets(common pageCommon) {
@@ -95,7 +94,8 @@ func (pg *transactionsPage) setWallets(common pageCommon) {
 	pg.walletDropDown = common.theme.DropDown(walletDropDownItems, 2)
 }
 
-func (pg *transactionsPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *transactionsPage) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.common
 	pg.setWallets(common)
 	container := func(gtx C) D {
 		walletID := common.info.Wallets[pg.walletDropDown.SelectedIndex()].ID
@@ -237,7 +237,8 @@ func (pg *transactionsPage) txsFilters(common *pageCommon) layout.Widget {
 	}
 }
 
-func (pg *transactionsPage) Handle(common pageCommon) {
+func (pg *transactionsPage) handle() {
+	common := pg.common
 	sortSelection := pg.orderDropDown.SelectedIndex()
 
 	if pg.filterSorter != sortSelection {
@@ -297,3 +298,5 @@ func initTxnWidgets(common pageCommon, transaction wallet.Transaction) transacti
 
 	return txn
 }
+
+func (pg *transactionsPage) onClose() {}

--- a/ui/utxo_page.go
+++ b/ui/utxo_page.go
@@ -21,6 +21,7 @@ const PageUTXO = "unspentTransactionOutput"
 
 type utxoPage struct {
 	theme                  *decredmaterial.Theme
+	common                 pageCommon
 	utxoListContainer      layout.List
 	txAuthor               *dcrlibwallet.TxAuthor
 	backButton             decredmaterial.IconButton
@@ -40,9 +41,10 @@ type utxoPage struct {
 	selectedAccountID int32
 }
 
-func (win *Window) UTXOPage(common pageCommon) layout.Widget {
+func (win *Window) UTXOPage(common pageCommon) Page {
 	pg := &utxoPage{
 		theme:          common.theme,
+		common:         common,
 		unspentOutputs: &win.walletUnspentOutputs,
 		utxoListContainer: layout.List{
 			Axis: layout.Vertical,
@@ -58,13 +60,11 @@ func (win *Window) UTXOPage(common pageCommon) layout.Widget {
 	pg.backButton.Size = values.MarginPadding30
 	pg.useUTXOButton = common.theme.Button(new(widget.Clickable), "OK")
 
-	return func(gtx C) D {
-		pg.Handler(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *utxoPage) Handler(common pageCommon) {
+func (pg *utxoPage) handle() {
+	common := pg.common
 	pg.selectedWalletID = common.info.Wallets[*common.selectedWallet].ID
 	pg.selectedAccountID = common.info.Wallets[*common.selectedWallet].Accounts[*common.selectedAccount].Number
 
@@ -147,7 +147,8 @@ func (pg *utxoPage) clearPageData() {
 	pg.txnFee = ""
 }
 
-func (pg *utxoPage) Layout(gtx layout.Context, c pageCommon) layout.Dimensions {
+func (pg *utxoPage) Layout(gtx layout.Context) layout.Dimensions {
+	c := pg.common
 	return c.Layout(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
@@ -297,3 +298,5 @@ func (pg *utxoPage) utxoRow(gtx layout.Context, data *wallet.UnspentOutput, c *p
 		}),
 	)
 }
+
+func (pg *utxoPage) onClose() {}

--- a/ui/validate_address.go
+++ b/ui/validate_address.go
@@ -21,6 +21,7 @@ const (
 )
 
 type validateAddressPage struct {
+	common                pageCommon
 	theme                 *decredmaterial.Theme
 	addressEditor         decredmaterial.Editor
 	clearBtn, validateBtn decredmaterial.Button
@@ -29,12 +30,13 @@ type validateAddressPage struct {
 	stateValidate         int
 }
 
-func (win *Window) ValidateAddressPage(common pageCommon) layout.Widget {
+func (win *Window) ValidateAddressPage(common pageCommon) Page {
 	pg := &validateAddressPage{
 		theme:       common.theme,
 		validateBtn: common.theme.Button(new(widget.Clickable), "Validate"),
 		clearBtn:    common.theme.Button(new(widget.Clickable), "Clear"),
 		wallet:      common.wallet,
+		common:      common,
 	}
 
 	pg.addressEditor = common.theme.Editor(new(widget.Editor), "Address")
@@ -49,14 +51,11 @@ func (win *Window) ValidateAddressPage(common pageCommon) layout.Widget {
 
 	pg.stateValidate = none
 
-	return func(gtx C) D {
-		pg.handle()
-		pg.updateColors(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *validateAddressPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *validateAddressPage) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.common
 	pg.walletID = common.info.Wallets[*common.selectedWallet].ID
 	body := func(gtx C) D {
 		page := SubPage{
@@ -222,6 +221,9 @@ func (pg *validateAddressPage) pageSections(gtx layout.Context, body layout.Widg
 }
 
 func (pg *validateAddressPage) handle() {
+	c := pg.common
+	pg.updateColors(c)
+
 	if pg.validateBtn.Button.Clicked() {
 		pg.validateAddress()
 	}
@@ -277,3 +279,5 @@ func (pg *validateAddressPage) clearInputs(c *pageCommon) {
 	pg.validateBtn.Background = c.theme.Color.Hint
 	pg.addressEditor.Editor.SetText("")
 }
+
+func (pg *validateAddressPage) onClose() {}

--- a/ui/verify_message_page.go
+++ b/ui/verify_message_page.go
@@ -15,6 +15,7 @@ const PageVerifyMessage = "VerifyMessage"
 
 type verifyMessagePage struct {
 	theme                                 *decredmaterial.Theme
+	common                                pageCommon
 	addressInput, messageInput, signInput decredmaterial.Editor
 	clearBtn, verifyBtn                   decredmaterial.Button
 	verifyMessage                         decredmaterial.Label
@@ -22,9 +23,10 @@ type verifyMessagePage struct {
 	verifyMessageStatus *widget.Icon
 }
 
-func (win *Window) VerifyMessagePage(c pageCommon) layout.Widget {
+func (win *Window) VerifyMessagePage(c pageCommon) Page {
 	pg := &verifyMessagePage{
 		theme:         c.theme,
+		common:        c,
 		addressInput:  c.theme.Editor(new(widget.Editor), "Address"),
 		messageInput:  c.theme.Editor(new(widget.Editor), "Message"),
 		signInput:     c.theme.Editor(new(widget.Editor), "Signature"),
@@ -38,13 +40,12 @@ func (win *Window) VerifyMessagePage(c pageCommon) layout.Widget {
 	pg.verifyBtn.TextSize, pg.clearBtn.TextSize, pg.clearBtn.TextSize = values.TextSize14, values.TextSize14, values.TextSize14
 	pg.clearBtn.Background = color.NRGBA{0, 0, 0, 0}
 
-	return func(gtx C) D {
-		pg.handle(c)
-		return pg.Layout(gtx, c)
-	}
+	return pg
 }
 
-func (pg *verifyMessagePage) Layout(gtx layout.Context, c pageCommon) layout.Dimensions {
+func (pg *verifyMessagePage) Layout(gtx layout.Context) layout.Dimensions {
+	c := pg.common
+
 	var walletName = c.info.Wallets[*c.selectedWallet].Name
 	if *c.returnPage == PageSecurityTools {
 		walletName = ""
@@ -144,7 +145,9 @@ func (pg *verifyMessagePage) verifyMessageResponse() layout.Widget {
 	}
 }
 
-func (pg *verifyMessagePage) handle(c pageCommon) {
+func (pg *verifyMessagePage) handle() {
+	c := pg.common
+
 	pg.verifyBtn.Background, pg.clearBtn.Color = c.theme.Color.Hint, c.theme.Color.Hint
 	if pg.inputsNotEmpty(c) {
 		pg.verifyBtn.Background, pg.clearBtn.Color = c.theme.Color.Primary, c.theme.Color.Primary
@@ -223,3 +226,5 @@ func (pg *verifyMessagePage) inputsNotEmpty(c pageCommon) bool {
 	pg.verifyBtn.Background = c.theme.Color.Primary
 	return true
 }
+
+func (pg *verifyMessagePage) onClose() {}

--- a/ui/wallet_settings_page.go
+++ b/ui/wallet_settings_page.go
@@ -14,6 +14,7 @@ const PageWalletSettings = "WalletSettings"
 
 type walletSettingsPage struct {
 	theme      *decredmaterial.Theme
+	common     pageCommon
 	walletInfo *wallet.MultiWalletInfo
 	wal        *wallet.Wallet
 
@@ -25,9 +26,10 @@ type walletSettingsPage struct {
 	chevronRightIcon *widget.Icon
 }
 
-func (win *Window) WalletSettingsPage(common pageCommon) layout.Widget {
+func (win *Window) WalletSettingsPage(common pageCommon) Page {
 	pg := &walletSettingsPage{
 		theme:         common.theme,
+		common:        common,
 		walletInfo:    win.walletInfo,
 		wal:           common.wallet,
 		notificationW: new(widget.Bool),
@@ -42,13 +44,12 @@ func (win *Window) WalletSettingsPage(common pageCommon) layout.Widget {
 
 	pg.chevronRightIcon.Color = pg.theme.Color.LightGray
 
-	return func(gtx C) D {
-		pg.handle(common)
-		return pg.Layout(gtx, common)
-	}
+	return pg
 }
 
-func (pg *walletSettingsPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+func (pg *walletSettingsPage) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.common
+
 	beep := pg.wal.ReadBoolConfigValueForKey(dcrlibwallet.BeepNewBlocksConfigKey)
 	pg.notificationW.Value = false
 	if beep {
@@ -184,7 +185,8 @@ func (pg *walletSettingsPage) resetSelectedWallet(common pageCommon) {
 	common.wallAcctSelector.selectedReceiveAccount = 0
 }
 
-func (pg *walletSettingsPage) handle(common pageCommon) {
+func (pg *walletSettingsPage) handle() {
+	common := pg.common
 	for pg.changePass.Clicked() {
 		walletID := pg.walletInfo.Wallets[*common.selectedWallet].ID
 		go func() {
@@ -274,3 +276,5 @@ func (pg *walletSettingsPage) handle(common pageCommon) {
 	default:
 	}
 }
+
+func (pg *walletSettingsPage) onClose() {}


### PR DESCRIPTION
This fixes a bug that causes scrolling on the wallets page to stop functioning when a wallet options menu is open.

Fixes #397 