### PR TITLE
restore default subpage icon

### DIFF
--- a/ui/receive_page.go
+++ b/ui/receive_page.go
@@ -329,6 +329,7 @@ func (pg *receivePage) handle() {
 
 	if common.subPageBackButton.Button.Clicked() {
 		common.changePage(*common.returnPage)
+		common.subPageBackButton.Icon = common.icons.navigationArrowBack
 	}
 
 	if pg.copy.Button.Clicked() {

--- a/ui/receive_page.go
+++ b/ui/receive_page.go
@@ -329,7 +329,6 @@ func (pg *receivePage) handle() {
 
 	if common.subPageBackButton.Button.Clicked() {
 		common.changePage(*common.returnPage)
-		common.subPageBackButton.Icon = common.icons.navigationArrowBack
 	}
 
 	if pg.copy.Button.Clicked() {
@@ -347,4 +346,6 @@ func (pg *receivePage) handle() {
 	}
 }
 
-func (pg *receivePage) onClose() {}
+func (pg *receivePage) onClose() {
+	pg.common.subPageBackButton.Icon = pg.common.icons.navigationArrowBack
+}

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -916,7 +916,6 @@ func (pg *sendPage) handle() {
 		pg.resetErrorText()
 		pg.resetFields()
 		c.changePage(*c.returnPage)
-		c.subPageBackButton.Icon = c.icons.navigationArrowBack
 	}
 
 	if c.subPageInfoButton.Button.Clicked() {
@@ -1053,4 +1052,6 @@ func (pg *sendPage) handle() {
 	}
 }
 
-func (pg *sendPage) onClose() {}
+func (pg *sendPage) onClose() {
+	pg.common.subPageBackButton.Icon = pg.common.icons.navigationArrowBack
+}

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -916,6 +916,7 @@ func (pg *sendPage) handle() {
 		pg.resetErrorText()
 		pg.resetFields()
 		c.changePage(*c.returnPage)
+		c.subPageBackButton.Icon = c.icons.navigationArrowBack
 	}
 
 	if c.subPageInfoButton.Button.Clicked() {


### PR DESCRIPTION
Fix #477
The pr restores the default subpage icon after navigating to either the receive page or the send page.