### PR TITLE
Fix account detail page handle for rename account modal

### DIFF
--- a/ui/account_details_page.go
+++ b/ui/account_details_page.go
@@ -246,7 +246,8 @@ func (pg *acctDetailsPage) pageSections(gtx layout.Context, body layout.Widget) 
 	return layout.Inset{Left: m, Right: m, Top: mtb, Bottom: mtb}.Layout(gtx, body)
 }
 
-func (pg *acctDetailsPage) Handler(gtx layout.Context, common *pageCommon) {
+func (pg *acctDetailsPage) handle() {
+	common := pg.common
 	if pg.backButton.Button.Clicked() {
 		common.changePage(PageWallet)
 	}
@@ -267,5 +268,4 @@ func (pg *acctDetailsPage) Handler(gtx layout.Context, common *pageCommon) {
 	}
 }
 
-func (pg *acctDetailsPage) handle()  {}
 func (pg *acctDetailsPage) onClose() {}


### PR DESCRIPTION
Resolve #447 

This PR fix bug when the edit icon the wallet account details page is clicked, the app crash.