### PR TITLE
update the editor design of the restore page

### DIFF
--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -68,7 +68,7 @@ func (t *Theme) RestoreEditor(editor *widget.Editor, hint string, title string) 
 		Edit:       e,
 		TitleLabel: t.Body2(title),
 		LineColor:  t.Color.Gray1,
-		height:     30,
+		height:     61,
 	}
 }
 
@@ -268,21 +268,23 @@ func (e Editor) handleEvents() {
 }
 
 func (re RestoreEditor) Layout(gtx layout.Context) layout.Dimensions {
+	l := re.t.SeparatorVertical(re.height, 4)
+	if re.Edit.Editor.Focused() {
+		re.TitleLabel.Color, re.LineColor, l.Color = re.t.Color.Primary, re.t.Color.Primary, re.t.Color.Primary
+	} else {
+		l.Color = re.t.Color.Gray1
+	}
 	border := widget.Border{Color: re.LineColor, CornerRadius: values.MarginPadding8, Width: values.MarginPadding2}
 	return border.Layout(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
-				return layout.Inset{
-					Left:  unit.Dp(10),
-					Right: unit.Dp(10),
-				}.Layout(gtx, func(gtx C) D {
+				gtx.Constraints.Min.X = 65
+				return layout.Center.Layout(gtx, func(gtx C) D {
 					return re.TitleLabel.Layout(gtx)
 				})
 			}),
 			layout.Rigid(func(gtx C) D {
-				l := re.t.SeparatorVertical(re.height, 2)
-				l.Color = re.t.Color.Gray1
-				return layout.Inset{}.Layout(gtx, func(gtx C) D {
+				return layout.Inset{Left: unit.Dp(-3), Right: unit.Dp(5)}.Layout(gtx, func(gtx C) D {
 					return l.Layout(gtx)
 				})
 			}),

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -278,7 +278,8 @@ func (re RestoreEditor) Layout(gtx layout.Context) layout.Dimensions {
 	return border.Layout(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
-				gtx.Constraints.Min.X = int(gtx.Metric.PxPerDp) * 40
+				width := unit.Value{U: unit.UnitDp, V: 40}
+				gtx.Constraints.Min.X = gtx.Px(width)
 				return layout.Center.Layout(gtx, func(gtx C) D {
 					return re.TitleLabel.Layout(gtx)
 				})

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -68,7 +68,7 @@ func (t *Theme) RestoreEditor(editor *widget.Editor, hint string, title string) 
 		Edit:       e,
 		TitleLabel: t.Body2(title),
 		LineColor:  t.Color.Gray1,
-		height:     61,
+		height:     31,
 	}
 }
 
@@ -268,7 +268,7 @@ func (e Editor) handleEvents() {
 }
 
 func (re RestoreEditor) Layout(gtx layout.Context) layout.Dimensions {
-	l := re.t.SeparatorVertical(re.height, 4)
+	l := re.t.SeparatorVertical(int(gtx.Metric.PxPerDp)*re.height, int(gtx.Metric.PxPerDp)*2)
 	if re.Edit.Editor.Focused() {
 		re.TitleLabel.Color, re.LineColor, l.Color = re.t.Color.Primary, re.t.Color.Primary, re.t.Color.Primary
 	} else {
@@ -278,7 +278,7 @@ func (re RestoreEditor) Layout(gtx layout.Context) layout.Dimensions {
 	return border.Layout(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
-				gtx.Constraints.Min.X = 65
+				gtx.Constraints.Min.X = int(gtx.Metric.PxPerDp) * 40
 				return layout.Center.Layout(gtx, func(gtx C) D {
 					return re.TitleLabel.Layout(gtx)
 				})


### PR DESCRIPTION
Resolves #408 

This PR fixes the following;
- extend vertical line to reach horizontal borders
- make width of editor's id to be the same
- make the vertical line bolder
- make the editor's borders change to blue while focused
- give adequate space to the cursor after the vertical line

**Screenshots**
<img width="800" alt="Screenshot 2021-05-17 at 10 36 14 PM" src="https://user-images.githubusercontent.com/25265396/118560543-8c63e600-b761-11eb-968b-38eb0572babf.png">
