### PR TITLE
Top-level app.Window reference

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,13 +82,13 @@ func main() {
 
 	collection := fontCollection()
 
-	win, err := ui.CreateWindow(wal, decredIcons, collection, internalLog)
+	win, appWindow, err := ui.CreateWindow(wal, decredIcons, collection, internalLog)
 	if err != nil {
 		fmt.Printf("Could not initialize window: %s\ns", err)
 		return
 	}
 
 	// Start the ui frontend
-	go win.Loop(shutdown)
+	go win.Loop(appWindow, shutdown)
 	app.Main()
 }

--- a/ui/state.go
+++ b/ui/state.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"gioui.org/op"
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/wallet"
@@ -70,7 +71,7 @@ func (win *Window) updateStates(update interface{}) {
 		win.notifyOnSuccess("Wallet renamed")
 	case wallet.Restored:
 		win.states.creating = false
-		win.window.Invalidate()
+		op.InvalidateOp{}.Add(win.ops)
 	case wallet.DeletedWallet:
 		win.selected = 0
 		win.notifyOnSuccess("Wallet removed")
@@ -106,7 +107,7 @@ func (win *Window) updateStates(update interface{}) {
 	win.wallet.GetAllTransactions(0, 0, 0)
 	win.wallet.GetAllTickets()
 	win.wallet.GetAllProposals()
-	win.window.Invalidate()
+	op.InvalidateOp{}.Add(win.ops)
 	log.Debugf("Updated with multiwallet info: %+v\n and window state %+v", win.walletInfo, win.states)
 }
 


### PR DESCRIPTION
This pr fix #436
* remove *app.Window from window struct
* use op.InvalidateOp{}.Add(win.ops) instead of win.window.Invalidate()for app refresh