### PR TITLE
Use dcrlibwallet directly in overview and transactions page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,7 @@ require (
 	golang.org/x/text v0.3.3
 )
 
-replace github.com/decred/dcrdata/txhelpers/v4 => github.com/decred/dcrdata/txhelpers/v4 v4.0.0-20200108145420-f82113e7e212
+replace (
+	github.com/decred/dcrdata/txhelpers/v4 => github.com/decred/dcrdata/txhelpers/v4 v4.0.0-20200108145420-f82113e7e212
+	github.com/planetdecred/dcrlibwallet => github.com/planetdecred/dcrlibwallet v1.6.1-0.20210618124747-f776ef63322f
+)

--- a/go.sum
+++ b/go.sum
@@ -711,6 +711,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/planetdecred/dcrlibwallet v1.6.0 h1:Bn5es2IKoQkXSYSg1cD2h2Z3ndWkf7IiaU7aTqtvOcU=
 github.com/planetdecred/dcrlibwallet v1.6.0/go.mod h1:gM1g2wCXwmLxICoV26M3rtCiyat7/YiIok+C2apx3pY=
+github.com/planetdecred/dcrlibwallet v1.6.1-0.20210618124747-f776ef63322f h1:lgVy3wX3Y6dkEFZ4YjVyibegW/B7Rnn0W4m8lpTsOkA=
+github.com/planetdecred/dcrlibwallet v1.6.1-0.20210618124747-f776ef63322f/go.mod h1:gM1g2wCXwmLxICoV26M3rtCiyat7/YiIok+C2apx3pY=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/ui/about_page.go
+++ b/ui/about_page.go
@@ -51,6 +51,10 @@ func AboutPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *aboutPage) OnResume() {
+
+}
+
 func (pg *aboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	body := func(gtx C) D {
 		page := SubPage{

--- a/ui/account_details_page.go
+++ b/ui/account_details_page.go
@@ -47,6 +47,10 @@ func AcctDetailsPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *acctDetailsPage) OnResume() {
+
+}
+
 func (pg *acctDetailsPage) Layout(gtx layout.Context) layout.Dimensions {
 	common := pg.common
 

--- a/ui/components.go
+++ b/ui/components.go
@@ -975,9 +975,9 @@ func (page *pageCommon) handleToast() {
 
 // createOrUpdateWalletDropDown check for len of wallets to create dropDown,
 // also update the list when create, update, delete a wallet.
-func (page *pageCommon) createOrUpdateWalletDropDown(dwn **decredmaterial.DropDown) {
+func (page *pageCommon) createOrUpdateWalletDropDown(dwn **decredmaterial.DropDown, wallets []*dcrlibwallet.Wallet) {
 	var walletDropDownItems []decredmaterial.DropDownItem
-	for _, wal := range page.multiWallet.AllWallets() {
+	for _, wal := range wallets {
 		item := decredmaterial.DropDownItem{
 			Text: wal.Name,
 			Icon: page.icons.walletIcon,

--- a/ui/components.go
+++ b/ui/components.go
@@ -30,7 +30,7 @@ const (
 
 type (
 	TransactionRow struct {
-		transaction wallet.Transaction
+		transaction dcrlibwallet.Transaction
 		index       int
 		showBadge   bool
 	}
@@ -82,11 +82,13 @@ func transactionRow(gtx layout.Context, common *pageCommon, row TransactionRow) 
 		directionIconTopMargin = values.MarginPadding0
 	}
 
+	wal := common.multiWallet.WalletWithID(row.transaction.WalletID)
+
 	return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
 				icon := common.icons.receiveIcon
-				if row.transaction.Txn.Direction == dcrlibwallet.TxDirectionSent {
+				if row.transaction.Direction == dcrlibwallet.TxDirectionSent {
 					icon = common.icons.sendIcon
 				}
 				icon.Scale = 1.0
@@ -128,11 +130,11 @@ func transactionRow(gtx layout.Context, common *pageCommon, row TransactionRow) 
 									return layout.Inset{Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
 										return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 											layout.Rigid(func(gtx C) D {
-												return common.layoutBalance(gtx, row.transaction.Balance, true)
+												return common.layoutBalance(gtx, dcrutil.Amount(row.transaction.Amount).String(), true)
 											}),
 											layout.Rigid(func(gtx C) D {
 												if row.showBadge {
-													return walletLabel(gtx, common, row.transaction.WalletName)
+													return walletLabel(gtx, common, wal.Name)
 												}
 												return layout.Dimensions{}
 											}),
@@ -144,15 +146,12 @@ func transactionRow(gtx layout.Context, common *pageCommon, row TransactionRow) 
 										layout.Rigid(func(gtx C) D {
 											return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
 												func(gtx C) D {
-													s := formatDateOrTime(row.transaction.Txn.Timestamp)
-													if row.transaction.Status != "confirmed" {
-														s = row.transaction.Status
-													}
-													status := common.theme.Body1(s)
-													if row.transaction.Status != "confirmed" {
+													status := common.theme.Body1("pending")
+													if txConfirmations(common, row.transaction) <= 1 {
 														status.Color = common.theme.Color.Gray5
 													} else {
 														status.Color = common.theme.Color.Gray4
+														status.Text = formatDateOrTime(row.transaction.Timestamp)
 													}
 													status.Alignment = text.Middle
 													return status.Layout(gtx)
@@ -161,7 +160,7 @@ func transactionRow(gtx layout.Context, common *pageCommon, row TransactionRow) 
 										layout.Rigid(func(gtx C) D {
 											return layout.Inset{Right: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
 												statusIcon := common.icons.confirmIcon
-												if row.transaction.Status != "confirmed" {
+												if txConfirmations(common, row.transaction) <= 1 {
 													statusIcon = common.icons.pendingIcon
 												}
 												statusIcon.Scale = 1.0
@@ -177,6 +176,15 @@ func transactionRow(gtx layout.Context, common *pageCommon, row TransactionRow) 
 			}),
 		)
 	})
+}
+
+func txConfirmations(common *pageCommon, transaction dcrlibwallet.Transaction) int32 {
+	if transaction.BlockHeight != -1 {
+		// TODO
+		return (common.multiWallet.WalletWithID(transaction.WalletID).GetBestBlock() - transaction.BlockHeight) + 1
+	}
+
+	return 0
 }
 
 // walletLabel displays the wallet which a transaction belongs to. It is only displayed on the overview page when there

--- a/ui/components.go
+++ b/ui/components.go
@@ -976,25 +976,15 @@ func (page *pageCommon) handleToast() {
 // createOrUpdateWalletDropDown check for len of wallets to create dropDown,
 // also update the list when create, update, delete a wallet.
 func (page *pageCommon) createOrUpdateWalletDropDown(dwn **decredmaterial.DropDown) {
-	init := func() {
-		var walletDropDownItems []decredmaterial.DropDownItem
-		for i := range page.info.Wallets {
-			item := decredmaterial.DropDownItem{
-				Text: page.info.Wallets[i].Name,
-				Icon: page.icons.walletIcon,
-			}
-			walletDropDownItems = append(walletDropDownItems, item)
+	var walletDropDownItems []decredmaterial.DropDownItem
+	for _, wal := range page.multiWallet.AllWallets() {
+		item := decredmaterial.DropDownItem{
+			Text: wal.Name,
+			Icon: page.icons.walletIcon,
 		}
-		*dwn = page.theme.DropDown(walletDropDownItems, 2)
+		walletDropDownItems = append(walletDropDownItems, item)
 	}
-
-	if *dwn == nil && len(page.info.Wallets) > 0 {
-		init()
-		return
-	}
-	if (*dwn).Len() != len(page.info.Wallets) {
-		init()
-	}
+	*dwn = page.theme.DropDown(walletDropDownItems, 2)
 }
 
 func createOrderDropDown(c *pageCommon) *decredmaterial.DropDown {

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -150,6 +150,10 @@ func CreateRestorePage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *createRestore) OnResume() {
+
+}
+
 func (pg *createRestore) Layout(gtx layout.Context) layout.Dimensions {
 	pd := values.MarginPadding15
 	dims := layout.Flex{Axis: layout.Vertical, Spacing: layout.SpaceBetween}.Layout(gtx,

--- a/ui/debug_page.go
+++ b/ui/debug_page.go
@@ -45,6 +45,10 @@ func DebugPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *debugPage) OnResume() {
+
+}
+
 func (pg *debugPage) handle() {
 	for i := range pg.debugItems {
 		for pg.debugItems[i].clickable.Clicked() {

--- a/ui/decredmaterial/dropdown.go
+++ b/ui/decredmaterial/dropdown.go
@@ -105,6 +105,9 @@ func (c *DropDown) Changed() bool {
 		if index != 0 {
 			for c.items[index].button.Button.Clicked() {
 				if c.items[0].label.Text != c.items[index].Text {
+					c.selectedIndex = index
+					c.items[0].label.Text = c.items[index].Text
+					c.isOpen = false
 					return true
 				}
 			}

--- a/ui/help_page.go
+++ b/ui/help_page.go
@@ -28,6 +28,10 @@ func HelpPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *helpPage) OnResume() {
+
+}
+
 // main settings layout
 func (pg *helpPage) Layout(gtx layout.Context) layout.Dimensions {
 	body := func(gtx C) D {

--- a/ui/log_page.go
+++ b/ui/log_page.go
@@ -46,6 +46,10 @@ func LogPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *logPage) OnResume() {
+
+}
+
 func (pg *logPage) copyLogEntries(gtx C) {
 	go func() {
 		pg.entriesLock.Lock()

--- a/ui/main_page.go
+++ b/ui/main_page.go
@@ -41,7 +41,6 @@ func newMainPage(common *pageCommon) *mainPage {
 		pageCommon: common,
 		autoSync:   true,
 		pages:      common.loadPages(),
-		current:    PageOverview,
 
 		minimizeNavDrawerButton: common.theme.PlainIconButton(new(widget.Clickable), common.icons.navigationArrowBack),
 		maximizeNavDrawerButton: common.theme.PlainIconButton(new(widget.Clickable), common.icons.navigationArrowForward),
@@ -133,6 +132,8 @@ func (mp *mainPage) OnResume() {
 	mp.multiWallet.AddSyncProgressListener(mp, PageMain)
 
 	mp.updateBalance()
+
+	mp.changeFragment(OverviewPage(mp.pageCommon), PageOverview)
 
 	if mp.autoSync {
 		mp.autoSync = false
@@ -239,12 +240,13 @@ func (mp *mainPage) handle() {
 
 	for i := range mp.drawerNavItems {
 		for mp.drawerNavItems[i].clickable.Clicked() {
-			if i == 1 { // transactions page
+			if i == 0 {
+				mp.changeFragment(OverviewPage(mp.pageCommon), PageOverview)
+			} else if i == 1 {
 				mp.changeFragment(TransactionsPage(mp.pageCommon), PageTransactions)
 			} else {
 				mp.changePage(mp.drawerNavItems[i].page)
 			}
-
 		}
 	}
 }
@@ -261,7 +263,9 @@ func (mp *mainPage) changeFragment(page Page, id string) {
 }
 
 func (mp *mainPage) changePage(page string) {
-	mp.pages[mp.current].onClose()
+	if pg, ok := mp.pages[mp.current]; ok {
+		pg.onClose()
+	}
 	mp.current = page
 }
 

--- a/ui/main_page.go
+++ b/ui/main_page.go
@@ -252,6 +252,9 @@ func (mp *mainPage) handle() {
 }
 
 func (mp *mainPage) onClose() {
+	if pg, ok := mp.pages[mp.current]; ok {
+		pg.onClose()
+	}
 	mp.multiWallet.Politeia.RemoveNotificationListener(PageMain)
 	mp.multiWallet.RemoveTxAndBlockNotificationListener(PageMain)
 	mp.multiWallet.RemoveSyncProgressListener(PageMain)
@@ -266,7 +269,11 @@ func (mp *mainPage) changePage(page string) {
 	if pg, ok := mp.pages[mp.current]; ok {
 		pg.onClose()
 	}
-	mp.current = page
+
+	if pg, ok := mp.pages[page]; ok {
+		pg.OnResume()
+		mp.current = page
+	}
 }
 
 func (mp *mainPage) setReturnPage(from string) {

--- a/ui/main_page.go
+++ b/ui/main_page.go
@@ -194,7 +194,7 @@ func (mp *mainPage) startSyncing() {
 func (mp *mainPage) unlockWalletForSyncing(wal *dcrlibwallet.Wallet) {
 	newPasswordModal(mp.pageCommon).
 		title(values.String(values.StrResumeAccountDiscoveryTitle)).
-		hint("Spending password").
+		hint(wal.Name+" Spending password").
 		negativeButton(values.String(values.StrCancel), func() {}).
 		positiveButton(values.String(values.StrUnlock), func(password string, pm *passwordModal) bool {
 			go func() {

--- a/ui/main_page.go
+++ b/ui/main_page.go
@@ -239,7 +239,12 @@ func (mp *mainPage) handle() {
 
 	for i := range mp.drawerNavItems {
 		for mp.drawerNavItems[i].clickable.Clicked() {
-			mp.changePage(mp.drawerNavItems[i].page)
+			if i == 1 { // transactions page
+				mp.changeFragment(TransactionsPage(mp.pageCommon), PageTransactions)
+			} else {
+				mp.changePage(mp.drawerNavItems[i].page)
+			}
+
 		}
 	}
 }

--- a/ui/main_page.go
+++ b/ui/main_page.go
@@ -126,7 +126,7 @@ func (mp *mainPage) initNavItems() {
 
 func (mp *mainPage) OnResume() {
 	// register for notifications
-	mp.multiWallet.SetAccountMixerNotification(mp)
+	mp.multiWallet.AddAccountMixerNotificationListener(mp, PageMain)
 	mp.multiWallet.Politeia.AddNotificationListener(mp, PageMain)
 	mp.multiWallet.AddTxAndBlockNotificationListener(mp, PageMain)
 	mp.multiWallet.AddSyncProgressListener(mp, PageMain)
@@ -255,6 +255,7 @@ func (mp *mainPage) onClose() {
 	if pg, ok := mp.pages[mp.current]; ok {
 		pg.onClose()
 	}
+	mp.multiWallet.RemoveAccountMixerNotificationListener(PageMain)
 	mp.multiWallet.Politeia.RemoveNotificationListener(PageMain)
 	mp.multiWallet.RemoveTxAndBlockNotificationListener(PageMain)
 	mp.multiWallet.RemoveSyncProgressListener(PageMain)

--- a/ui/main_page.go
+++ b/ui/main_page.go
@@ -48,6 +48,7 @@ func newMainPage(common *pageCommon) *mainPage {
 	}
 
 	// init shared page functions
+	common.changeFragment = mp.changeFragment
 	common.changePage = mp.changePage
 	common.setReturnPage = mp.setReturnPage
 	common.returnPage = &mp.previous
@@ -247,6 +248,11 @@ func (mp *mainPage) onClose() {
 	mp.multiWallet.Politeia.RemoveNotificationListener(PageMain)
 	mp.multiWallet.RemoveTxAndBlockNotificationListener(PageMain)
 	mp.multiWallet.RemoveSyncProgressListener(PageMain)
+}
+
+func (mp *mainPage) changeFragment(page Page, id string) {
+	mp.pages[id] = page
+	mp.changePage(id)
 }
 
 func (mp *mainPage) changePage(page string) {

--- a/ui/more_page.go
+++ b/ui/more_page.go
@@ -64,6 +64,10 @@ func MorePage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *morePage) OnResume() {
+
+}
+
 func (pg *morePage) handleClickEvents(common *pageCommon) {
 	for i := range pg.morePageListItems {
 		for pg.morePageListItems[i].clickable.Clicked() {

--- a/ui/overview_page.go
+++ b/ui/overview_page.go
@@ -37,9 +37,8 @@ type overviewPage struct {
 	theme *decredmaterial.Theme
 	tab   *decredmaterial.Tabs
 
-	allWallets        []*dcrlibwallet.Wallet
-	transactions      []dcrlibwallet.Transaction
-	walletTransaction **dcrlibwallet.Transaction
+	allWallets   []*dcrlibwallet.Wallet
+	transactions []dcrlibwallet.Transaction
 
 	toTransactions    decredmaterial.TextAndIconButton
 	sync              decredmaterial.Button
@@ -75,8 +74,7 @@ func OverviewPage(c *pageCommon) Page {
 		theme:      c.theme,
 		tab:        c.navTab,
 
-		allWallets:        c.multiWallet.AllWallets(),
-		walletTransaction: c.walletTransaction,
+		allWallets: c.multiWallet.AllWallets(),
 
 		listContainer:    &layout.List{Axis: layout.Vertical},
 		walletSyncList:   &layout.List{Axis: layout.Vertical},

--- a/ui/overview_page.go
+++ b/ui/overview_page.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"encoding/json"
 	"fmt"
 	"image"
 	"image/color"
@@ -117,39 +116,24 @@ func OverviewPage(c *pageCommon) Page {
 	pg.walletStatusIcon = c.icons.imageBrightness1
 	pg.cachedIcon = c.icons.cached
 
-	pg.listenForSyncNotifications()
-	pg.loadTransactions()
+	return pg
+}
 
+func (pg *overviewPage) OnResume() {
 	pg.walletSyncing = pg.multiWallet.IsSyncing()
 	pg.walletSynced = pg.multiWallet.IsSynced()
 	pg.isConnnected = pg.multiWallet.IsConnectedToDecredNetwork()
 	pg.connectedPeers = pg.multiWallet.ConnectedPeers()
 	pg.bestBlock = pg.multiWallet.GetBestBlock()
 
-	if pg.isConnnected {
-		pg.sync.Text = values.String(values.StrDisconnect)
-	} else {
-		pg.sync.Text = values.String(values.StrReconnect)
-	}
-
-	return pg
-}
-
-func (pg *overviewPage) OnResume() {
-
+	pg.loadTransactions()
+	pg.listenForSyncNotifications()
 }
 
 func (pg *overviewPage) loadTransactions() {
-	transactionsJSON, err := pg.multiWallet.GetTransactions(0, 5, dcrlibwallet.TxFilterAll, true)
+	transactions, err := pg.multiWallet.GetTransactionsRaw(0, 5, dcrlibwallet.TxFilterAll, true)
 	if err != nil {
 		log.Error("Error getting transactions:", err)
-		return
-	}
-
-	var transactions []dcrlibwallet.Transaction
-	err = json.Unmarshal([]byte(transactionsJSON), &transactions)
-	if err != nil {
-		log.Error("Error decoding transactions:", err)
 		return
 	}
 

--- a/ui/overview_page.go
+++ b/ui/overview_page.go
@@ -135,6 +135,10 @@ func OverviewPage(c *pageCommon) Page {
 	return pg
 }
 
+func (pg *overviewPage) OnResume() {
+
+}
+
 func (pg *overviewPage) loadTransactions() {
 	transactionsJSON, err := pg.multiWallet.GetTransactions(0, 5, dcrlibwallet.TxFilterAll, true)
 	if err != nil {

--- a/ui/overview_page.go
+++ b/ui/overview_page.go
@@ -667,6 +667,7 @@ func (pg *overviewPage) listenForSyncNotifications() {
 				case wallet.SyncCanceled:
 					fallthrough
 				case wallet.SyncCompleted:
+					pg.loadTransactions()
 					pg.walletSyncing = pg.multiWallet.IsSyncing()
 					pg.walletSynced = pg.multiWallet.IsSynced()
 					pg.isConnnected = pg.multiWallet.IsConnectedToDecredNetwork()

--- a/ui/overview_page.go
+++ b/ui/overview_page.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 	"image"
 	"image/color"
+	"time"
 
 	"gioui.org/gesture"
 	"gioui.org/io/event"
 	"gioui.org/io/pointer"
 	"gioui.org/layout"
 	"gioui.org/widget"
-	"github.com/planetdecred/dcrlibwallet"
 
+	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/values"
 	"github.com/planetdecred/godcr/wallet"
@@ -29,15 +30,14 @@ type walletSyncDetails struct {
 }
 
 type overviewPage struct {
-	common *pageCommon
+	*pageCommon
 	listContainer, walletSyncList,
 	transactionsList *layout.List
 	theme *decredmaterial.Theme
 	tab   *decredmaterial.Tabs
 
+	allWallets         []*dcrlibwallet.Wallet
 	wallet             **wallet.Wallet
-	walletInfo         *wallet.MultiWalletInfo
-	walletSyncStatus   *wallet.SyncStatus
 	walletTransactions **wallet.Transactions
 	walletTransaction  **wallet.Transaction
 	toTransactions     decredmaterial.TextAndIconButton
@@ -48,12 +48,21 @@ type overviewPage struct {
 	syncingIcon          *widget.Image
 	toTransactionDetails []*gesture.Click
 
-	autoSyncWallet bool
+	walletSyncing bool
+	walletSynced  bool
+	isConnnected  bool
+
+	bestBlock            *dcrlibwallet.BlockInfo
+	connectedPeers       int32
+	remainingSyncTime    string
+	headersToFetchOrScan int32
+	headerFetchProgress  int32
+	syncProgress         int
+	syncStep             int
 
 	syncButtonHeight      int
 	moreButtonWidth       int
 	moreButtonHeight      int
-	isCheckingLockWL      bool
 	syncDetailsVisibility bool
 	txnRowHeight          int
 	queue                 event.Queue
@@ -61,26 +70,24 @@ type overviewPage struct {
 
 func OverviewPage(c *pageCommon) Page {
 	pg := &overviewPage{
-		theme:  c.theme,
-		common: c,
-		tab:    c.navTab,
+		pageCommon: c,
+		theme:      c.theme,
+		tab:        c.navTab,
 
+		allWallets:         c.multiWallet.AllWallets(),
 		wallet:             &c.wallet,
-		walletInfo:         c.info,
-		walletSyncStatus:   c.walletSyncStatus,
 		walletTransactions: c.walletTransactions,
 		walletTransaction:  c.walletTransaction,
 		listContainer:      &layout.List{Axis: layout.Vertical},
 		walletSyncList:     &layout.List{Axis: layout.Vertical},
 		transactionsList:   &layout.List{Axis: layout.Vertical},
 
+		bestBlock: c.multiWallet.GetBestBlock(),
+
 		syncButtonHeight: 50,
 		moreButtonWidth:  115,
 		moreButtonHeight: 70,
 		txnRowHeight:     56,
-
-		isCheckingLockWL: false,
-		autoSyncWallet:   true,
 	}
 
 	pg.toTransactions = c.theme.TextAndIconButton(new(widget.Clickable), values.String(values.StrSeeAll), c.icons.navigationArrowForward)
@@ -110,13 +117,14 @@ func OverviewPage(c *pageCommon) Page {
 	pg.walletStatusIcon = c.icons.imageBrightness1
 	pg.cachedIcon = c.icons.cached
 
+	pg.listenForSyncNotifications()
 	return pg
 }
 
 // Layout lays out the entire content for overview pg.
 func (pg *overviewPage) Layout(gtx layout.Context) layout.Dimensions {
 	pg.queue = gtx
-	c := pg.common
+	c := pg.pageCommon
 	if c.info.LoadedWallets == 0 {
 		return c.UniformPadding(gtx, func(gtx C) D {
 			return layout.Center.Layout(gtx, func(gtx C) D {
@@ -230,19 +238,19 @@ func (pg *overviewPage) syncStatusSection(gtx layout.Context) layout.Dimensions 
 										return pg.syncStatusTextRow(gtx, uniform)
 									}),
 									layout.Rigid(func(gtx C) D {
-										if !pg.walletInfo.Syncing {
+										if !pg.walletSyncing {
 											return pg.syncDormantContent(gtx, uniform)
 										}
 										return layout.Dimensions{}
 									}),
 									layout.Rigid(func(gtx C) D {
-										if pg.walletInfo.Syncing {
+										if pg.walletSyncing {
 											return pg.progressBarRow(gtx, uniform)
 										}
 										return layout.Dimensions{}
 									}),
 									layout.Rigid(func(gtx C) D {
-										if pg.walletInfo.Syncing {
+										if pg.walletSyncing {
 											return pg.progressStatusRow(gtx, uniform)
 										}
 										return layout.Dimensions{}
@@ -253,13 +261,13 @@ func (pg *overviewPage) syncStatusSection(gtx layout.Context) layout.Dimensions 
 					})
 				}),
 				layout.Rigid(func(gtx C) D {
-					if pg.walletInfo.Syncing {
+					if pg.walletSyncing {
 						return pg.theme.Separator().Layout(gtx)
 					}
 					return layout.Dimensions{}
 				}),
 				layout.Rigid(func(gtx C) D {
-					if pg.walletInfo.Syncing && pg.syncDetailsVisibility {
+					if pg.walletSyncing && pg.syncDetailsVisibility {
 						return Container{layout.UniformInset(values.MarginPadding16)}.Layout(gtx, func(gtx C) D {
 							return pg.walletSyncRow(gtx, uniform)
 						})
@@ -267,13 +275,13 @@ func (pg *overviewPage) syncStatusSection(gtx layout.Context) layout.Dimensions 
 					return layout.Dimensions{}
 				}),
 				layout.Rigid(func(gtx C) D {
-					if pg.walletInfo.Syncing && pg.syncDetailsVisibility {
+					if pg.walletSyncing && pg.syncDetailsVisibility {
 						return pg.theme.Separator().Layout(gtx)
 					}
 					return layout.Dimensions{}
 				}),
 				layout.Rigid(func(gtx C) D {
-					if pg.walletInfo.Syncing {
+					if pg.walletSyncing {
 						gtx.Constraints.Min.X = gtx.Constraints.Max.X
 						return layout.Inset{Top: values.MarginPadding14}.Layout(gtx, func(gtx C) D {
 							return pg.toggleSyncDetails.Layout(gtx)
@@ -313,7 +321,7 @@ func (pg *overviewPage) syncDormantContent(gtx layout.Context, uniform layout.In
 				return layout.Inset{Bottom: values.MarginPadding12}.Layout(gtx, pg.blockInfoRow)
 			}),
 			layout.Rigid(func(gtx C) D {
-				if pg.walletInfo.Synced {
+				if pg.walletSynced {
 					return pg.connectionPeer(gtx)
 				}
 				latestBlockTitleLabel := pg.theme.Body1(values.String(values.StrNoConnectedPeer))
@@ -335,7 +343,7 @@ func (pg *overviewPage) blockInfoRow(gtx layout.Context) layout.Dimensions {
 			return layout.Inset{
 				Left:  values.MarginPadding5,
 				Right: values.MarginPadding5,
-			}.Layout(gtx, pg.theme.Body1(fmt.Sprintf("%v", pg.walletInfo.BestBlockHeight)).Layout)
+			}.Layout(gtx, pg.theme.Body1(fmt.Sprintf("%d", pg.bestBlock.Height)).Layout)
 		}),
 		layout.Rigid(func(gtx C) D {
 			pg.walletStatusIcon.Color = pg.theme.Color.Gray
@@ -344,7 +352,7 @@ func (pg *overviewPage) blockInfoRow(gtx layout.Context) layout.Dimensions {
 			})
 		}),
 		layout.Rigid(func(gtx C) D {
-			return layout.Inset{Right: values.MarginPadding5}.Layout(gtx, pg.theme.Body1(fmt.Sprintf("%v", pg.walletInfo.LastSyncTime)).Layout)
+			return layout.Inset{Right: values.MarginPadding5}.Layout(gtx, pg.theme.Body1(wallet.SecondsToDays(pg.bestBlock.Timestamp)).Layout)
 		}),
 		layout.Rigid(func(gtx C) D {
 			lastSyncedLabel := pg.theme.Body1(values.String(values.StrAgo))
@@ -362,7 +370,7 @@ func (pg *overviewPage) connectionPeer(gtx layout.Context) layout.Dimensions {
 			return connectedPeersInfoLabel.Layout(gtx)
 		}),
 		layout.Rigid(func(gtx C) D {
-			return layout.Inset{Left: values.MarginPadding5, Right: values.MarginPadding5}.Layout(gtx, pg.theme.Body1(fmt.Sprintf("%d", pg.walletSyncStatus.ConnectedPeers)).Layout)
+			return layout.Inset{Left: values.MarginPadding5, Right: values.MarginPadding5}.Layout(gtx, pg.theme.Body1(fmt.Sprintf("%d", pg.connectedPeers)).Layout)
 		}),
 		layout.Rigid(func(gtx C) D {
 			peersLabel := pg.theme.Body1("peers")
@@ -378,7 +386,7 @@ func (pg *overviewPage) syncBoxTitleRow(gtx layout.Context) layout.Dimensions {
 	title.Color = pg.theme.Color.Gray3
 	statusLabel := pg.theme.Body1(values.String(values.StrOffline))
 	pg.walletStatusIcon.Color = pg.theme.Color.Danger
-	if pg.walletInfo.Synced || pg.walletInfo.Syncing {
+	if pg.isConnnected {
 		statusLabel.Text = values.String(values.StrOnline)
 		pg.walletStatusIcon.Color = pg.theme.Color.Success
 	}
@@ -401,9 +409,9 @@ func (pg *overviewPage) syncBoxTitleRow(gtx layout.Context) layout.Dimensions {
 // syncStatusTextRow lays out sync status text and sync button.
 func (pg *overviewPage) syncStatusTextRow(gtx layout.Context, inset layout.Inset) layout.Dimensions {
 	syncStatusLabel := pg.theme.H6(values.String(values.StrWalletNotSynced))
-	if pg.walletInfo.Syncing {
+	if pg.walletSyncing {
 		syncStatusLabel.Text = values.String(values.StrSyncingState)
-	} else if pg.walletInfo.Synced {
+	} else if pg.walletSynced {
 		syncStatusLabel.Text = values.String(values.StrSynced)
 	}
 
@@ -442,11 +450,11 @@ func (pg *overviewPage) syncStatusTextRow(gtx layout.Context, inset layout.Inset
 
 func (pg *overviewPage) syncStatusIcon(gtx layout.Context) layout.Dimensions {
 	syncStatusIcon := pg.notSyncedIcon
-	if pg.walletInfo.Synced {
+	if pg.walletSynced {
 		syncStatusIcon = pg.syncedIcon
 	}
 	i := layout.Inset{Right: values.MarginPadding16, Top: values.MarginPadding9}
-	if pg.walletInfo.Syncing {
+	if pg.walletSyncing {
 		return i.Layout(gtx, pg.syncingIcon.Layout)
 	}
 	return i.Layout(gtx, func(gtx C) D {
@@ -457,8 +465,7 @@ func (pg *overviewPage) syncStatusIcon(gtx layout.Context) layout.Dimensions {
 // progressBarRow lays out the progress bar.
 func (pg *overviewPage) progressBarRow(gtx layout.Context, inset layout.Inset) layout.Dimensions {
 	return inset.Layout(gtx, func(gtx C) D {
-		progress := pg.walletSyncStatus.Progress
-		p := pg.theme.ProgressBar(int(progress))
+		p := pg.theme.ProgressBar(pg.syncProgress)
 		p.Height = values.MarginPadding8
 		p.Radius = values.MarginPadding4
 		p.Color = pg.theme.Color.Success
@@ -468,12 +475,12 @@ func (pg *overviewPage) progressBarRow(gtx layout.Context, inset layout.Inset) l
 
 // progressStatusRow lays out the progress status when the wallet is syncing.
 func (pg *overviewPage) progressStatusRow(gtx layout.Context, inset layout.Inset) layout.Dimensions {
-	timeLeft := pg.walletSyncStatus.RemainingTime
+	timeLeft := pg.remainingSyncTime
 	if timeLeft == "" {
 		timeLeft = "0s"
 	}
 
-	percentageLabel := pg.theme.Body1(fmt.Sprintf("%v%%", pg.walletSyncStatus.Progress))
+	percentageLabel := pg.theme.Body1(fmt.Sprintf("%v%%", pg.syncProgress))
 	timeLeftLabel := pg.theme.Body1(fmt.Sprintf("%v Left", timeLeft))
 	return inset.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 		return endToEndRow(gtx, percentageLabel.Layout, timeLeftLabel.Layout)
@@ -486,9 +493,9 @@ func (pg *overviewPage) walletSyncRow(gtx layout.Context, inset layout.Inset) la
 	return layout.Inset{Top: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
-				completedSteps := pg.theme.Body2(values.StringF(values.StrSyncSteps, pg.walletSyncStatus.Steps))
+				completedSteps := pg.theme.Body2(values.StringF(values.StrSyncSteps, pg.syncStep))
 				completedSteps.Color = pg.theme.Color.Gray
-				headersFetched := pg.theme.Body1(values.StringF(values.StrFetchingBlockHeaders, pg.walletSyncStatus.HeadersFetchProgress))
+				headersFetched := pg.theme.Body1(values.StringF(values.StrFetchingBlockHeaders, pg.headerFetchProgress))
 				return inset.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 					return endToEndRow(gtx, completedSteps.Layout, headersFetched.Layout)
 				})
@@ -496,26 +503,26 @@ func (pg *overviewPage) walletSyncRow(gtx layout.Context, inset layout.Inset) la
 			layout.Rigid(func(gtx C) D {
 				connectedPeersTitleLabel := pg.theme.Body2(values.String(values.StrConnectedPeersCount))
 				connectedPeersTitleLabel.Color = pg.theme.Color.Gray
-				connectedPeersLabel := pg.theme.Body1(fmt.Sprintf("%d", pg.walletSyncStatus.ConnectedPeers))
+				connectedPeersLabel := pg.theme.Body1(fmt.Sprintf("%d", pg.connectedPeers))
 				return inset.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 					return endToEndRow(gtx, connectedPeersTitleLabel.Layout, connectedPeersLabel.Layout)
 				})
 			}),
 			layout.Rigid(func(gtx C) D {
-				var overallBlockHeight int32
 				var walletSyncBoxes []layout.Widget
 
-				if pg.walletSyncStatus != nil {
-					overallBlockHeight = pg.walletSyncStatus.HeadersToFetch
-				}
+				currentSeconds := time.Now().UnixNano() / int64(time.Second)
+				for i := 0; i < len(pg.allWallets); i++ {
+					w := pg.allWallets[i]
 
-				for i := 0; i < len(pg.walletInfo.Wallets); i++ {
-					w := pg.walletInfo.Wallets[i]
-					if w.BestBlockHeight > overallBlockHeight {
-						overallBlockHeight = w.BestBlockHeight
+					status := "syncing..."
+					if w.IsWaiting() {
+						status = "waiting..."
 					}
-					blockHeightProgress := values.StringF(values.StrBlockHeaderFetchedCount, w.BestBlockHeight, overallBlockHeight)
-					details := pg.syncDetail(w.Name, w.Status, blockHeightProgress, w.DaysBehind)
+
+					blockHeightProgress := values.StringF(values.StrBlockHeaderFetchedCount, w.GetBestBlock(), pg.headersToFetchOrScan)
+					daysBehind := wallet.SecondsToDays(currentSeconds - w.GetBestBlockTimeStamp())
+					details := pg.syncDetail(w.Name, status, blockHeightProgress, daysBehind)
 					uniform := layout.UniformInset(values.MarginPadding5)
 					walletSyncBoxes = append(walletSyncBoxes,
 						func(gtx C) D {
@@ -569,49 +576,13 @@ func (pg *overviewPage) walletSyncBox(gtx layout.Context, inset layout.Inset, de
 
 func (pg *overviewPage) handle() {
 	eq := pg.queue
-	c := pg.common
-
-	wal := *pg.wallet
-	if wal != nil {
-		isDarkModeOn := wal.ReadBoolConfigValueForKey("isDarkModeOn")
-		if isDarkModeOn != pg.theme.DarkMode {
-			pg.theme.SwitchDarkMode(isDarkModeOn)
-		}
-	}
-
-	if pg.walletInfo.Synced {
-		pg.sync.Text = values.String(values.StrDisconnect)
-	}
-
-	if pg.autoSyncWallet && !pg.walletInfo.Synced {
-		walletsLocked := getLockedWallets(c.wallet.AllWallets())
-		if len(walletsLocked) == 0 {
-			log.Info("Starting sync")
-			c.wallet.StartSync()
-			pg.sync.Text = values.String(values.StrCancel)
-			pg.autoSyncWallet = false
-		}
-	}
-
-	if !pg.isCheckingLockWL {
-		if lockedWallets := getLockedWallets(c.wallet.AllWallets()); len(lockedWallets) > 0 {
-			showWalletUnlockModal(c, lockedWallets)
-		}
-		pg.isCheckingLockWL = true
-	}
 
 	if pg.sync.Button.Clicked() {
-		if pg.walletInfo.Synced || pg.walletInfo.Syncing {
-			c.wallet.CancelSync()
-			pg.sync.Text = values.String(values.StrReconnect)
-		} else {
-			c.wallet.StartSync()
-			pg.sync.Text = values.String(values.StrCancel)
-		}
+		go pg.toggleSync()
 	}
 
 	if pg.toTransactions.Button.Clicked() {
-		c.changePage(PageTransactions)
+		pg.changePage(PageTransactions)
 	}
 
 	for index, click := range pg.toTransactionDetails {
@@ -620,8 +591,8 @@ func (pg *overviewPage) handle() {
 				txn := (*pg.walletTransactions).Recent[index]
 				*pg.walletTransaction = &txn
 
-				c.setReturnPage(PageOverview)
-				c.changePage(PageTransactionDetails)
+				pg.setReturnPage(PageOverview)
+				pg.changePage(PageTransactionDetails)
 				return
 			}
 		}
@@ -637,29 +608,52 @@ func (pg *overviewPage) handle() {
 	}
 }
 
-func (pg *overviewPage) onClose() {}
+func (pg *overviewPage) listenForSyncNotifications() {
+	go func() {
+		for {
+			syncStatus := <-pg.syncStatusUpdate
+			switch t := syncStatus.ProgressReport.(type) {
+			case wallet.SyncHeadersFetchProgress:
+				pg.headerFetchProgress = t.Progress.HeadersFetchProgress
+				pg.headersToFetchOrScan = t.Progress.TotalHeadersToFetch
+				pg.syncProgress = int(t.Progress.TotalSyncProgress)
+				pg.remainingSyncTime = wallet.SecondsToDays(t.Progress.TotalTimeRemainingSeconds)
+				pg.syncStep = wallet.FetchHeadersSteps
+			case wallet.SyncAddressDiscoveryProgress:
+				pg.syncProgress = int(t.Progress.TotalSyncProgress)
+				pg.remainingSyncTime = wallet.SecondsToDays(t.Progress.TotalTimeRemainingSeconds)
+				pg.syncStep = wallet.AddressDiscoveryStep
+			case wallet.SyncHeadersRescanProgress:
+				pg.headersToFetchOrScan = t.Progress.TotalHeadersToScan
+				pg.syncProgress = int(t.Progress.TotalSyncProgress)
+				pg.remainingSyncTime = wallet.SecondsToDays(t.Progress.TotalTimeRemainingSeconds)
+				pg.syncStep = wallet.RescanHeadersStep
+			}
 
-func showWalletUnlockModal(c *pageCommon, lockedWallets []*dcrlibwallet.Wallet) {
-	newPasswordModal(c).
-		title(values.String(values.StrResumeAccountDiscoveryTitle)).
-		hint("Spending password").
-		negativeButton(values.String(values.StrCancel), func() {}).
-		positiveButton(values.String(values.StrUnlock), func(password string, pm *passwordModal) bool {
-			go func() {
-				err := c.wallet.UnlockWallet(lockedWallets[0].ID, []byte(password))
-				if err != nil {
-					errText := err.Error()
-					if err.Error() == "invalid_passphrase" {
-						errText = "Invalid passphrase"
-					}
-					pm.setError(errText)
-					pm.setLoading(false)
-					return
-				}
-				pm.Dismiss()
-			}()
+			switch syncStatus.Stage {
+			case wallet.PeersConnected:
+				pg.connectedPeers = syncStatus.ConnectedPeers
+			case wallet.SyncStarted:
+				fallthrough
+			case wallet.SyncCanceled:
+				fallthrough
+			case wallet.SyncCompleted:
+				pg.walletSyncing = pg.multiWallet.IsSyncing()
+				pg.walletSynced = pg.multiWallet.IsSynced()
+				pg.isConnnected = pg.multiWallet.IsConnectedToDecredNetwork()
+			case wallet.BlockAttached:
+				pg.bestBlock = pg.multiWallet.GetBestBlock()
+			}
 
-			return false
-		}).Show()
+			if pg.isConnnected {
+				pg.sync.Text = values.String(values.StrDisconnect)
+			} else {
+				pg.sync.Text = values.String(values.StrReconnect)
+			}
 
+			pg.refreshWindow()
+		}
+	}()
 }
+
+func (pg *overviewPage) onClose() {}

--- a/ui/page.go
+++ b/ui/page.go
@@ -104,39 +104,39 @@ type walletAccountSelector struct {
 }
 
 type pageCommon struct {
-	printer            *message.Printer
-	multiWallet        *dcrlibwallet.MultiWallet
-	syncStatusUpdate   chan wallet.SyncStatusUpdate
-	wallet             *wallet.Wallet
-	walletAccount      **wallet.Account
-	info               *wallet.MultiWalletInfo
-	selectedWallet     *int
-	selectedAccount    *int
-	theme              *decredmaterial.Theme
-	icons              pageIcons
-	page               *string
-	returnPage         *string
-	dcrUsdtBittrex     DCRUSDTBittrex
-	navTab             *decredmaterial.Tabs
-	keyEvents          chan *key.Event
-	toast              **toast
-	states             *states
-	internalLog        *chan string
-	walletSyncStatus   *wallet.SyncStatus
-	walletTransactions **wallet.Transactions
-	acctMixerStatus    *chan *wallet.AccountMixer
-	selectedProposal   **dcrlibwallet.Proposal
-	proposals          **wallet.Proposals
-	syncedProposal     chan *wallet.Proposal
-	txAuthor           *dcrlibwallet.TxAuthor
-	broadcastResult    *wallet.Broadcast
-	signatureResult    **wallet.Signature
-	walletTickets      **wallet.Tickets
-	vspInfo            **wallet.VSP
-	unspentOutputs     **wallet.UnspentOutputs
-	showModal          func(Modal)
-	dismissModal       func(Modal)
-	toggleSync         func()
+	printer             *message.Printer
+	multiWallet         *dcrlibwallet.MultiWallet
+	notificationsUpdate chan interface{}
+	wallet              *wallet.Wallet
+	walletAccount       **wallet.Account
+	info                *wallet.MultiWalletInfo
+	selectedWallet      *int
+	selectedAccount     *int
+	theme               *decredmaterial.Theme
+	icons               pageIcons
+	page                *string
+	returnPage          *string
+	dcrUsdtBittrex      DCRUSDTBittrex
+	navTab              *decredmaterial.Tabs
+	keyEvents           chan *key.Event
+	toast               **toast
+	states              *states
+	internalLog         *chan string
+	walletSyncStatus    *wallet.SyncStatus
+	walletTransactions  **wallet.Transactions
+	acctMixerStatus     *chan *wallet.AccountMixer
+	selectedProposal    **dcrlibwallet.Proposal
+	proposals           **wallet.Proposals
+	syncedProposal      chan *wallet.Proposal
+	txAuthor            *dcrlibwallet.TxAuthor
+	broadcastResult     *wallet.Broadcast
+	signatureResult     **wallet.Signature
+	walletTickets       **wallet.Tickets
+	vspInfo             **wallet.VSP
+	unspentOutputs      **wallet.UnspentOutputs
+	showModal           func(Modal)
+	dismissModal        func(Modal)
+	toggleSync          func()
 
 	testButton decredmaterial.Button
 
@@ -237,20 +237,20 @@ func (win *Window) newPageCommon(decredIcons map[string]image.Image) *pageCommon
 	}
 
 	common := &pageCommon{
-		printer:            message.NewPrinter(language.English),
-		multiWallet:        win.wallet.GetMultiWallet(),
-		syncStatusUpdate:   make(chan wallet.SyncStatusUpdate, 10),
-		wallet:             win.wallet,
-		walletAccount:      &win.walletAccount,
-		info:               win.walletInfo,
-		selectedWallet:     &win.selected,
-		selectedAccount:    &win.selectedAccount,
-		theme:              win.theme,
-		keyEvents:          win.keyEvents,
-		states:             &win.states,
-		icons:              ic,
-		walletSyncStatus:   win.walletSyncStatus,
-		walletTransactions: &win.walletTransactions,
+		printer:             message.NewPrinter(language.English),
+		multiWallet:         win.wallet.GetMultiWallet(),
+		notificationsUpdate: make(chan interface{}, 10),
+		wallet:              win.wallet,
+		walletAccount:       &win.walletAccount,
+		info:                win.walletInfo,
+		selectedWallet:      &win.selected,
+		selectedAccount:     &win.selectedAccount,
+		theme:               win.theme,
+		keyEvents:           win.keyEvents,
+		states:              &win.states,
+		icons:               ic,
+		walletSyncStatus:    win.walletSyncStatus,
+		walletTransactions:  &win.walletTransactions,
 		// walletTransaction:  &win.walletTransaction,
 		acctMixerStatus:  &win.walletAcctMixerStatus,
 		selectedProposal: &win.selectedProposal,
@@ -323,7 +323,6 @@ func (common *pageCommon) loadPages() map[string]Page {
 	pages := make(map[string]Page)
 
 	pages[PageWallet] = WalletPage(common)
-	pages[PageOverview] = OverviewPage(common)
 	pages[PageMore] = MorePage(common)
 	pages[PageCreateRestore] = CreateRestorePage(common)
 	pages[PageReceive] = ReceivePage(common)

--- a/ui/page.go
+++ b/ui/page.go
@@ -124,7 +124,6 @@ type pageCommon struct {
 	internalLog        *chan string
 	walletSyncStatus   *wallet.SyncStatus
 	walletTransactions **wallet.Transactions
-	walletTransaction  **dcrlibwallet.Transaction
 	acctMixerStatus    *chan *wallet.AccountMixer
 	selectedProposal   **dcrlibwallet.Proposal
 	proposals          **wallet.Proposals
@@ -325,7 +324,6 @@ func (common *pageCommon) loadPages() map[string]Page {
 
 	pages[PageWallet] = WalletPage(common)
 	pages[PageOverview] = OverviewPage(common)
-	pages[PageTransactions] = TransactionsPage(common)
 	pages[PageMore] = MorePage(common)
 	pages[PageCreateRestore] = CreateRestorePage(common)
 	pages[PageReceive] = ReceivePage(common)

--- a/ui/page.go
+++ b/ui/page.go
@@ -137,6 +137,7 @@ type pageCommon struct {
 	unspentOutputs     **wallet.UnspentOutputs
 	showModal          func(Modal)
 	dismissModal       func(Modal)
+	toggleSync         func()
 
 	testButton decredmaterial.Button
 
@@ -145,6 +146,7 @@ type pageCommon struct {
 	subPageBackButton decredmaterial.IconButton
 	subPageInfoButton decredmaterial.IconButton
 
+	refreshWindow    func()
 	changeWindowPage func(Page)
 	changePage       func(string)
 	setReturnPage    func(string)
@@ -263,6 +265,7 @@ func (win *Window) newPageCommon(decredIcons map[string]image.Image) *pageCommon
 		showModal:          win.showModal,
 		dismissModal:       win.dismissModal,
 		changeWindowPage:   win.changePage,
+		refreshWindow:      win.refreshWindow,
 
 		selectedUTXO: make(map[int]map[int32]map[string]*wallet.UnspentOutput),
 		toast:        &win.toast,

--- a/ui/page.go
+++ b/ui/page.go
@@ -50,6 +50,7 @@ type pageIcons struct {
 }
 
 type Page interface {
+	OnResume()
 	Layout(layout.Context) layout.Dimensions
 	handle()
 	onClose()

--- a/ui/page.go
+++ b/ui/page.go
@@ -50,7 +50,7 @@ type pageIcons struct {
 }
 
 type Page interface {
-	OnResume()
+	OnResume() // called when a page is starting or resuming from a paused state.
 	Layout(layout.Context) layout.Dimensions
 	handle()
 	onClose()

--- a/ui/page.go
+++ b/ui/page.go
@@ -124,7 +124,7 @@ type pageCommon struct {
 	internalLog        *chan string
 	walletSyncStatus   *wallet.SyncStatus
 	walletTransactions **wallet.Transactions
-	walletTransaction  **wallet.Transaction
+	walletTransaction  **dcrlibwallet.Transaction
 	acctMixerStatus    *chan *wallet.AccountMixer
 	selectedProposal   **dcrlibwallet.Proposal
 	proposals          **wallet.Proposals
@@ -150,6 +150,7 @@ type pageCommon struct {
 	changeWindowPage func(Page)
 	changePage       func(string)
 	setReturnPage    func(string)
+	changeFragment   func(Page, string)
 
 	wallAcctSelector *walletAccountSelector
 }
@@ -251,21 +252,21 @@ func (win *Window) newPageCommon(decredIcons map[string]image.Image) *pageCommon
 		icons:              ic,
 		walletSyncStatus:   win.walletSyncStatus,
 		walletTransactions: &win.walletTransactions,
-		walletTransaction:  &win.walletTransaction,
-		acctMixerStatus:    &win.walletAcctMixerStatus,
-		selectedProposal:   &win.selectedProposal,
-		proposals:          &win.proposals,
-		syncedProposal:     win.proposal,
-		txAuthor:           &win.txAuthor,
-		broadcastResult:    &win.broadcastResult,
-		signatureResult:    &win.signatureResult,
-		walletTickets:      &win.walletTickets,
-		vspInfo:            &win.vspInfo,
-		unspentOutputs:     &win.walletUnspentOutputs,
-		showModal:          win.showModal,
-		dismissModal:       win.dismissModal,
-		changeWindowPage:   win.changePage,
-		refreshWindow:      win.refreshWindow,
+		// walletTransaction:  &win.walletTransaction,
+		acctMixerStatus:  &win.walletAcctMixerStatus,
+		selectedProposal: &win.selectedProposal,
+		proposals:        &win.proposals,
+		syncedProposal:   win.proposal,
+		txAuthor:         &win.txAuthor,
+		broadcastResult:  &win.broadcastResult,
+		signatureResult:  &win.signatureResult,
+		walletTickets:    &win.walletTickets,
+		vspInfo:          &win.vspInfo,
+		unspentOutputs:   &win.walletUnspentOutputs,
+		showModal:        win.showModal,
+		dismissModal:     win.dismissModal,
+		changeWindowPage: win.changePage,
+		refreshWindow:    win.refreshWindow,
 
 		selectedUTXO: make(map[int]map[int32]map[string]*wallet.UnspentOutput),
 		toast:        &win.toast,
@@ -329,7 +330,6 @@ func (common *pageCommon) loadPages() map[string]Page {
 	pages[PageCreateRestore] = CreateRestorePage(common)
 	pages[PageReceive] = ReceivePage(common)
 	pages[PageSend] = SendPage(common)
-	pages[PageTransactionDetails] = TransactionDetailsPage(common)
 	pages[PageSignMessage] = SignMessagePage(common)
 	pages[PageVerifyMessage] = VerifyMessagePage(common)
 	pages[PageSeedBackup] = BackupPage(common)

--- a/ui/privacy_page.go
+++ b/ui/privacy_page.go
@@ -50,6 +50,10 @@ func PrivacyPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *privacyPage) OnResume() {
+
+}
+
 func (pg *privacyPage) Layout(gtx layout.Context) layout.Dimensions {
 	c := pg.common
 	d := func(gtx C) D {

--- a/ui/proposal_details_page.go
+++ b/ui/proposal_details_page.go
@@ -74,6 +74,10 @@ func ProposalDetailsPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *proposalDetails) OnResume() {
+
+}
+
 func (pg *proposalDetails) handle() {
 	for token := range pg.proposalItems {
 		for location, clickable := range pg.proposalItems[token].clickables {

--- a/ui/proposals_page.go
+++ b/ui/proposals_page.go
@@ -124,6 +124,10 @@ func ProposalsPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *proposalsPage) OnResume() {
+
+}
+
 func (pg *proposalsPage) handle() {
 	common := pg.common
 	for i := range pg.tabs.tabs {

--- a/ui/receive_page.go
+++ b/ui/receive_page.go
@@ -78,6 +78,10 @@ func ReceivePage(common *pageCommon) Page {
 	return page
 }
 
+func (pg *receivePage) OnResume() {
+
+}
+
 func (pg *receivePage) Layout(gtx layout.Context) layout.Dimensions {
 	common := pg.common
 	if pg.gtx == nil {

--- a/ui/security_tools_page.go
+++ b/ui/security_tools_page.go
@@ -30,6 +30,10 @@ func SecurityToolsPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *securityToolsPage) OnResume() {
+
+}
+
 // main settings layout
 func (pg *securityToolsPage) Layout(gtx layout.Context) layout.Dimensions {
 	common := pg.common

--- a/ui/seed_backup_page.go
+++ b/ui/seed_backup_page.go
@@ -145,6 +145,10 @@ func BackupPage(c *pageCommon) Page {
 	return b
 }
 
+func (pg *backupPage) OnResume() {
+
+}
+
 func (pg *backupPage) activeButton() {
 	pg.action.Background = pg.theme.Color.Primary
 	pg.action.Color = pg.theme.Color.InvText

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -219,6 +219,10 @@ func SendPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *sendPage) OnResume() {
+
+}
+
 func (pg *sendPage) Layout(gtx layout.Context) layout.Dimensions {
 	common := pg.common
 	pageContent := []func(gtx C) D{

--- a/ui/settings_page.go
+++ b/ui/settings_page.go
@@ -122,6 +122,10 @@ func SettingsPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *settingsPage) OnResume() {
+
+}
+
 func (pg *settingsPage) Layout(gtx layout.Context) layout.Dimensions {
 	common := pg.common
 	pg.updateSettingOptions()

--- a/ui/sign_message_page.go
+++ b/ui/sign_message_page.go
@@ -71,6 +71,10 @@ func SignMessagePage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *signMessagePage) OnResume() {
+
+}
+
 func (pg *signMessagePage) Layout(gtx layout.Context) layout.Dimensions {
 	if pg.gtx == nil {
 		pg.gtx = &gtx

--- a/ui/statistics_page.go
+++ b/ui/statistics_page.go
@@ -45,6 +45,10 @@ func StatPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *statPage) OnResume() {
+
+}
+
 func (pg *statPage) layoutStats(gtx C) D {
 	background := pg.common.theme.Color.Surface
 	card := pg.common.theme.Card()

--- a/ui/tickets_activity_page.go
+++ b/ui/tickets_activity_page.go
@@ -53,6 +53,10 @@ func TicketActivityPage(c *pageCommon) Page {
 	return pg
 }
 
+func (pg *ticketsActivityPage) OnResume() {
+
+}
+
 func (pg *ticketsActivityPage) Layout(gtx layout.Context) layout.Dimensions {
 	c := pg.common
 	c.createOrUpdateWalletDropDown(&pg.walletDropDown, pg.wallets)

--- a/ui/tickets_list_page.go
+++ b/ui/tickets_list_page.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/wallet"
 
 	"gioui.org/layout"
@@ -30,6 +31,8 @@ type ticketPageList struct {
 	isGridView         bool
 	common             *pageCommon
 	statusTooltips     []*decredmaterial.Tooltip
+
+	wallets []*dcrlibwallet.Wallet
 }
 
 func TicketPageList(c *pageCommon) Page {
@@ -40,6 +43,8 @@ func TicketPageList(c *pageCommon) Page {
 		ticketsList:    layout.List{Axis: layout.Vertical},
 		toggleViewType: new(widget.Clickable),
 		isGridView:     true,
+
+		wallets: c.multiWallet.AllWallets(),
 	}
 	pg.orderDropDown = createOrderDropDown(c)
 	pg.ticketTypeDropDown = c.theme.DropDown([]decredmaterial.DropDownItem{
@@ -58,7 +63,7 @@ func TicketPageList(c *pageCommon) Page {
 
 func (pg *ticketPageList) Layout(gtx layout.Context) layout.Dimensions {
 	c := pg.common
-	c.createOrUpdateWalletDropDown(&pg.walletDropDown)
+	c.createOrUpdateWalletDropDown(&pg.walletDropDown, pg.wallets)
 	pg.initTicketTooltips(*c)
 
 	body := func(gtx C) D {
@@ -68,7 +73,7 @@ func (pg *ticketPageList) Layout(gtx layout.Context) layout.Dimensions {
 				c.changePage(PageTickets)
 			},
 			body: func(gtx C) D {
-				walletID := c.info.Wallets[pg.walletDropDown.SelectedIndex()].ID
+				walletID := pg.wallets[pg.walletDropDown.SelectedIndex()].ID
 				tickets := (*pg.tickets).Confirmed[walletID]
 				return layout.Stack{Alignment: layout.N}.Layout(gtx,
 					layout.Expanded(func(gtx C) D {
@@ -295,7 +300,7 @@ func (pg *ticketPageList) ticketListGridLayout(gtx layout.Context, c *pageCommon
 }
 
 func (pg *ticketPageList) initTicketTooltips(common pageCommon) {
-	walletID := common.info.Wallets[pg.walletDropDown.SelectedIndex()].ID
+	walletID := pg.wallets[pg.walletDropDown.SelectedIndex()].ID
 	tickets := (*pg.tickets).Confirmed[walletID]
 
 	for range tickets {
@@ -304,7 +309,6 @@ func (pg *ticketPageList) initTicketTooltips(common pageCommon) {
 }
 
 func (pg *ticketPageList) handle() {
-	c := pg.common
 
 	if pg.toggleViewType.Clicked() {
 		pg.isGridView = !pg.isGridView
@@ -314,7 +318,7 @@ func (pg *ticketPageList) handle() {
 	if pg.filterSorter != sortSelection {
 		pg.filterSorter = sortSelection
 		newestFirst := pg.filterSorter == 0
-		for _, wal := range c.info.Wallets {
+		for _, wal := range pg.wallets {
 			tickets := (*pg.tickets).Confirmed[wal.ID]
 			sort.SliceStable(tickets, func(i, j int) bool {
 				backTime := time.Unix(tickets[j].Info.Ticket.Timestamp, 0)

--- a/ui/tickets_list_page.go
+++ b/ui/tickets_list_page.go
@@ -61,6 +61,10 @@ func TicketPageList(c *pageCommon) Page {
 	return pg
 }
 
+func (pg *ticketPageList) OnResume() {
+
+}
+
 func (pg *ticketPageList) Layout(gtx layout.Context) layout.Dimensions {
 	c := pg.common
 	c.createOrUpdateWalletDropDown(&pg.walletDropDown, pg.wallets)

--- a/ui/tickets_page.go
+++ b/ui/tickets_page.go
@@ -27,7 +27,7 @@ const PageTickets = "Tickets"
 type ticketPage struct {
 	th     *decredmaterial.Theme
 	wal    *wallet.Wallet
-	vspd   *dcrlibwallet.VSPD
+	vspd   *dcrlibwallet.VSP
 	common *pageCommon
 
 	ticketPageContainer layout.List

--- a/ui/tickets_page.go
+++ b/ui/tickets_page.go
@@ -119,6 +119,10 @@ func TicketPage(c *pageCommon) Page {
 	return pg
 }
 
+func (pg *ticketPage) OnResume() {
+
+}
+
 func (pg *ticketPage) Layout(gtx layout.Context) layout.Dimensions {
 	c := pg.common
 	dims := c.UniformPadding(gtx, func(gtx layout.Context) layout.Dimensions {

--- a/ui/transaction_details_page.go
+++ b/ui/transaction_details_page.go
@@ -97,6 +97,10 @@ func TransactionDetailsPage(common *pageCommon, transaction *dcrlibwallet.Transa
 	return pg
 }
 
+func (pg *transactionDetailsPage) OnResume() {
+
+}
+
 func (pg *transactionDetailsPage) Layout(gtx layout.Context) layout.Dimensions {
 	common := pg.common
 	if pg.gtx == nil {

--- a/ui/transaction_details_page.go
+++ b/ui/transaction_details_page.go
@@ -348,9 +348,9 @@ func (pg *transactionDetailsPage) txnInputs(gtx layout.Context) layout.Dimension
 			accountName := "external"
 			walletName := ""
 			if input.AccountNumber != -1 {
-				account, err := pg.wallet.GetAccount(input.AccountNumber)
+				name, err := pg.wallet.AccountName(input.AccountNumber)
 				if err == nil {
-					accountName = account.Name
+					accountName = name
 					walletName = pg.wallet.Name
 				}
 			}

--- a/ui/transactions_page.go
+++ b/ui/transactions_page.go
@@ -50,9 +50,9 @@ func TransactionsPage(common *pageCommon) Page {
 		container:          layout.Flex{Axis: layout.Vertical},
 		txsList:            layout.List{Axis: layout.Vertical},
 		walletTransactions: common.walletTransactions,
-		walletTransaction:  common.walletTransaction,
-		separator:          common.theme.Separator(),
-		theme:              common.theme,
+		// walletTransaction:  common.walletTransaction,
+		separator: common.theme.Separator(),
+		theme:     common.theme,
 	}
 
 	pg.orderDropDown = createOrderDropDown(common)
@@ -118,9 +118,9 @@ func (pg *transactionsPage) Layout(gtx layout.Context) layout.Dimensions {
 									click.Add(gtx.Ops)
 									pg.goToTxnDetails(click.Events(gtx), common, &wallTxs[index])
 									var row = TransactionRow{
-										transaction: wallTxs[index],
-										index:       index,
-										showBadge:   false,
+										// transaction: wallTxs[index],
+										index:     index,
+										showBadge: false,
 									}
 									return transactionRow(gtx, common, row)
 								})
@@ -243,23 +243,24 @@ func (pg *transactionsPage) goToTxnDetails(events []gesture.ClickEvent, common *
 	}
 }
 
-func initTxnWidgets(common *pageCommon, transaction wallet.Transaction) transactionWdg {
+func initTxnWidgets(common *pageCommon, transaction *dcrlibwallet.Transaction) transactionWdg {
+
 	var txn transactionWdg
-	t := time.Unix(transaction.Txn.Timestamp, 0).UTC()
+	t := time.Unix(transaction.Timestamp, 0).UTC()
 	txn.time = common.theme.Body1(t.Format(time.UnixDate))
 	txn.status = common.theme.Body1("")
-	txn.wallet = common.theme.Body2(transaction.WalletName)
+	txn.wallet = common.theme.Body2(common.multiWallet.WalletWithID(transaction.WalletID).Name)
 
-	if transaction.Status == "confirmed" {
-		txn.status.Text = formatDateOrTime(transaction.Txn.Timestamp)
+	if txConfirmations(common, *transaction) > 1 {
+		txn.status.Text = formatDateOrTime(transaction.Timestamp)
 		txn.statusIcon = common.icons.confirmIcon
 	} else {
-		txn.status.Text = transaction.Status
+		txn.status.Text = "pending"
 		txn.status.Color = common.theme.Color.Gray
 		txn.statusIcon = common.icons.pendingIcon
 	}
 
-	if transaction.Txn.Direction == dcrlibwallet.TxDirectionSent {
+	if transaction.Direction == dcrlibwallet.TxDirectionSent {
 		txn.direction = common.icons.sendIcon
 	} else {
 		txn.direction = common.icons.receiveIcon

--- a/ui/transactions_page.go
+++ b/ui/transactions_page.go
@@ -52,7 +52,7 @@ func TransactionsPage(common *pageCommon) Page {
 		wallets: common.multiWallet.AllWallets(),
 	}
 
-	common.createOrUpdateWalletDropDown(&pg.walletDropDown)
+	common.createOrUpdateWalletDropDown(&pg.walletDropDown, pg.wallets)
 	pg.orderDropDown = createOrderDropDown(common)
 	pg.txTypeDropDown = common.theme.DropDown([]decredmaterial.DropDownItem{
 		{

--- a/ui/transactions_page.go
+++ b/ui/transactions_page.go
@@ -77,6 +77,10 @@ func TransactionsPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *transactionsPage) OnResume() {
+
+}
+
 func (pg *transactionsPage) loadTransactions() {
 	selectedWallet := pg.wallets[pg.walletDropDown.SelectedIndex()]
 	newestFirst := pg.orderDropDown.SelectedIndex() == 0

--- a/ui/transactions_page.go
+++ b/ui/transactions_page.go
@@ -52,7 +52,6 @@ func TransactionsPage(common *pageCommon) Page {
 		wallets: common.multiWallet.AllWallets(),
 	}
 
-	common.createOrUpdateWalletDropDown(&pg.walletDropDown, pg.wallets)
 	pg.orderDropDown = createOrderDropDown(common)
 	pg.txTypeDropDown = common.theme.DropDown([]decredmaterial.DropDownItem{
 		{
@@ -72,13 +71,13 @@ func TransactionsPage(common *pageCommon) Page {
 		},
 	}, 1)
 
-	pg.listenForTxNotifications()
-	pg.loadTransactions()
 	return pg
 }
 
 func (pg *transactionsPage) OnResume() {
-
+	pg.createOrUpdateWalletDropDown(&pg.walletDropDown, pg.wallets)
+	pg.listenForTxNotifications()
+	pg.loadTransactions()
 }
 
 func (pg *transactionsPage) loadTransactions() {

--- a/ui/transactions_page.go
+++ b/ui/transactions_page.go
@@ -2,21 +2,16 @@ package ui
 
 import (
 	"image"
-	"sort"
 	"time"
 
-	"gioui.org/f32"
 	"gioui.org/gesture"
 	"gioui.org/io/pointer"
 	"gioui.org/layout"
-	"gioui.org/op"
-	"gioui.org/op/paint"
 	"gioui.org/widget"
 
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/values"
-	"github.com/planetdecred/godcr/wallet"
 )
 
 const PageTransactions = "Transactions"
@@ -28,33 +23,33 @@ type transactionWdg struct {
 }
 
 type transactionsPage struct {
-	container                   layout.Flex
-	txsList                     layout.List
-	walletTransactions          **wallet.Transactions
-	walletTransaction           **wallet.Transaction
-	filterSorter                int
-	filterDirection, filterSort []decredmaterial.RadioButton
-	toTxnDetails                []*gesture.Click
-	separator                   decredmaterial.Line
-	theme                       *decredmaterial.Theme
-	common                      *pageCommon
+	*pageCommon
+	container    layout.Flex
+	txsList      layout.List
+	toTxnDetails []*gesture.Click
+	separator    decredmaterial.Line
+	theme        *decredmaterial.Theme
 
 	orderDropDown  *decredmaterial.DropDown
 	txTypeDropDown *decredmaterial.DropDown
 	walletDropDown *decredmaterial.DropDown
+
+	transactions []dcrlibwallet.Transaction
+	wallets      []*dcrlibwallet.Wallet
 }
 
 func TransactionsPage(common *pageCommon) Page {
 	pg := &transactionsPage{
-		common:             common,
-		container:          layout.Flex{Axis: layout.Vertical},
-		txsList:            layout.List{Axis: layout.Vertical},
-		walletTransactions: common.walletTransactions,
-		// walletTransaction:  common.walletTransaction,
-		separator: common.theme.Separator(),
-		theme:     common.theme,
+		pageCommon: common,
+		container:  layout.Flex{Axis: layout.Vertical},
+		txsList:    layout.List{Axis: layout.Vertical},
+		separator:  common.theme.Separator(),
+		theme:      common.theme,
+
+		wallets: common.multiWallet.AllWallets(),
 	}
 
+	common.createOrUpdateWalletDropDown(&pg.walletDropDown)
 	pg.orderDropDown = createOrderDropDown(common)
 	pg.txTypeDropDown = common.theme.DropDown([]decredmaterial.DropDownItem{
 		{
@@ -74,21 +69,39 @@ func TransactionsPage(common *pageCommon) Page {
 		},
 	}, 1)
 
+	pg.loadTransactions()
 	return pg
 }
 
-func (pg *transactionsPage) Layout(gtx layout.Context) layout.Dimensions {
-	common := pg.common
-	common.createOrUpdateWalletDropDown(&pg.walletDropDown)
-	container := func(gtx C) D {
-		walletID := common.info.Wallets[pg.walletDropDown.SelectedIndex()].ID
-		wallTxs := (*pg.walletTransactions).Txs[walletID]
-		if pg.txTypeDropDown.SelectedIndex()-1 != -1 {
-			wallTxs = filterTransactions(wallTxs, func(i int) bool {
-				return i == pg.txTypeDropDown.SelectedIndex()-1
-			})
-		}
+func (pg *transactionsPage) loadTransactions() {
+	selectedWallet := pg.wallets[pg.walletDropDown.SelectedIndex()]
+	newestFirst := pg.orderDropDown.SelectedIndex() == 0
 
+	txFilter := dcrlibwallet.TxFilterAll
+	switch pg.txTypeDropDown.SelectedIndex() {
+	case 1:
+		txFilter = dcrlibwallet.TxFilterSent
+	case 2:
+		txFilter = dcrlibwallet.TxFilterReceived
+	case 3:
+		txFilter = dcrlibwallet.TxFilterTransferred
+	case 4:
+		txFilter = dcrlibwallet.TxFilterStaking
+	}
+
+	wallTxs, err := selectedWallet.GetTransactionsRaw(0, 0, txFilter, newestFirst) //TODO
+	if err != nil {
+		log.Error("Error loading transactions:", err)
+	} else {
+		pg.transactions = wallTxs
+	}
+}
+
+func (pg *transactionsPage) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.pageCommon
+
+	container := func(gtx C) D {
+		wallTxs := pg.transactions
 		return layout.Stack{Alignment: layout.N}.Layout(gtx,
 			layout.Expanded(func(gtx C) D {
 				return layout.Inset{
@@ -116,11 +129,11 @@ func (pg *transactionsPage) Layout(gtx layout.Context) layout.Dimensions {
 									click := pg.toTxnDetails[index]
 									pointer.Rect(image.Rectangle{Max: gtx.Constraints.Max}).Add(gtx.Ops)
 									click.Add(gtx.Ops)
-									pg.goToTxnDetails(click.Events(gtx), common, &wallTxs[index])
+									pg.goToTxnDetails(click.Events(gtx), &wallTxs[index])
 									var row = TransactionRow{
-										// transaction: wallTxs[index],
-										index:     index,
-										showBadge: false,
+										transaction: wallTxs[index],
+										index:       index,
+										showBadge:   false,
 									}
 									return transactionRow(gtx, common, row)
 								})
@@ -132,16 +145,6 @@ func (pg *transactionsPage) Layout(gtx layout.Context) layout.Dimensions {
 		)
 	}
 	return common.UniformPadding(gtx, container)
-}
-
-func filterTransactions(transactions []wallet.Transaction, f func(int) bool) []wallet.Transaction {
-	t := make([]wallet.Transaction, 0)
-	for _, v := range transactions {
-		if f(int(v.Txn.Direction)) {
-			t = append(t, v)
-		}
-	}
-	return t
 }
 
 func (pg *transactionsPage) dropDowns(gtx layout.Context) layout.Dimensions {
@@ -169,76 +172,25 @@ func (pg *transactionsPage) dropDowns(gtx layout.Context) layout.Dimensions {
 	})
 }
 
-func (pg *transactionsPage) txsFilters(common *pageCommon) layout.Widget {
-	return func(gtx C) D {
-		return layout.Inset{
-			Top:    values.MarginPadding15,
-			Left:   values.MarginPadding15,
-			Bottom: values.MarginPadding15}.Layout(gtx, func(gtx C) D {
-			return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
-				layout.Rigid(func(gtx C) D {
-					return (&layout.List{Axis: layout.Horizontal}).
-						Layout(gtx, len(pg.filterSort), func(gtx C, index int) D {
-							return layout.Inset{Right: values.MarginPadding15}.Layout(gtx, pg.filterSort[index].Layout)
-						})
-				}),
-				layout.Rigid(func(gtx C) D {
-					return layout.Inset{
-						Left:  values.MarginPadding35,
-						Right: values.MarginPadding35,
-						Top:   values.MarginPadding5}.Layout(gtx, func(gtx C) D {
-						dims := image.Point{X: 1, Y: 35}
-						rect := f32.Rectangle{Max: layout.FPt(dims)}
-						rect.Size()
-						op.TransformOp{}.Add(gtx.Ops)
-						paint.Fill(gtx.Ops, common.theme.Color.Hint)
-						return layout.Dimensions{Size: dims}
-					})
-				}),
-				layout.Rigid(func(gtx C) D {
-					return (&layout.List{Axis: layout.Horizontal}).
-						Layout(gtx, len(pg.filterDirection), func(gtx C, index int) D {
-							return layout.Inset{Right: values.MarginPadding15}.Layout(gtx, pg.filterDirection[index].Layout)
-						})
-				}),
-			)
-		})
-	}
-}
-
 func (pg *transactionsPage) handle() {
-	common := pg.common
-	sortSelection := pg.orderDropDown.SelectedIndex()
+	for pg.txTypeDropDown.Changed() {
+		pg.loadTransactions()
+	}
 
-	if pg.filterSorter != sortSelection {
-		pg.filterSorter = sortSelection
-		pg.sortTransactions(common)
+	for pg.orderDropDown.Changed() {
+		pg.loadTransactions()
+	}
+
+	for pg.walletDropDown.Changed() {
+		pg.loadTransactions()
 	}
 }
 
-func (pg *transactionsPage) sortTransactions(common *pageCommon) {
-	newestFirst := pg.filterSorter == 0
-
-	for _, wal := range common.info.Wallets {
-		transactions := (*pg.walletTransactions).Txs[wal.ID]
-		sort.SliceStable(transactions, func(i, j int) bool {
-			backTime := time.Unix(transactions[j].Txn.Timestamp, 0)
-			frontTime := time.Unix(transactions[i].Txn.Timestamp, 0)
-			if newestFirst {
-				return backTime.Before(frontTime)
-			}
-			return frontTime.Before(backTime)
-		})
-	}
-}
-
-func (pg *transactionsPage) goToTxnDetails(events []gesture.ClickEvent, common *pageCommon, txn *wallet.Transaction) {
+func (pg *transactionsPage) goToTxnDetails(events []gesture.ClickEvent, txn *dcrlibwallet.Transaction) {
 	for _, e := range events {
 		if e.Type == gesture.TypeClick {
-			*pg.walletTransaction = txn
-
-			common.setReturnPage(PageTransactions)
-			common.changePage(PageTransactionDetails)
+			pg.setReturnPage(PageTransactions)
+			pg.changeFragment(TransactionDetailsPage(pg.pageCommon, txn), "txdetails")
 		}
 	}
 }

--- a/ui/utxo_page.go
+++ b/ui/utxo_page.go
@@ -63,6 +63,10 @@ func UTXOPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *utxoPage) OnResume() {
+
+}
+
 func (pg *utxoPage) handle() {
 	common := pg.common
 	pg.selectedWalletID = common.info.Wallets[*common.selectedWallet].ID

--- a/ui/validate_address.go
+++ b/ui/validate_address.go
@@ -54,6 +54,10 @@ func ValidateAddressPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *validateAddressPage) OnResume() {
+
+}
+
 func (pg *validateAddressPage) Layout(gtx layout.Context) layout.Dimensions {
 	common := pg.common
 	pg.walletID = common.info.Wallets[*common.selectedWallet].ID

--- a/ui/verify_message_page.go
+++ b/ui/verify_message_page.go
@@ -43,6 +43,10 @@ func VerifyMessagePage(c *pageCommon) Page {
 	return pg
 }
 
+func (pg *verifyMessagePage) OnResume() {
+
+}
+
 func (pg *verifyMessagePage) Layout(gtx layout.Context) layout.Dimensions {
 	c := pg.common
 

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -125,6 +125,10 @@ func WalletPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *walletPage) OnResume() {
+
+}
+
 func (pg *walletPage) initializeWalletMenu() {
 	pg.optionsMenu = []menuItem{
 		{

--- a/ui/wallet_settings_page.go
+++ b/ui/wallet_settings_page.go
@@ -47,6 +47,10 @@ func WalletSettingsPage(common *pageCommon) Page {
 	return pg
 }
 
+func (pg *walletSettingsPage) OnResume() {
+
+}
+
 func (pg *walletSettingsPage) Layout(gtx layout.Context) layout.Dimensions {
 	common := pg.common
 

--- a/ui/window.go
+++ b/ui/window.go
@@ -122,6 +122,10 @@ func (win *Window) Start() {
 
 func (win *Window) changePage(page Page) {
 	win.currentPage = page
+	win.refreshWindow()
+}
+
+func (win *Window) refreshWindow() {
 	win.invalidate <- struct{}{}
 }
 

--- a/wallet/responses.go
+++ b/wallet/responses.go
@@ -235,7 +235,7 @@ type Balance struct {
 // CreateVSP is sent when the Wallet is done creating a new VSP
 type VSPInfo struct {
 	Host string
-	Info *dcrlibwallet.GetVspInfoResponse
+	Info *dcrlibwallet.VspInfoResponse
 }
 
 // VSP is sent when the Wallet is done getting all VSP info

--- a/wallet/txlistener.go
+++ b/wallet/txlistener.go
@@ -1,7 +1,6 @@
 package wallet
 
-// NewTransaction is sent when a new transaction is received.
-type NewTransaction string
+import "github.com/planetdecred/dcrlibwallet"
 
 // NewBlock is sent when a block is attached to the multiwallet.
 type NewBlock struct {
@@ -14,6 +13,10 @@ type TxConfirmed struct {
 	WalletID int
 	Height   int32
 	Hash     string
+}
+
+type NewTransaction struct {
+	Transaction *dcrlibwallet.Transaction
 }
 
 func (l *listener) OnTransaction(transaction string) {

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -71,7 +71,7 @@ func (wal *Wallet) SetupListeners() {
 		return
 	}
 
-	wal.multi.SetAccountMixerNotification(l)
+	wal.multi.AddAccountMixerNotificationListener(l, syncID)
 
 	wal.multi.Politeia.AddNotificationListener(l, syncID)
 
@@ -117,7 +117,7 @@ func (wal *Wallet) LoadWallets() {
 		return
 	}
 
-	wal.multi.SetAccountMixerNotification(l)
+	wal.multi.AddAccountMixerNotificationListener(l, syncID)
 
 	wal.multi.Politeia.AddNotificationListener(l, syncID)
 


### PR DESCRIPTION
The change removes the use of global transactions data to populate the layout of overview, transactions and transaction details page. The transactions are now fetched from dcrlibwallet when the page is initially loaded and the list is refreshed whenever a transaction notification is received.