### PR TITLE
Navigation arrow keys to select seed sugestion.

### DIFF
--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -663,6 +663,7 @@ func (pg *createRestore) layoutSeedMenu(gtx layout.Context, optionsSeedMenuIndex
 		border := widget.Border{Color: pg.theme.Color.LightGray, CornerRadius: values.MarginPadding5, Width: values.MarginPadding2}
 		return border.Layout(gtx, func(gtx C) D {
 			return pg.optionsMenuCard.Layout(gtx, func(gtx C) D {
+				gtx.Constraints.Min.X = gtx.Constraints.Max.X
 				return (&layout.List{Axis: layout.Vertical}).Layout(gtx, len(pg.seedMenu), func(gtx C, i int) D {
 					return material.Clickable(gtx, pg.seedMenu[i].button, func(gtx C) D {
 						return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
@@ -881,6 +882,12 @@ func (pg *createRestore) handle(common pageCommon) {
 				pg.seedClicked = true
 				pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[0]), -1)
 			}
+		}
+		if evt.Name == key.NameUpArrow {
+
+		}
+		if evt.Name == key.NameDownArrow {
+
 		}
 	case err := <-pg.errorReceiver:
 		common.states.creating = false

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -560,8 +560,8 @@ func (pg *createRestore) inputsGroup(gtx layout.Context, l *layout.List, len, st
 
 func (pg *createRestore) onSuggestionSeedsClicked() {
 	index := pg.seedEditors.focusIndex
-	for _, b := range pg.seedMenu {
-		for b.button.Button.Clicked() {
+	for i, b := range pg.seedMenu {
+		for pg.seedMenu[i].button.Button.Clicked() {
 			pg.seedEditors.editors[index].Edit.Editor.SetText(b.text)
 			pg.seedEditors.editors[index].Edit.Editor.MoveCaret(len(b.text), 0)
 			pg.seedClicked = true
@@ -571,15 +571,6 @@ func (pg *createRestore) onSuggestionSeedsClicked() {
 		}
 	}
 }
-
-// func (pg *createRestore) suggestionSeedEffect() {
-// 	for _, b := range pg.seedMenu {
-// 		b.button.Background = color.NRGBA{}
-// 		for b.button.Button.Hovered() {
-// 			b.button.Background = pg.theme.Color.LightGray
-// 		}
-// 	}
-// }
 
 func diff(a, b []int) []int {
 	temp := map[int]int{}
@@ -910,6 +901,9 @@ func (pg *createRestore) handle(common pageCommon) {
 			if pg.selected >= len(pg.suggestions) {
 				pg.selected = len(pg.suggestions) - 1
 			}
+		}
+		if (evt.Name == key.NameReturn || evt.Name == key.NameEnter) && pg.openPopupIndex != -1 && evt.State == key.Press {
+			pg.seedMenu[pg.selected].button.Button.Click()
 		}
 	case err := <-pg.errorReceiver:
 		common.states.creating = false

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -619,6 +619,7 @@ func (pg *createRestore) editorSeedsEventsHandler() {
 
 				pg.resetSeedFields.Color = pg.theme.Color.Primary
 				pg.suggestions = pg.suggestionSeeds(text)
+				pg.seedMenu = pg.seedMenu[:len(pg.suggestions)]
 				for k, s := range pg.suggestions {
 					pg.seedMenu[k].text, pg.seedMenu[k].button.Text = s, s
 				}
@@ -649,7 +650,7 @@ func (pg *createRestore) initSeedMenu() {
 
 func (pg *createRestore) suggestionSeedEffect() {
 	for k := range pg.suggestions {
-		if pg.selected == k {
+		if pg.selected == k || pg.seedMenu[k].button.Button.Hovered() {
 			pg.seedMenu[k].button.Background = pg.theme.Color.LightGray
 		} else {
 			pg.seedMenu[k].button.Background = color.NRGBA{}


### PR DESCRIPTION
This PR fix #407 
it uses the arrow up and down navigation keys to select seed suggestion and the enter button to submit the selected seed.
it also fix issues with seed suggestion menu being stuck on the maximum number of initially suggested seeds, even when they are no longer needed based on the texted entered into the seed editor.