### PR TITLE
Add dcrlibwallet notification listeners to main page

### DIFF
--- a/.github/workflows/ginkgo.yml
+++ b/.github/workflows/ginkgo.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-on: [pull_request]
+on: []
 
 jobs:
   build:

--- a/main.go
+++ b/main.go
@@ -72,7 +72,6 @@ func main() {
 		return
 	}
 
-	wal.LoadWallets()
 	shutdown := make(chan int)
 	go func() {
 		<-shutdown

--- a/ui/listeners.go
+++ b/ui/listeners.go
@@ -5,8 +5,36 @@ import (
 	"github.com/planetdecred/godcr/wallet"
 )
 
+// Transaction notifications
+
+func (mp *mainPage) OnTransaction(transaction string) {
+	mp.updateBalance()
+
+	// beeep send notification
+}
+
+func (mp *mainPage) OnBlockAttached(walletID int, blockHeight int32) {
+	mp.updateBalance()
+}
+
+func (mp *mainPage) OnTransactionConfirmed(walletID int, hash string, blockHeight int32) {
+	mp.updateBalance()
+}
+
+// Account mixer
+func (mp *mainPage) OnAccountMixerStarted(walletID int) {}
+func (mp *mainPage) OnAccountMixerEnded(walletID int)   {}
+
+// Politeia notifications
+func (mp *mainPage) OnProposalsSynced()                            {}
+func (mp *mainPage) OnNewProposal(proposal *dcrlibwallet.Proposal) {}
+
+func (mp *mainPage) OnProposalVoteStarted(proposal *dcrlibwallet.Proposal)  {}
+func (mp *mainPage) OnProposalVoteFinished(proposal *dcrlibwallet.Proposal) {}
+
+// Sync notifications
+
 func (mp *mainPage) OnSyncStarted(wasRestarted bool) {
-	log.Info("Main page sync started")
 	mp.syncStatusUpdate <- wallet.SyncStatusUpdate{
 		Stage: wallet.SyncStarted,
 	}
@@ -52,6 +80,7 @@ func (mp *mainPage) OnHeadersRescanProgress(headersRescanProgress *dcrlibwallet.
 	}
 }
 func (mp *mainPage) OnSyncCompleted() {
+	mp.updateBalance()
 	mp.syncStatusUpdate <- wallet.SyncStatusUpdate{
 		Stage: wallet.SyncCompleted,
 	}

--- a/ui/main_page.go
+++ b/ui/main_page.go
@@ -11,12 +11,15 @@ import (
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/values"
+	"github.com/planetdecred/godcr/wallet"
 )
 
 const PageMain = "Main"
 
 type mainPage struct {
 	*pageCommon
+
+	syncStatusUpdate chan wallet.SyncStatusUpdate
 
 	modalMutex sync.Mutex
 	modals     []Modal
@@ -44,6 +47,8 @@ func newMainPage(common *pageCommon) *mainPage {
 	}
 
 	mp := &mainPage{
+		syncStatusUpdate: make(chan wallet.SyncStatusUpdate, 10),
+
 		pageCommon: common,
 		pages:      common.loadPages(),
 		current:    PageOverview,
@@ -64,7 +69,8 @@ func newMainPage(common *pageCommon) *mainPage {
 
 	mp.initNavItems()
 
-	mp.updateBalance()
+	mp.multiWallet.AddSyncProgressListener(mp, PageMain) // register for sync notifications
+	mp.updateBalance()                                   // update in onresume
 
 	return mp
 }

--- a/ui/page.go
+++ b/ui/page.go
@@ -105,6 +105,7 @@ type walletAccountSelector struct {
 
 type pageCommon struct {
 	printer            *message.Printer
+	multiWallet        *dcrlibwallet.MultiWallet
 	wallet             *wallet.Wallet
 	walletAccount      **wallet.Account
 	info               *wallet.MultiWalletInfo
@@ -232,6 +233,7 @@ func (win *Window) newPageCommon(decredIcons map[string]image.Image) *pageCommon
 
 	common := &pageCommon{
 		printer:            message.NewPrinter(language.English),
+		multiWallet:        win.wallet.GetMultiWallet(),
 		wallet:             win.wallet,
 		walletAccount:      &win.walletAccount,
 		info:               win.walletInfo,

--- a/ui/page.go
+++ b/ui/page.go
@@ -106,6 +106,7 @@ type walletAccountSelector struct {
 type pageCommon struct {
 	printer            *message.Printer
 	multiWallet        *dcrlibwallet.MultiWallet
+	syncStatusUpdate   chan wallet.SyncStatusUpdate
 	wallet             *wallet.Wallet
 	walletAccount      **wallet.Account
 	info               *wallet.MultiWalletInfo
@@ -234,6 +235,7 @@ func (win *Window) newPageCommon(decredIcons map[string]image.Image) *pageCommon
 	common := &pageCommon{
 		printer:            message.NewPrinter(language.English),
 		multiWallet:        win.wallet.GetMultiWallet(),
+		syncStatusUpdate:   make(chan wallet.SyncStatusUpdate, 10),
 		wallet:             win.wallet,
 		walletAccount:      &win.walletAccount,
 		info:               win.walletInfo,
@@ -268,6 +270,8 @@ func (win *Window) newPageCommon(decredIcons map[string]image.Image) *pageCommon
 	if common.fetchExchangeValue(&common.dcrUsdtBittrex) != nil {
 		log.Info("Error fetching exchange value")
 	}
+
+	common.refreshTheme()
 
 	return common
 }
@@ -342,6 +346,13 @@ func (common *pageCommon) loadPages() map[string]Page {
 	pages[PageTicketsActivity] = TicketActivityPage(common)
 
 	return pages
+}
+
+func (common *pageCommon) refreshTheme() {
+	isDarkModeOn := common.wallet.ReadBoolConfigValueForKey("isDarkModeOn")
+	if isDarkModeOn != common.theme.DarkMode {
+		common.theme.SwitchDarkMode(isDarkModeOn)
+	}
 }
 
 func (common *pageCommon) fetchExchangeValue(target interface{}) error {

--- a/ui/settings_page.go
+++ b/ui/settings_page.go
@@ -369,8 +369,8 @@ func (pg *settingsPage) handle() {
 	pg.currencyPreference.Handle()
 
 	if pg.isDarkModeOn.Changed() {
-		pg.theme.SwitchDarkMode(pg.isDarkModeOn.Value)
 		pg.wal.SaveConfigValueForKey("isDarkModeOn", pg.isDarkModeOn.Value)
+		common.refreshTheme()
 	}
 
 	if pg.spendUnconfirmed.Changed() {

--- a/ui/sync_listener.go
+++ b/ui/sync_listener.go
@@ -1,0 +1,66 @@
+package ui
+
+import (
+	"github.com/planetdecred/dcrlibwallet"
+	"github.com/planetdecred/godcr/wallet"
+)
+
+func (mp *mainPage) OnSyncStarted(wasRestarted bool) {
+	log.Info("Main page sync started")
+	mp.syncStatusUpdate <- wallet.SyncStatusUpdate{
+		Stage: wallet.SyncStarted,
+	}
+}
+
+func (mp *mainPage) OnPeerConnectedOrDisconnected(numberOfConnectedPeers int32) {
+	mp.syncStatusUpdate <- wallet.SyncStatusUpdate{
+		Stage:          wallet.PeersConnected,
+		ConnectedPeers: numberOfConnectedPeers,
+	}
+}
+
+func (mp *mainPage) OnCFiltersFetchProgress(cfiltersFetchProgress *dcrlibwallet.CFiltersFetchProgressReport) {
+	mp.syncStatusUpdate <- wallet.SyncStatusUpdate{
+		Stage:          wallet.CfiltersFetchProgress,
+		ProgressReport: cfiltersFetchProgress,
+	}
+}
+
+func (mp *mainPage) OnHeadersFetchProgress(headersFetchProgress *dcrlibwallet.HeadersFetchProgressReport) {
+	mp.syncStatusUpdate <- wallet.SyncStatusUpdate{
+		Stage: wallet.HeadersFetchProgress,
+		ProgressReport: wallet.SyncHeadersFetchProgress{
+			Progress: headersFetchProgress,
+		},
+	}
+}
+func (mp *mainPage) OnAddressDiscoveryProgress(addressDiscoveryProgress *dcrlibwallet.AddressDiscoveryProgressReport) {
+	mp.syncStatusUpdate <- wallet.SyncStatusUpdate{
+		Stage: wallet.AddressDiscoveryProgress,
+		ProgressReport: wallet.SyncAddressDiscoveryProgress{
+			Progress: addressDiscoveryProgress,
+		},
+	}
+}
+
+func (mp *mainPage) OnHeadersRescanProgress(headersRescanProgress *dcrlibwallet.HeadersRescanProgressReport) {
+	mp.syncStatusUpdate <- wallet.SyncStatusUpdate{
+		Stage: wallet.HeadersRescanProgress,
+		ProgressReport: wallet.SyncHeadersRescanProgress{
+			Progress: headersRescanProgress,
+		},
+	}
+}
+func (mp *mainPage) OnSyncCompleted() {
+	mp.syncStatusUpdate <- wallet.SyncStatusUpdate{
+		Stage: wallet.SyncCompleted,
+	}
+}
+
+func (mp *mainPage) OnSyncCanceled(willRestart bool) {
+	mp.syncStatusUpdate <- wallet.SyncStatusUpdate{
+		Stage: wallet.SyncCanceled,
+	}
+}
+func (mp *mainPage) OnSyncEndedWithError(err error)          {}
+func (mp *mainPage) Debug(debugInfo *dcrlibwallet.DebugInfo) {}

--- a/ui/window.go
+++ b/ui/window.go
@@ -94,7 +94,9 @@ func CreateWindow(wal *wallet.Wallet, decredIcons map[string]image.Image, collec
 	win.proposal = make(chan *wallet.Proposal)
 
 	win.wallet = wal
+	win.wallet.LoadWallets()
 	win.states.loading = true
+
 	win.keyEvents = make(chan *key.Event)
 
 	win.internalLog = internalLog

--- a/ui/window.go
+++ b/ui/window.go
@@ -210,6 +210,10 @@ func (win *Window) Loop(w *app.Window, shutdown chan int) {
 		case e := <-w.Events():
 			switch evt := e.(type) {
 			case system.DestroyEvent:
+
+				if win.currentPage != nil {
+					win.currentPage.onClose()
+				}
 				if win.walletInfo.Syncing || win.walletInfo.Synced {
 					win.sysDestroyWithSync = true
 					win.wallet.CancelSync()

--- a/wallet/listener.go
+++ b/wallet/listener.go
@@ -4,18 +4,21 @@ import (
 	"github.com/planetdecred/dcrlibwallet"
 )
 
-// SyncProgressStage represents the spv sync stage at which the multiwallet is currently
-type SyncProgressStage int
+// SyncNotificationType represents the spv sync stage at which the multiwallet is currently
+type SyncNotificationType int
 
 const (
 	// SyncStarted signifies that spv sync has started
-	SyncStarted SyncProgressStage = iota
+	SyncStarted SyncNotificationType = iota
 
 	// SyncCanceled is a pseudo stage that represents a canceled sync
 	SyncCanceled
 
 	// SyncCompleted signifies that spv sync has been completed
 	SyncCompleted
+
+	// CfiltersFetchProgress indicates a cfilters fetch signal
+	CfiltersFetchProgress
 
 	// HeadersFetchProgress indicates a headers fetch signal
 	HeadersFetchProgress
@@ -75,7 +78,7 @@ type (
 
 	// SyncStatusUpdate represents information about the status of the multiwallet spv sync
 	SyncStatusUpdate struct {
-		Stage          SyncProgressStage
+		Stage          SyncNotificationType
 		ProgressReport interface{}
 		ConnectedPeers int32
 		BlockInfo      NewBlock


### PR DESCRIPTION
Adding dcrlibwallet notification listeners to the main page will enable other pages(or modals) to optionally subscribe to the notification channel and listen for the notification types they want. This makes the pages less dependent on the global dcrlibwallet(commands.go) functions that deliver results through channels.