### PR TITLE
Fix display the account name in the Inputs and the Outputs of the transaction

### DIFF
--- a/wallet/commands.go
+++ b/wallet/commands.go
@@ -1448,3 +1448,16 @@ func (wal *Wallet) DataSize() string {
 	}
 	return fmt.Sprintf("%f GB", float64(v)*1e-9)
 }
+
+// GetAccountName returns the account name or 'external' if it does not belong to the wallet
+func (wal *Wallet) GetAccountName(walletID int, accountNumber int32) string {
+	wallet := wal.multi.WalletWithID(walletID)
+	if wallet == nil {
+		return "external"
+	}
+	account, err := wallet.GetAccount(accountNumber)
+	if err != nil {
+		return "external"
+	}
+	return account.Name
+}


### PR DESCRIPTION
The brackets () before the wallet name(Wallet-Main) should display the account name that owns the address or 'external' if the address does not belong to the wallet. But right now, it is empty as shown
![image](https://user-images.githubusercontent.com/33905113/122257290-14244800-cefa-11eb-8358-6d2077a5ca6d.png)

So this PR will display the account name or 'external' if the address does not belong to the wallet
![image](https://user-images.githubusercontent.com/33905113/122257704-74b38500-cefa-11eb-9a38-dae521145571.png)
