### PR TITLE
Replace win.clipboard with gio clipboard api

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,6 @@ decred.org/cspp v0.3.0/go.mod h1:UygjYilC94dER3BEU65Zzyoqy9ngJfWCD2rdJqvUs2A=
 decred.org/dcrwallet v1.6.0-rc4 h1:5IT6mFa+2YMqenu6aE2LetD0N8QSUVFyAFl205PvIIE=
 decred.org/dcrwallet v1.6.0-rc4/go.mod h1:lsrNbuKxkPGeHXPufxNTckwQopCEDz0r3t0a8JCKAmU=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-gioui.org v0.0.0-20210228180843-e1248651c871 h1:LDHDc7aDPdzf9I5MfEnSRCSJj6W0Nf6Dl9cLOGj4/ew=
-gioui.org v0.0.0-20210228180843-e1248651c871/go.mod h1:Y+uS7hHMvku1Q+ooaoq6fYD5B2LGoT8JtFgvmYmRzTw=
 gioui.org v0.0.0-20210418151603-3b69b5ed0512 h1:dYVWczPB9wooub+XoeKgUlVdQ2N2YdeUFbnazwcQiXw=
 gioui.org v0.0.0-20210418151603-3b69b5ed0512/go.mod h1:RSH6KIUZ0p2xy5zHDxgAM4zumjgTw83q2ge/PI+yyw8=
 github.com/AndreasBriese/bbloom v0.0.0-20190306092124-e2d15f34fcf9/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
@@ -646,7 +644,6 @@ golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200124204421-9fbb57f87de9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -34,8 +34,6 @@ var (
 type (
 	C = layout.Context
 	D = layout.Dimensions
-
-	ReadClipboard struct{}
 )
 
 type Theme struct {
@@ -80,9 +78,6 @@ type Theme struct {
 	expandIcon            *widget.Image
 	collapseIcon          *widget.Image
 
-	Clipboard     chan string
-	ReadClipboard chan interface{}
-
 	dropDownMenus []*DropDown
 }
 
@@ -124,8 +119,6 @@ func NewTheme(fontCollection []text.FontFace, decredIcons map[string]image.Image
 
 	t.expandIcon = &widget.Image{Src: paint.NewImageOp(decredIcons["expand_icon"])}
 	t.collapseIcon = &widget.Image{Src: paint.NewImageOp(decredIcons["collapse_icon"])}
-
-	t.Clipboard = make(chan string)
 	return t
 }
 

--- a/ui/log_page.go
+++ b/ui/log_page.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"sync"
 
+	"gioui.org/io/clipboard"
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
@@ -46,13 +47,11 @@ func (win *Window) LogPage(common pageCommon) layout.Widget {
 	}
 }
 
-func (pg *logPage) copyLogEntries(common pageCommon) {
+func (pg *logPage) copyLogEntries(gtx C) {
 	go func() {
 		pg.entriesLock.Lock()
 		defer pg.entriesLock.Unlock()
-		common.clipboard <- WriteClipboard{
-			Text: pg.fullLog,
-		}
+		clipboard.WriteOp{Text: pg.fullLog}.Add(gtx.Ops)
 	}()
 }
 
@@ -85,7 +84,7 @@ func (pg *logPage) Layout(gtx C, common pageCommon) D {
 				})
 			},
 			handleExtra: func() {
-				pg.copyLogEntries(common)
+				pg.copyLogEntries(gtx)
 			},
 			body: func(gtx C) D {
 				background := common.theme.Color.Surface

--- a/ui/page.go
+++ b/ui/page.go
@@ -112,7 +112,6 @@ type pageCommon struct {
 	walletTabs      *decredmaterial.Tabs
 	accountTabs     *decredmaterial.Tabs
 	keyEvents       chan *key.Event
-	clipboard       chan interface{}
 	toast           chan *toast
 	toastLoad       *toast
 	states          *states
@@ -284,7 +283,6 @@ func (win *Window) addPages(decredIcons map[string]image.Image) {
 		walletTabs:              win.walletTabs,
 		accountTabs:             win.accountTabs,
 		keyEvents:               win.keyEvents,
-		clipboard:               win.clipboard,
 		toast:                   win.toast,
 		toastLoad:               &toast{},
 		states:                  &win.states,

--- a/ui/receive_page.go
+++ b/ui/receive_page.go
@@ -6,6 +6,7 @@ import (
 	"image/color"
 	"time"
 
+	"gioui.org/io/clipboard"
 	"gioui.org/layout"
 	"gioui.org/op"
 	"gioui.org/op/paint"
@@ -72,7 +73,7 @@ func (win *Window) ReceivePage(common pageCommon) layout.Widget {
 	page.newAddr.TextSize = values.TextSize16
 
 	return func(gtx C) D {
-		page.Handle(common)
+		page.Handle(gtx, common)
 		return page.Layout(gtx, common)
 	}
 }
@@ -285,7 +286,7 @@ func (pg *receivePage) addressQRCodeLayout(gtx layout.Context, common pageCommon
 	return img.Layout(gtx)
 }
 
-func (pg *receivePage) Handle(common pageCommon) {
+func (pg *receivePage) Handle(gtx C, common pageCommon) {
 	if pg.backdrop.Clicked() {
 		pg.isNewAddr = false
 	}
@@ -335,9 +336,10 @@ func (pg *receivePage) Handle(common pageCommon) {
 	}
 
 	if pg.copy.Button.Clicked() {
-		go func() {
-			common.clipboard <- WriteClipboard{Text: common.info.Wallets[common.wallAcctSelector.selectedReceiveWallet].Accounts[common.wallAcctSelector.selectedReceiveAccount].CurrentAddress}
-		}()
+
+		selectedAccount := common.info.Wallets[common.wallAcctSelector.selectedReceiveWallet].Accounts[common.wallAcctSelector.selectedReceiveAccount]
+		clipboard.WriteOp{Text: selectedAccount.CurrentAddress}.Add(gtx.Ops)
+
 		pg.copy.Text = "Copied!"
 		pg.copy.Color = common.theme.Color.Success
 		time.AfterFunc(time.Second*3, func() {

--- a/ui/sign_message_page.go
+++ b/ui/sign_message_page.go
@@ -3,11 +3,11 @@ package ui
 import (
 	"image/color"
 
-	"github.com/planetdecred/godcr/ui/values"
-
+	"gioui.org/io/clipboard"
 	"gioui.org/layout"
 	"gioui.org/widget"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
+	"github.com/planetdecred/godcr/ui/values"
 	"github.com/planetdecred/godcr/wallet"
 )
 
@@ -66,7 +66,7 @@ func (win *Window) SignMessagePage(common pageCommon) layout.Widget {
 	pg.signedMessageLabel.Color = common.theme.Color.Gray
 
 	return func(gtx C) D {
-		pg.handle(common)
+		pg.handle(gtx, common)
 		pg.updateColors(common)
 		pg.validate(true)
 		return pg.Layout(gtx, common)
@@ -211,7 +211,7 @@ func (pg *signMessagePage) updateColors(common pageCommon) {
 	}
 }
 
-func (pg *signMessagePage) handle(common pageCommon) {
+func (pg *signMessagePage) handle(gtx C, common pageCommon) {
 	for pg.clearButton.Button.Clicked() {
 		pg.clearForm()
 	}
@@ -238,9 +238,7 @@ func (pg *signMessagePage) handle(common pageCommon) {
 	}
 
 	if pg.copySignature.Clicked() {
-		go func() {
-			common.clipboard <- WriteClipboard{Text: pg.signedMessageLabel.Text}
-		}()
+		clipboard.WriteOp{Text: pg.signedMessageLabel.Text}.Add(gtx.Ops)
 	}
 
 	if *pg.result != nil {

--- a/ui/transaction_details_page.go
+++ b/ui/transaction_details_page.go
@@ -5,6 +5,7 @@ import (
 	"image/color"
 	"strings"
 
+	"gioui.org/io/clipboard"
 	"gioui.org/layout"
 	"gioui.org/widget"
 
@@ -59,7 +60,7 @@ func (win *Window) TransactionDetailsPage(common pageCommon) layout.Widget {
 	pg.dot.Color = common.theme.Color.Gray
 
 	return func(gtx C) D {
-		pg.Handler(common)
+		pg.Handler(gtx, common)
 		return pg.Layout(gtx, common)
 	}
 }
@@ -428,23 +429,18 @@ func (pg *transactionDetailsPage) separator(gtx layout.Context) layout.Dimension
 	})
 }
 
-func (pg *transactionDetailsPage) Handler(common pageCommon) {
+func (pg *transactionDetailsPage) Handler(gtx C, common pageCommon) {
 	if pg.toDcrdata.Clicked() {
 		goToURL(common.wallet.GetBlockExplorerURL((*pg.txnInfo).Txn.Hash))
 	}
 
 	for _, b := range pg.copyTextBtn {
 		for b.Button.Clicked() {
-			t := b.Text
-			go func() {
-				common.clipboard <- WriteClipboard{Text: t}
-			}()
+			clipboard.WriteOp{Text: b.Text}.Add(gtx.Ops)
 		}
 	}
 
 	for pg.hashBtn.Button.Clicked() {
-		go func() {
-			common.clipboard <- WriteClipboard{Text: (*pg.txnInfo).Txn.Hash}
-		}()
+		clipboard.WriteOp{Text: (*pg.txnInfo).Txn.Hash}.Add(gtx.Ops)
 	}
 }

--- a/ui/utxo_page.go
+++ b/ui/utxo_page.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"fmt"
 
+	"gioui.org/io/clipboard"
 	"gioui.org/layout"
 	"gioui.org/text"
 	"gioui.org/widget"
@@ -288,9 +289,7 @@ func (pg *utxoPage) utxoRow(gtx layout.Context, data *wallet.UnspentOutput, c *p
 		}),
 		layout.Rigid(func(gtx C) D {
 			if pg.copyButtons[index].Button.Clicked() {
-				go func() {
-					c.clipboard <- WriteClipboard{Text: data.UTXO.Addresses}
-				}()
+				clipboard.WriteOp{Text: data.UTXO.Addresses}.Add(gtx.Ops)
 			}
 			return layout.Inset{Left: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
 				return pg.copyButtons[index].Layout(gtx)


### PR DESCRIPTION
This pr replaces the default `win.clipboard`  with gio's clipboard which can be accessed from any page rather than requiring access to `app.Window`.

Closes #409 