### PR TITLE
window: maintain pages history and add function to go to previous page

### DIFF
--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -639,6 +639,8 @@ func (pg *createRestore) handle() {
 			pg.resetSeeds()
 			pg.resetPasswords()
 
+			// Go back to wallets page if there's more than one wallet
+			// or launch main page.
 			if pg.common.multiWallet.LoadedWalletsCount() > 1 {
 				pg.common.popWindowPage()
 			} else {

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -621,7 +621,6 @@ func (pg *createRestore) handle() {
 	}
 
 	if pg.restoreWalletBtn.Button.Clicked() {
-
 		pass := pg.validatePasswords()
 		walletName := pg.validateWalletName()
 		if !pg.validateSeeds() || pass == "" || walletName == "" {
@@ -646,7 +645,6 @@ func (pg *createRestore) handle() {
 				pg.common.wallet.SetupListeners()
 				pg.common.changeWindowPage(newMainPage(pg.common), false)
 			}
-
 		}()
 	}
 

--- a/ui/create_restore_page.go
+++ b/ui/create_restore_page.go
@@ -50,10 +50,9 @@ type createRestore struct {
 	openPopupIndex  int
 	selected        int
 
-	hideRestoreWallet decredmaterial.IconButton
-	restoreWalletBtn  decredmaterial.Button
-	resetSeedFields   decredmaterial.Button
-	hideResetModal    decredmaterial.Button
+	closePageBtn     decredmaterial.IconButton
+	restoreWalletBtn decredmaterial.Button
+	resetSeedFields  decredmaterial.Button
 
 	spendingPassword      decredmaterial.Editor
 	walletName            decredmaterial.Editor
@@ -86,7 +85,6 @@ func CreateRestorePage(common *pageCommon) Page {
 		spendingPassword:      common.theme.EditorPassword(new(widget.Editor), "Spending password"),
 		walletName:            common.theme.Editor(new(widget.Editor), "Wallet name"),
 		matchSpendingPassword: common.theme.EditorPassword(new(widget.Editor), "Confirm spending password"),
-		hideResetModal:        common.theme.Button(new(widget.Clickable), "cancel"),
 		suggestionLimit:       3,
 		createModal:           common.theme.Modal(),
 		warningModal:          common.theme.Modal(),
@@ -108,9 +106,9 @@ func CreateRestorePage(common *pageCommon) Page {
 
 	pg.restoreWalletBtn = common.theme.Button(new(widget.Clickable), "Restore")
 
-	pg.hideRestoreWallet = common.theme.IconButton(new(widget.Clickable), mustIcon(widget.NewIcon(icons.NavigationClose)))
-	pg.hideRestoreWallet.Background = color.NRGBA{}
-	pg.hideRestoreWallet.Color = common.theme.Color.Hint
+	pg.closePageBtn = common.theme.IconButton(new(widget.Clickable), mustIcon(widget.NewIcon(icons.NavigationClose)))
+	pg.closePageBtn.Background = color.NRGBA{}
+	pg.closePageBtn.Color = common.theme.Color.Hint
 
 	pg.resetSeedFields = common.theme.Button(new(widget.Clickable), "Clear all")
 	pg.resetSeedFields.Color = common.theme.Color.Hint
@@ -179,7 +177,7 @@ func (pg *createRestore) restore(gtx layout.Context) layout.Dimensions {
 						return layout.W.Layout(gtx, func(gtx C) D {
 							return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 								layout.Rigid(func(gtx C) D {
-									return layout.Inset{Top: values.MarginPadding6}.Layout(gtx, pg.hideRestoreWallet.Layout)
+									return layout.Inset{Top: values.MarginPadding6}.Layout(gtx, pg.closePageBtn.Layout)
 								}),
 								layout.Rigid(func(gtx C) D {
 									return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, pg.theme.H6("Restore wallet").Layout)
@@ -618,8 +616,8 @@ func (pg *createRestore) resetSeeds() {
 func (pg *createRestore) handle() {
 	common := pg.common
 
-	for pg.hideRestoreWallet.Button.Clicked() {
-		// go back to previous page
+	for pg.closePageBtn.Button.Clicked() {
+		common.popWindowPage()
 	}
 
 	if pg.restoreWalletBtn.Button.Clicked() {
@@ -642,8 +640,13 @@ func (pg *createRestore) handle() {
 			pg.resetSeeds()
 			pg.resetPasswords()
 
-			pg.common.wallet.SetupListeners()
-			pg.common.changeWindowPage(newMainPage(pg.common))
+			if pg.common.multiWallet.LoadedWalletsCount() > 1 {
+				pg.common.popWindowPage()
+			} else {
+				pg.common.wallet.SetupListeners()
+				pg.common.changeWindowPage(newMainPage(pg.common), false)
+			}
+
 		}()
 	}
 

--- a/ui/main_page.go
+++ b/ui/main_page.go
@@ -133,7 +133,11 @@ func (mp *mainPage) OnResume() {
 
 	mp.updateBalance()
 
-	mp.changeFragment(OverviewPage(mp.pageCommon), PageOverview)
+	if pg, ok := mp.pages[mp.current]; ok {
+		pg.OnResume()
+	} else {
+		mp.changeFragment(OverviewPage(mp.pageCommon), PageOverview)
+	}
 
 	if mp.autoSync {
 		mp.autoSync = false

--- a/ui/page.go
+++ b/ui/page.go
@@ -127,7 +127,8 @@ type pageCommon struct {
 	subPageInfoButton decredmaterial.IconButton
 
 	refreshWindow    func()
-	changeWindowPage func(Page)
+	changeWindowPage func(Page, bool)
+	popWindowPage    func() bool
 	changePage       func(string)
 	setReturnPage    func(string)
 	changeFragment   func(Page, string)
@@ -244,6 +245,7 @@ func (win *Window) newPageCommon(decredIcons map[string]image.Image) *pageCommon
 		showModal:        win.showModal,
 		dismissModal:     win.dismissModal,
 		changeWindowPage: win.changePage,
+		popWindowPage:    win.popPage,
 		refreshWindow:    win.refreshWindow,
 
 		selectedUTXO: make(map[int]map[int32]map[string]*wallet.UnspentOutput),
@@ -278,7 +280,6 @@ func (common *pageCommon) loadPages() map[string]Page {
 
 	pages[PageWallet] = WalletPage(common)
 	pages[PageMore] = MorePage(common)
-	pages[PageCreateRestore] = CreateRestorePage(common)
 	pages[PageReceive] = ReceivePage(common)
 	pages[PageSend] = SendPage(common)
 	pages[PageSignMessage] = SignMessagePage(common)

--- a/ui/start_page.go
+++ b/ui/start_page.go
@@ -109,7 +109,7 @@ func (sp *startPage) openWallets(passphrase string) error {
 
 func (sp *startPage) proceedToMainPage() {
 	sp.wallet.SetupListeners()
-	sp.changeWindowPage(newMainPage(sp.pageCommon))
+	sp.changeWindowPage(newMainPage(sp.pageCommon), false)
 }
 
 func (sp *startPage) handle() {
@@ -133,7 +133,7 @@ func (sp *startPage) handle() {
 	}
 
 	for sp.restoreButton.Button.Clicked() {
-		sp.changeWindowPage(CreateRestorePage(sp.pageCommon))
+		sp.changeWindowPage(CreateRestorePage(sp.pageCommon), true)
 	}
 }
 

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -200,7 +200,7 @@ func (pg *walletPage) initializeWalletMenu() {
 			text:   values.String(values.StrImportExistingWallet),
 			button: new(widget.Clickable),
 			action: func(common *pageCommon) {
-				common.changePage(PageCreateRestore)
+				common.changeWindowPage(CreateRestorePage(common), true)
 			},
 		},
 		{


### PR DESCRIPTION
This adds a `popPage` function that changes the previous window page when called and returns true if the page was changed. A `keepBackStack` parameter is also added to `changePage` function to configure that pages should be in the back stack history.
Closes #489 
