### PR TITLE
Fix account selector modal crash

### DIFF
--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -1117,7 +1117,6 @@ func (pg *sendPage) Handle(c pageCommon) {
 				pg.rightExchangeValue = "USD"
 			}
 		}
-
 		pg.calculateValues(c, true)
 	}
 

--- a/ui/state.go
+++ b/ui/state.go
@@ -83,7 +83,7 @@ func (win *Window) updateStates(update interface{}) {
 		win.window.Invalidate()
 	case wallet.DeletedWallet:
 		win.selected = 0
-		win.changePage(PageWallet)
+		win.changePageAndRefresh(PageWallet)
 		win.notifyOnSuccess("Wallet removed")
 	case wallet.AddedAccount:
 		win.notifyOnSuccess("Account created")

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -63,6 +63,7 @@ type walletPage struct {
 	watchOnlyWalletMoreButtons                 map[int]decredmaterial.IconButton
 	shadowBox                                  *decredmaterial.Shadow
 	separator                                  decredmaterial.Line
+	refreshPage                                *bool
 }
 
 func (win *Window) WalletPage(common pageCommon) layout.Widget {
@@ -82,6 +83,7 @@ func (win *Window) WalletPage(common pageCommon) layout.Widget {
 		openPopupIndex:           -1,
 		shadowBox:                common.theme.Shadow(),
 		separator:                common.theme.Separator(),
+		refreshPage:              &win.refreshPage,
 	}
 
 	pg.separator.Color = common.theme.Color.Background
@@ -273,6 +275,11 @@ func (pg *walletPage) showImportWatchOnlyWalletModal(common pageCommon) {
 
 // Layout lays out the widgets for the main wallets pg.
 func (pg *walletPage) Layout(gtx layout.Context, common pageCommon) layout.Dimensions {
+	if *pg.refreshPage {
+		common.refreshWindow()
+		*pg.refreshPage = false
+	}
+
 	if common.info.LoadedWallets == 0 {
 		return common.Layout(gtx, func(gtx C) D {
 			return common.UniformPadding(gtx, func(gtx C) D {

--- a/ui/wallet_settings_page.go
+++ b/ui/wallet_settings_page.go
@@ -176,6 +176,14 @@ func (pg *walletSettingsPage) bottomSectionLabel(title string) layout.Widget {
 	}
 }
 
+func (pg *walletSettingsPage) resetSelectedWallet(common pageCommon) {
+	common.wallAcctSelector.selectedSendWallet = 0
+	common.wallAcctSelector.selectedSendAccount = 0
+
+	common.wallAcctSelector.selectedReceiveWallet = 0
+	common.wallAcctSelector.selectedReceiveAccount = 0
+}
+
 func (pg *walletSettingsPage) handle(common pageCommon) {
 	for pg.changePass.Clicked() {
 		walletID := pg.walletInfo.Wallets[*common.selectedWallet].ID
@@ -241,7 +249,7 @@ func (pg *walletSettingsPage) handle(common pageCommon) {
 							title:    "Confirm to remove",
 							confirm: func(pass string) {
 								pg.wal.DeleteWallet(walletID, []byte(pass), pg.errorReceiver)
-								common.resetSelected()
+								pg.resetSelectedWallet(common)
 							},
 							confirmText: "Confirm",
 							cancel:      common.closeModal,

--- a/ui/wallet_settings_page.go
+++ b/ui/wallet_settings_page.go
@@ -241,6 +241,7 @@ func (pg *walletSettingsPage) handle(common pageCommon) {
 							title:    "Confirm to remove",
 							confirm: func(pass string) {
 								pg.wal.DeleteWallet(walletID, []byte(pass), pg.errorReceiver)
+								common.resetSelected()
 							},
 							confirmText: "Confirm",
 							cancel:      common.closeModal,

--- a/ui/window.go
+++ b/ui/window.go
@@ -61,9 +61,7 @@ type Window struct {
 	sysDestroyWithSync      bool
 	walletAcctMixerStatus   chan *wallet.AccountMixer
 	internalLog             chan string
-
-	selectedProposal        *dcrlibwallet.Proposal
-	refreshPage bool
+	refreshPage             bool
 }
 
 type WriteClipboard struct {

--- a/ui/window.go
+++ b/ui/window.go
@@ -61,6 +61,9 @@ type Window struct {
 	sysDestroyWithSync      bool
 	walletAcctMixerStatus   chan *wallet.AccountMixer
 	internalLog             chan string
+
+	selectedProposal        *dcrlibwallet.Proposal
+	refreshPage bool
 }
 
 type WriteClipboard struct {
@@ -122,6 +125,11 @@ func CreateWindow(wal *wallet.Wallet, decredIcons map[string]image.Image, collec
 func (win *Window) changePage(page string) {
 	win.current = page
 	win.refresh()
+}
+
+func (win *Window) changePageAndRefresh(page string) {
+	win.refreshPage = true
+	win.changePage(page)
 }
 
 func (win *Window) refresh() {


### PR DESCRIPTION
This resolves the account selector modal crash when a selected wallet is deleted.

Fixes #389 
