### PR TITLE
adjust shadow colors to match mockup

### DIFF
--- a/ui/decredmaterial/shadow.go
+++ b/ui/decredmaterial/shadow.go
@@ -30,9 +30,9 @@ const (
 func (t *Theme) Shadow() *Shadow {
 	return &Shadow{
 		surface:       t.Color.Surface,
-		ambientColor:  color.NRGBA{A: 0x10},
-		penumbraColor: color.NRGBA{A: 0x20},
-		umbraColor:    color.NRGBA{A: 0x30},
+		ambientColor:  color.NRGBA{A: 0x1},
+		penumbraColor: color.NRGBA{A: 0x5},
+		umbraColor:    color.NRGBA{A: 0x10},
 	}
 }
 


### PR DESCRIPTION
This PR adjusts the shadow colors to match the current mock up designs, this affects the tickets page and the wallet option menu

**Screenshots**

![Screenshot from 2021-05-21 17-53-14](https://user-images.githubusercontent.com/25265396/119172626-18298b00-ba5e-11eb-8e6f-dcc90c12f6ff.png)
![Screenshot from 2021-05-21 17-52-56](https://user-images.githubusercontent.com/25265396/119172636-1b247b80-ba5e-11eb-99cc-e10c07d46f1d.png)
