### PR TITLE
add loader widget to confirmation box

### DIFF
--- a/ui/modal_templates.go
+++ b/ui/modal_templates.go
@@ -5,6 +5,8 @@ import (
 	"gioui.org/text"
 	"gioui.org/unit"
 	"gioui.org/widget"
+	"gioui.org/widget/material"
+	"gioui.org/font/gofont"
 
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
@@ -55,6 +57,7 @@ type modalLoad struct {
 	template    string
 	title       string
 	confirm     interface{}
+	loading 	bool
 	confirmText string
 	cancel      interface{}
 	cancelText  string
@@ -87,6 +90,10 @@ func (m *ModalTemplate) importWatchOnlyWallet() []func(gtx C) D {
 			return m.extendedPublicKey.Layout(gtx)
 		},
 	}
+}
+
+func (load *modalLoad) setLoading(loading bool) {
+	load.loading = loading
 }
 
 func (m *ModalTemplate) createNewWallet() []func(gtx C) D {
@@ -425,7 +432,12 @@ func (m *ModalTemplate) actions(th *decredmaterial.Theme, load *modalLoad) []fun
 							if load.template == RescanWalletTemplate {
 								m.confirm.Background, m.confirm.Color = th.Color.Surface, th.Color.Primary
 							}
-							return m.confirm.Layout(gtx)
+							if load.loading {
+								th := material.NewTheme(gofont.Collection())
+								return material.Loader(th).Layout(gtx)		
+							} else {
+								return m.confirm.Layout(gtx)
+							}
 						})
 					}),
 				)
@@ -445,6 +457,8 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 
 		if m.editorsNotEmpty(th, m.walletName.Editor, m.spendingPassword.Editor, m.matchSpendingPassword.Editor) &&
 			m.confirm.Button.Clicked() {
+			load.setLoading(true)
+			// load.loading = true
 			if m.passwordsMatch(m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
 				load.confirm.(func(string, string))(m.walletName.Editor.Text(), m.spendingPassword.Editor.Text())
 			}

--- a/ui/modal_templates.go
+++ b/ui/modal_templates.go
@@ -1,12 +1,12 @@
 package ui
 
 import (
+	"gioui.org/font/gofont"
 	"gioui.org/layout"
 	"gioui.org/text"
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
-	"gioui.org/font/gofont"
 
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
@@ -57,7 +57,7 @@ type modalLoad struct {
 	template    string
 	title       string
 	confirm     interface{}
-	loading 	bool
+	loading     bool
 	confirmText string
 	cancel      interface{}
 	cancelText  string
@@ -92,8 +92,8 @@ func (m *ModalTemplate) importWatchOnlyWallet() []func(gtx C) D {
 	}
 }
 
-func (load *modalLoad) setLoading(loading bool) {
-	load.loading = loading
+func (load *modalLoad) setLoading(isLoading bool) {
+	load.loading = isLoading
 }
 
 func (m *ModalTemplate) createNewWallet() []func(gtx C) D {
@@ -388,6 +388,7 @@ func (m *ModalTemplate) Layout(th *decredmaterial.Theme, load *modalLoad) []func
 	if !load.isReset {
 		m.resetFields()
 		load.isReset = true
+		load.setLoading(false)
 	}
 
 	title := []func(gtx C) D{
@@ -434,10 +435,11 @@ func (m *ModalTemplate) actions(th *decredmaterial.Theme, load *modalLoad) []fun
 							}
 							if load.loading {
 								th := material.NewTheme(gofont.Collection())
-								return material.Loader(th).Layout(gtx)		
-							} else {
-								return m.confirm.Layout(gtx)
+								return layout.Inset{Top: unit.Dp(7)}.Layout(gtx, func(gtx C) D {
+									return material.Loader(th).Layout(gtx)
+								})
 							}
+							return m.confirm.Layout(gtx)
 						})
 					}),
 				)
@@ -458,7 +460,6 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 		if m.editorsNotEmpty(th, m.walletName.Editor, m.spendingPassword.Editor, m.matchSpendingPassword.Editor) &&
 			m.confirm.Button.Clicked() {
 			load.setLoading(true)
-			// load.loading = true
 			if m.passwordsMatch(m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
 				load.confirm.(func(string, string))(m.walletName.Editor.Text(), m.spendingPassword.Editor.Text())
 			}
@@ -495,6 +496,7 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 		return
 	case CreateAccountTemplate:
 		if m.editorsNotEmpty(th, m.walletName.Editor, m.spendingPassword.Editor) && m.confirm.Button.Clicked() {
+			load.setLoading(true)
 			load.confirm.(func(string, string))(m.walletName.Editor.Text(), m.spendingPassword.Editor.Text())
 		}
 		if m.cancel.Button.Clicked() {
@@ -527,6 +529,7 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 
 		if m.editorsNotEmpty(th, m.oldSpendingPassword.Editor, m.spendingPassword.Editor, m.matchSpendingPassword.Editor) &&
 			m.confirm.Button.Clicked() {
+			load.setLoading(true)
 			if m.passwordsMatch(m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
 				load.confirm.(func(string, string))(m.oldSpendingPassword.Editor.Text(), m.spendingPassword.Editor.Text())
 			}
@@ -550,6 +553,7 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 		return
 	case ImportWatchOnlyWalletTemplate:
 		if m.confirm.Button.Clicked() {
+			load.setLoading(true)
 			load.confirm.(func(string, string))(m.walletName.Editor.Text(), m.extendedPublicKey.Editor.Text())
 		}
 		if m.cancel.Button.Clicked() {

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -7,8 +7,11 @@ import (
 	"strconv"
 	"strings"
 
+	"gioui.org/font/gofont"
 	"gioui.org/layout"
+	"gioui.org/unit"
 	"gioui.org/widget"
+	"gioui.org/widget/material"
 
 	"github.com/decred/dcrd/dcrutil"
 	"github.com/planetdecred/dcrlibwallet"
@@ -583,6 +586,12 @@ func (pg *sendPage) confirmationModal(gtx layout.Context, common pageCommon) lay
 						})
 					}),
 					layout.Rigid(func(gtx C) D {
+						if common.modalLoad.loading {
+							th := material.NewTheme(gofont.Collection())
+							return layout.Inset{Top: unit.Dp(7)}.Layout(gtx, func(gtx C) D {
+								return material.Loader(th).Layout(gtx)
+							})
+						}
 						pg.confirmButton.Text = fmt.Sprintf("Send %s", dcrutil.Amount(pg.totalCostDCR).String())
 						return pg.confirmButton.Layout(gtx)
 					}),
@@ -920,6 +929,7 @@ func (pg *sendPage) watchForBroadcastResult(c pageCommon) {
 		pg.isConfirmationModalOpen = false
 		pg.isBroadcastingTransaction = false
 		pg.resetFields()
+		c.modalLoad.setLoading(false)
 		pg.broadcastResult.TxHash = ""
 		pg.calculateValues(c)
 		pg.destinationAddressEditor.Editor.SetText("")
@@ -1076,6 +1086,7 @@ func (pg *sendPage) Handle(c pageCommon) {
 	pg.watchForBroadcastResult(c)
 
 	for pg.confirmButton.Button.Clicked() {
+		c.modalLoad.setLoading(true)
 		if !pg.inputsNotEmpty(pg.passwordEditor.Editor) {
 			return
 		}
@@ -1098,6 +1109,7 @@ func (pg *sendPage) Handle(c pageCommon) {
 	}
 
 	for pg.closeConfirmationModalButton.Button.Clicked() {
+		c.modalLoad.setLoading(false)
 		pg.isConfirmationModalOpen = false
 	}
 


### PR DESCRIPTION
Resolves #388 

The PR adds a loader widget to certain modals after the action button has been clicked

**Screenshots**

![Screenshot from 2021-05-04 21-45-51](https://user-images.githubusercontent.com/25265396/117067824-64689180-ad22-11eb-82c6-3d794204f6b7.png)
