### PR TITLE
fix crash that occured due to invalid memory address

### DIFF
--- a/ui/receive_page.go
+++ b/ui/receive_page.go
@@ -287,7 +287,7 @@ func (pg *receivePage) addressQRCodeLayout(gtx layout.Context, common pageCommon
 
 func (pg *receivePage) handle() {
 	common := pg.common
-	gtx := *pg.gtx
+	gtx := pg.gtx
 	if pg.backdrop.Clicked() {
 		pg.isNewAddr = false
 	}

--- a/ui/sign_message_page.go
+++ b/ui/sign_message_page.go
@@ -214,7 +214,7 @@ func (pg *signMessagePage) updateColors(common pageCommon) {
 }
 
 func (pg *signMessagePage) handle() {
-	gtx := *pg.gtx
+	gtx := pg.gtx
 	common := pg.common
 	pg.updateColors(common)
 	pg.validate(true)

--- a/ui/transaction_details_page.go
+++ b/ui/transaction_details_page.go
@@ -435,7 +435,7 @@ func (pg *transactionDetailsPage) separator(gtx layout.Context) layout.Dimension
 
 func (pg *transactionDetailsPage) handle() {
 	common := pg.common
-	gtx := *pg.gtx
+	gtx := pg.gtx
 	if pg.toDcrdata.Clicked() {
 		goToURL(common.wallet.GetBlockExplorerURL((*pg.txnInfo).Txn.Hash))
 	}


### PR DESCRIPTION
This PR fixes the crashes that occurs on both the Receive Page and Transaction Details Page