### PR TITLE
fix loader display bug on password modal when error occurs

### DIFF
--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -892,6 +892,7 @@ func (pg *createRestore) handle() {
 		if err.Error() == "exists" {
 			errText = "Wallet name already exists"
 		}
+		common.modalLoad.setLoading(false)
 		common.notify(errText, false)
 	default:
 	}

--- a/ui/privacy_page.go
+++ b/ui/privacy_page.go
@@ -364,6 +364,7 @@ func (pg *privacyPage) handle() {
 
 	select {
 	case err := <-pg.errorReceiver:
+		common.modalLoad.setLoading(false)
 		common.notify(err.Error(), false)
 	case stt := <-*pg.acctMixerStatus:
 		if stt.RunStatus == wallet.MixerStarted {

--- a/ui/receive_page.go
+++ b/ui/receive_page.go
@@ -287,7 +287,7 @@ func (pg *receivePage) addressQRCodeLayout(gtx layout.Context, common pageCommon
 
 func (pg *receivePage) handle() {
 	common := pg.common
-	gtx := *pg.gtx
+	gtx := pg.gtx
 	if pg.backdrop.Clicked() {
 		pg.isNewAddr = false
 	}

--- a/ui/settings_page.go
+++ b/ui/settings_page.go
@@ -532,6 +532,7 @@ func (pg *settingsPage) handle() {
 
 	select {
 	case err := <-pg.errorReceiver:
+		common.modalLoad.setLoading(false)
 		if err.Error() == dcrlibwallet.ErrInvalidPassphrase {
 			e := "Password is incorrect"
 			common.notify(e, false)

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -974,6 +974,7 @@ func (pg *walletPage) handle() {
 
 	select {
 	case err := <-pg.errorReceiver:
+		common.modalLoad.setLoading(false)
 		if err.Error() == dcrlibwallet.ErrInvalidPassphrase {
 			e := values.String(values.StrInvalidPassphrase)
 			common.notify(e, false)

--- a/ui/wallet_settings_page.go
+++ b/ui/wallet_settings_page.go
@@ -269,6 +269,7 @@ func (pg *walletSettingsPage) handle() {
 
 	select {
 	case err := <-pg.errorReceiver:
+		common.modalLoad.setLoading(false)
 		if err.Error() == dcrlibwallet.ErrInvalidPassphrase {
 			e := values.String(values.StrInvalidPassphrase)
 			common.notify(e, false)

--- a/wallet/commands.go
+++ b/wallet/commands.go
@@ -451,11 +451,7 @@ func (wal *Wallet) SignMessage(walletID int, passphrase []byte, address, message
 
 		wall := wal.multi.WalletWithID(walletID)
 		if wall == nil {
-			resp.Resp = &Signature{
-				Err: InternalWalletError{
-					Message: "No wallet found",
-				},
-			}
+			resp.Err = ErrIDNotExist
 			wal.Send <- resp
 			return
 		}
@@ -465,9 +461,6 @@ func (wal *Wallet) SignMessage(walletID int, passphrase []byte, address, message
 			go func() {
 				errChan <- err
 			}()
-			resp.Resp = &Signature{
-				Err: fmt.Errorf("error signing message: %s", err.Error()),
-			}
 			wal.Send <- resp
 			return
 		}

--- a/wallet/responses.go
+++ b/wallet/responses.go
@@ -157,7 +157,6 @@ type SyncStatus struct {
 // Signature is sent in response to Wallet.SignMessage
 type Signature struct {
 	Signature string
-	Err       error
 }
 
 // TxHash is sent when the Wallet successfully broadcasts a transaction


### PR DESCRIPTION
This pr fix #431
fix loader display bug on password modal when error occurs
* clean up sign message page code, prevent password
 modal from closing when there is a password error.