### PR TITLE
Implement submit functionality when enter btn is pressed

### DIFF
--- a/ui/modal_templates.go
+++ b/ui/modal_templates.go
@@ -506,7 +506,7 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 
 		if m.editorsNotEmpty(m.walletName.Editor, m.spendingPassword.Editor, m.matchSpendingPassword.Editor) &&
 			m.passwordsMatch(m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
-			if m.confirm.Button.Clicked() || m.handleSubmitEvent(m.walletName.Editor, m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
+			if m.confirm.Button.Clicked() || handleSubmitEvent(m.walletName.Editor, m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
 				load.setLoading(true)
 				load.confirm.(func(string, string))(m.walletName.Editor.Text(), m.spendingPassword.Editor.Text())
 			}
@@ -523,7 +523,7 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 		return
 	case RenameWalletTemplate, RenameAccountTemplate, ConnectToSpecificPeerTemplate, ChangeSpecificPeerTemplate, UserAgentTemplate:
 		if m.editorsNotEmpty(m.walletName.Editor) {
-			if m.confirm.Button.Clicked() || m.handleSubmitEvent(m.walletName.Editor) {
+			if m.confirm.Button.Clicked() || handleSubmitEvent(m.walletName.Editor) {
 				load.confirm.(func(string))(m.walletName.Editor.Text())
 			}
 		}
@@ -545,7 +545,7 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 		return
 	case CreateAccountTemplate:
 		if m.editorsNotEmpty(m.walletName.Editor, m.spendingPassword.Editor) {
-			if m.confirm.Button.Clicked() || m.handleSubmitEvent(m.walletName.Editor, m.spendingPassword.Editor) {
+			if m.confirm.Button.Clicked() || handleSubmitEvent(m.walletName.Editor, m.spendingPassword.Editor) {
 				load.setLoading(true)
 				load.confirm.(func(string, string))(m.walletName.Editor.Text(), m.spendingPassword.Editor.Text())
 			}
@@ -559,7 +559,8 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 		return
 	case PasswordTemplate, UnlockWalletTemplate, RemoveStartupPasswordTemplate:
 		if m.editorsNotEmpty(m.spendingPassword.Editor) {
-			if m.confirm.Button.Clicked() || m.handleSubmitEvent(m.spendingPassword.Editor) {
+			if m.confirm.Button.Clicked() || handleSubmitEvent(m.spendingPassword.Editor) {
+				load.setLoading(true)
 				load.confirm.(func(string))(m.spendingPassword.Editor.Text())
 			}
 		}
@@ -582,7 +583,7 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 
 		if m.editorsNotEmpty(m.oldSpendingPassword.Editor, m.spendingPassword.Editor, m.matchSpendingPassword.Editor) &&
 			m.passwordsMatch(m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
-			if m.confirm.Button.Clicked() || m.handleSubmitEvent(m.oldSpendingPassword.Editor, m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
+			if m.confirm.Button.Clicked() || handleSubmitEvent(m.oldSpendingPassword.Editor, m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
 				load.setLoading(true)
 				load.confirm.(func(string, string))(m.oldSpendingPassword.Editor.Text(), m.spendingPassword.Editor.Text())
 			}
@@ -606,7 +607,7 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 		return
 	case ImportWatchOnlyWalletTemplate:
 		if m.editorsNotEmpty(m.walletName.Editor, m.extendedPublicKey.Editor) {
-			if m.confirm.Button.Clicked() || m.handleSubmitEvent(m.walletName.Editor, m.extendedPublicKey.Editor) {
+			if m.confirm.Button.Clicked() || handleSubmitEvent(m.walletName.Editor, m.extendedPublicKey.Editor) {
 				load.setLoading(true)
 				load.confirm.(func(string, string))(m.walletName.Editor.Text(), m.extendedPublicKey.Editor.Text())
 			}
@@ -647,7 +648,7 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 
 		if m.editorsNotEmpty(m.spendingPassword.Editor, m.matchSpendingPassword.Editor) &&
 			m.passwordsMatch(m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
-			if m.confirm.Button.Clicked() || m.handleSubmitEvent(m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
+			if m.confirm.Button.Clicked() || handleSubmitEvent(m.spendingPassword.Editor, m.matchSpendingPassword.Editor) {
 				load.confirm.(func(string))(m.spendingPassword.Editor.Text())
 			}
 		}
@@ -672,7 +673,7 @@ func (m *ModalTemplate) handle(th *decredmaterial.Theme, load *modalLoad) (templ
 		return
 	case UnlockWalletRestoreTemplate:
 		if m.editorsNotEmpty(m.spendingPassword.Editor) {
-			if m.confirm.Button.Clicked() || m.handleSubmitEvent(m.spendingPassword.Editor) {
+			if m.confirm.Button.Clicked() || handleSubmitEvent(m.spendingPassword.Editor) {
 				load.confirm.(func(string))(m.spendingPassword.Editor.Text())
 			}
 		}
@@ -710,18 +711,6 @@ func (m *ModalTemplate) handleButtonEvents(load *modalLoad) {
 	if m.cancel.Button.Clicked() {
 		load.cancel.(func())()
 	}
-}
-
-func (m *ModalTemplate) handleSubmitEvent(editors ...*widget.Editor) bool {
-	var submit bool
-	for _, editor := range editors {
-		for _, e := range editor.Events() {
-			if _, ok := e.(widget.SubmitEvent); ok {
-				submit = true
-			}
-		}
-	}
-	return submit
 }
 
 // editorsNotEmpty checks that the editor fields are not empty. It returns false if they are empty and true if they are

--- a/ui/sign_message_page.go
+++ b/ui/sign_message_page.go
@@ -31,9 +31,9 @@ type signMessagePage struct {
 
 func (win *Window) SignMessagePage(common pageCommon) layout.Widget {
 	addressEditor := common.theme.Editor(new(widget.Editor), "Address")
-	addressEditor.Editor.SingleLine = true
+	addressEditor.Editor.SingleLine, addressEditor.Editor.Submit = true, true
 	messageEditor := common.theme.Editor(new(widget.Editor), "Message")
-	messageEditor.Editor.SingleLine = true
+	messageEditor.Editor.SingleLine, messageEditor.Editor.Submit = true, true
 	clearButton := common.theme.Button(new(widget.Clickable), "Clear all")
 	clearButton.Background = color.NRGBA{}
 	clearButton.Color = common.theme.Color.Gray
@@ -216,7 +216,7 @@ func (pg *signMessagePage) handle(gtx C, common pageCommon) {
 		pg.clearForm()
 	}
 
-	for pg.signButton.Button.Clicked() {
+	for pg.signButton.Button.Clicked() || handleSubmitEvent(pg.addressEditor.Editor, pg.messageEditor.Editor) {
 		if !pg.isSigningMessage && pg.validate(false) {
 			address := pg.addressEditor.Editor.Text()
 			message := pg.messageEditor.Editor.Text()
@@ -226,7 +226,6 @@ func (pg *signMessagePage) handle(gtx C, common pageCommon) {
 					template: PasswordTemplate,
 					title:    "Confirm to sign",
 					confirm: func(pass string) {
-						pg.signButton.Text = "Signing..."
 						pg.wallet.SignMessage(pg.walletID, []byte(pass), address, message, pg.errorReceiver)
 					},
 					confirmText: "Confirm",

--- a/ui/util.go
+++ b/ui/util.go
@@ -180,3 +180,15 @@ func ticketStatusIcon(c *pageCommon, ticketStatus string) *struct {
 	}
 	return &st
 }
+
+func handleSubmitEvent(editors ...*widget.Editor) bool {
+	var submit bool
+	for _, editor := range editors {
+		for _, e := range editor.Events() {
+			if _, ok := e.(widget.SubmitEvent); ok {
+				submit = true
+			}
+		}
+	}
+	return submit
+}

--- a/ui/verify_message_page.go
+++ b/ui/verify_message_page.go
@@ -33,7 +33,8 @@ func (win *Window) VerifyMessagePage(c pageCommon) layout.Widget {
 		clearBtn:      c.theme.Button(new(widget.Clickable), "Clear all"),
 	}
 
-	pg.messageInput.Editor.SingleLine, pg.addressInput.Editor.SingleLine, pg.messageInput.Editor.SingleLine = true, true, true
+	pg.addressInput.Editor.SingleLine, pg.messageInput.Editor.SingleLine = true, true
+	pg.signInput.Editor.Submit, pg.addressInput.Editor.Submit, pg.messageInput.Editor.Submit = true, true, true
 	pg.verifyBtn.TextSize, pg.clearBtn.TextSize, pg.clearBtn.TextSize = values.TextSize14, values.TextSize14, values.TextSize14
 	pg.clearBtn.Background = color.NRGBA{0, 0, 0, 0}
 
@@ -147,7 +148,7 @@ func (pg *verifyMessagePage) handle(c pageCommon) {
 	pg.verifyBtn.Background, pg.clearBtn.Color = c.theme.Color.Hint, c.theme.Color.Hint
 	if pg.inputsNotEmpty(c) {
 		pg.verifyBtn.Background, pg.clearBtn.Color = c.theme.Color.Primary, c.theme.Color.Primary
-		if pg.verifyBtn.Button.Clicked() {
+		if pg.verifyBtn.Button.Clicked() || handleSubmitEvent(pg.addressInput.Editor, pg.messageInput.Editor, pg.signInput.Editor) {
 			pg.verifyMessage.Text = ""
 			pg.verifyMessageStatus = nil
 			valid, err := c.wallet.VerifyMessage(pg.addressInput.Editor.Text(), pg.messageInput.Editor.Text(), pg.signInput.Editor.Text())


### PR DESCRIPTION
Fix #405 

This Pr implements the submit functionality, when the enter button is pressed on the password modal,
modals with editors like the create wallet, rename wallet modals, send page confirmation etc.
It implements submit functionality for sign message and verify message page when the enter button is pressed.
It also implements the confirmation/submit for modal without editor inputs like the remove wallet, set wallet password, remove wallet password etc.