### PR TITLE
Remove global subpage buttons and declare them locally

### DIFF
--- a/ui/about_page.go
+++ b/ui/about_page.go
@@ -25,6 +25,8 @@ type aboutPage struct {
 	license        decredmaterial.Label
 
 	chevronRightIcon *widget.Icon
+
+	backButton decredmaterial.IconButton
 }
 
 func AboutPage(common *pageCommon) Page {
@@ -43,6 +45,7 @@ func AboutPage(common *pageCommon) Page {
 		chevronRightIcon: common.icons.chevronRight,
 	}
 
+	pg.backButton, _ = common.SubPageHeaderButtons()
 	pg.versionValue.Color = pg.theme.Color.Gray
 	pg.buildDateValue.Color = pg.theme.Color.Gray
 	pg.networkValue.Color = pg.theme.Color.Gray
@@ -58,7 +61,8 @@ func (pg *aboutPage) OnResume() {
 func (pg *aboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	body := func(gtx C) D {
 		page := SubPage{
-			title: "About",
+			title:      "About",
+			backButton: pg.backButton,
 			back: func() {
 				pg.common.changePage(PageMore)
 			},

--- a/ui/account_details_page.go
+++ b/ui/account_details_page.go
@@ -36,13 +36,11 @@ func AcctDetailsPage(common *pageCommon) Page {
 		wallet:        common.wallet,
 		acctInfo:      common.walletAccount,
 		theme:         common.theme,
-		backButton:    common.theme.PlainIconButton(new(widget.Clickable), common.icons.navigationArrowBack),
 		editAccount:   new(widget.Clickable),
 		errorReceiver: make(chan error),
 	}
 
-	pg.backButton.Color = common.theme.Color.Text
-	pg.backButton.Inset = layout.UniformInset(values.MarginPadding0)
+	pg.backButton, _ = common.SubPageHeaderButtons()
 
 	return pg
 }
@@ -78,6 +76,7 @@ func (pg *acctDetailsPage) Layout(gtx layout.Context) layout.Dimensions {
 		page := SubPage{
 			title:      acctName,
 			walletName: common.info.Wallets[*common.selectedWallet].Name,
+			backButton: pg.backButton,
 			back: func() {
 				common.changePage(PageWallet)
 			},
@@ -124,7 +123,7 @@ func (pg *acctDetailsPage) accountBalanceLayout(gtx layout.Context, common *page
 
 	return pg.pageSections(gtx, func(gtx C) D {
 		accountIcon := common.icons.accountIcon
-		if (*pg.acctInfo).Name == "imported" {
+		if (*pg.acctInfo).Name == "imported" { //TODO
 			accountIcon = common.icons.importedAccountIcon
 		}
 		accountIcon.Scale = 1
@@ -252,9 +251,6 @@ func (pg *acctDetailsPage) pageSections(gtx layout.Context, body layout.Widget) 
 
 func (pg *acctDetailsPage) handle() {
 	common := pg.common
-	if pg.backButton.Button.Clicked() {
-		common.changePage(PageWallet)
-	}
 
 	if pg.editAccount.Clicked() {
 		pg.current = common.info.Wallets[*common.selectedWallet]

--- a/ui/debug_page.go
+++ b/ui/debug_page.go
@@ -20,6 +20,8 @@ type debugPage struct {
 	theme      *decredmaterial.Theme
 	debugItems []debugItem
 	common     *pageCommon
+
+	backButton decredmaterial.IconButton
 }
 
 func DebugPage(common *pageCommon) Page {
@@ -41,6 +43,8 @@ func DebugPage(common *pageCommon) Page {
 		debugItems: debugItems,
 		common:     common,
 	}
+
+	pg.backButton, _ = common.SubPageHeaderButtons()
 
 	return pg
 }
@@ -91,7 +95,8 @@ func (pg *debugPage) layoutDebugItems(gtx C, common *pageCommon) {
 func (pg *debugPage) Layout(gtx C) D {
 	container := func(gtx C) D {
 		page := SubPage{
-			title: "Debug",
+			title:      "Debug",
+			backButton: pg.backButton,
 			back: func() {
 				pg.common.changePage(PageMore)
 			},

--- a/ui/help_page.go
+++ b/ui/help_page.go
@@ -16,6 +16,8 @@ type helpPage struct {
 	theme         *decredmaterial.Theme
 	documentation *widget.Clickable
 	common        *pageCommon
+
+	backButton decredmaterial.IconButton
 }
 
 func HelpPage(common *pageCommon) Page {
@@ -24,6 +26,8 @@ func HelpPage(common *pageCommon) Page {
 		documentation: new(widget.Clickable),
 		common:        common,
 	}
+
+	pg.backButton, _ = common.SubPageHeaderButtons()
 
 	return pg
 }
@@ -36,8 +40,9 @@ func (pg *helpPage) OnResume() {
 func (pg *helpPage) Layout(gtx layout.Context) layout.Dimensions {
 	body := func(gtx C) D {
 		page := SubPage{
-			title:    "Help",
-			subTitle: "For more information, please visit the Decred documentation.",
+			title:      "Help",
+			subTitle:   "For more information, please visit the Decred documentation.",
+			backButton: pg.backButton,
 			back: func() {
 				pg.common.changePage(PageMore)
 			},

--- a/ui/log_page.go
+++ b/ui/log_page.go
@@ -17,8 +17,9 @@ type logPage struct {
 	theme  *decredmaterial.Theme
 	common *pageCommon
 
-	copyLog  *widget.Clickable
-	copyIcon *widget.Image
+	copyLog    *widget.Clickable
+	copyIcon   *widget.Image
+	backButton decredmaterial.IconButton
 
 	entriesList layout.List
 	fullLog     string
@@ -40,6 +41,8 @@ func LogPage(common *pageCommon) Page {
 
 	pg.copyIcon = common.icons.copyIcon
 	pg.copyIcon.Scale = 0.25
+
+	pg.backButton, _ = common.SubPageHeaderButtons()
 
 	go pg.watchLogs(*common.internalLog)
 
@@ -73,7 +76,8 @@ func (pg *logPage) Layout(gtx C) D {
 
 	container := func(gtx C) D {
 		page := SubPage{
-			title: "Wallet log",
+			title:      "Wallet log",
+			backButton: pg.backButton,
 			back: func() {
 				common.changePage(PageDebug)
 			},

--- a/ui/privacy_page.go
+++ b/ui/privacy_page.go
@@ -22,11 +22,13 @@ type privacyPage struct {
 	common                               *pageCommon
 	pageContainer                        layout.List
 	toggleMixer, allowUnspendUnmixedAcct *widget.Bool
-	infoBtn                              decredmaterial.IconButton
 	toPrivacySetup                       decredmaterial.Button
 	dangerZoneCollapsible                *decredmaterial.Collapsible
 	errorReceiver                        chan error
 	acctMixerStatus                      *chan *wallet.AccountMixer
+
+	backButton decredmaterial.IconButton
+	infoButton decredmaterial.IconButton
 }
 
 func PrivacyPage(common *pageCommon) Page {
@@ -42,10 +44,7 @@ func PrivacyPage(common *pageCommon) Page {
 		acctMixerStatus:         common.acctMixerStatus,
 	}
 	pg.toPrivacySetup.Background = pg.theme.Color.Primary
-	pg.infoBtn = common.theme.IconButton(new(widget.Clickable), common.icons.actionInfo)
-	pg.infoBtn.Color = common.theme.Color.Gray
-	pg.infoBtn.Background = common.theme.Color.Surface
-	pg.infoBtn.Inset = layout.UniformInset(values.MarginPadding0)
+	pg.backButton, pg.infoButton = common.SubPageHeaderButtons()
 
 	return pg
 }
@@ -60,6 +59,8 @@ func (pg *privacyPage) Layout(gtx layout.Context) layout.Dimensions {
 		load := SubPage{
 			title:      "Privacy",
 			walletName: c.info.Wallets[*c.selectedWallet].Name,
+			backButton: pg.backButton,
+			infoButton: pg.infoButton,
 			back: func() {
 				c.changePage(PageWallet)
 			},

--- a/ui/proposal_details_page.go
+++ b/ui/proposal_details_page.go
@@ -45,8 +45,8 @@ type proposalDetails struct {
 	downloadIcon        *widget.Image
 	timerIcon           *widget.Image
 	successIcon         *widget.Icon
-
-	vote decredmaterial.Button
+	vote                decredmaterial.Button
+	backButton          decredmaterial.IconButton
 }
 
 func ProposalDetailsPage(common *pageCommon) Page {
@@ -72,6 +72,7 @@ func ProposalDetailsPage(common *pageCommon) Page {
 	}
 
 	pg.downloadIcon.Scale = 1
+	pg.backButton, _ = common.SubPageHeaderButtons()
 
 	pg.vote = common.theme.Button(new(widget.Clickable), "Vote")
 	pg.vote.TextSize = values.TextSize14
@@ -434,7 +435,8 @@ func (pg *proposalDetails) Layout(gtx C) D {
 
 	body := func(gtx C) D {
 		page := SubPage{
-			title: truncateString(proposal.Name, 40),
+			title:      truncateString(proposal.Name, 40),
+			backButton: pg.backButton,
 			back: func() {
 				common.changePage(PageProposals)
 				pg.descriptionList.Position.First, pg.descriptionList.Position.Offset = 0, 0

--- a/ui/receive_page.go
+++ b/ui/receive_page.go
@@ -37,7 +37,9 @@ type receivePage struct {
 
 	selector *accountSelector
 
-	backdrop *widget.Clickable
+	backdrop   *widget.Clickable
+	backButton decredmaterial.IconButton
+	infoButton decredmaterial.IconButton
 }
 
 func ReceivePage(common *pageCommon) Page {
@@ -75,6 +77,9 @@ func ReceivePage(common *pageCommon) Page {
 	page.newAddr.Color = common.theme.Color.Text
 	page.newAddr.Background = common.theme.Color.Surface
 	page.newAddr.TextSize = values.TextSize16
+
+	page.backButton, page.infoButton = common.SubPageHeaderButtons()
+	page.backButton.Icon = page.icons.contentClear
 
 	page.selector = newAccountSelector(common).
 		title("Receiving account").
@@ -229,8 +234,7 @@ func (pg *receivePage) topNav(gtx layout.Context) layout.Dimensions {
 		layout.Rigid(func(gtx C) D {
 			return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					pg.subPageBackButton.Icon = pg.icons.contentClear
-					return pg.subPageBackButton.Layout(gtx)
+					return pg.backButton.Layout(gtx)
 				}),
 				layout.Rigid(func(gtx C) D {
 					return layout.Inset{Left: m}.Layout(gtx, pg.theme.H6("Receive DCR").Layout)
@@ -238,7 +242,7 @@ func (pg *receivePage) topNav(gtx layout.Context) layout.Dimensions {
 			)
 		}),
 		layout.Flexed(1, func(gtx C) D {
-			return layout.E.Layout(gtx, pg.subPageInfoButton.Layout)
+			return layout.E.Layout(gtx, pg.infoButton.Layout)
 		}),
 	)
 }
@@ -337,7 +341,7 @@ func (pg *receivePage) handle() {
 		pg.isNewAddr = false
 	}
 
-	if common.subPageInfoButton.Button.Clicked() {
+	if pg.infoButton.Button.Clicked() {
 		info := newInfoModal(common).
 			title("Receive DCR").
 			body("Each time you receive a payment, a new address is generated to protect your privacy.").
@@ -345,7 +349,7 @@ func (pg *receivePage) handle() {
 		common.showModal(info)
 	}
 
-	if common.subPageBackButton.Button.Clicked() {
+	if pg.backButton.Button.Clicked() {
 		common.changePage(*common.returnPage)
 	}
 
@@ -379,6 +383,4 @@ generateAddress:
 }
 
 func (pg *receivePage) onClose() {
-	// TODO
-	pg.pageCommon.subPageBackButton.Icon = pg.pageCommon.icons.navigationArrowBack
 }

--- a/ui/security_tools_page.go
+++ b/ui/security_tools_page.go
@@ -17,6 +17,9 @@ type securityToolsPage struct {
 	verifyMessage   *widget.Clickable
 	validateAddress *widget.Clickable
 	common          *pageCommon
+
+	backButton decredmaterial.IconButton
+	infoButton decredmaterial.IconButton
 }
 
 func SecurityToolsPage(common *pageCommon) Page {
@@ -26,6 +29,8 @@ func SecurityToolsPage(common *pageCommon) Page {
 		validateAddress: new(widget.Clickable),
 		common:          common,
 	}
+
+	pg.backButton, pg.infoButton = common.SubPageHeaderButtons()
 
 	return pg
 }
@@ -39,7 +44,9 @@ func (pg *securityToolsPage) Layout(gtx layout.Context) layout.Dimensions {
 	common := pg.common
 	body := func(gtx C) D {
 		page := SubPage{
-			title: "Security Tools",
+			title:      "Security Tools",
+			backButton: pg.backButton,
+			infoButton: pg.infoButton,
 			back: func() {
 				*common.page = PageMore
 			},

--- a/ui/send_page.go
+++ b/ui/send_page.go
@@ -44,6 +44,8 @@ type sendPage struct {
 	leftAmountEditor         decredmaterial.Editor
 	rightAmountEditor        decredmaterial.Editor
 
+	backButton decredmaterial.IconButton
+	infoButton decredmaterial.IconButton
 	moreOption decredmaterial.IconButton
 
 	nextButton   decredmaterial.Button
@@ -196,6 +198,9 @@ func SendPage(common *pageCommon) Page {
 	pg.closeConfirmationModalButton.Background = color.NRGBA{}
 	pg.closeConfirmationModalButton.Color = common.theme.Color.Primary
 
+	pg.backButton, pg.infoButton = common.SubPageHeaderButtons()
+	pg.backButton.Icon = common.icons.contentClear
+
 	pg.moreOption = common.theme.PlainIconButton(new(widget.Clickable), common.icons.navMoreIcon)
 	pg.moreOption.Color = common.theme.Color.Gray3
 	pg.moreOption.Inset = layout.UniformInset(values.MarginPadding0)
@@ -295,7 +300,7 @@ func (pg *sendPage) Layout(gtx layout.Context) layout.Dimensions {
 						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 							layout.Rigid(func(gtx C) D {
 								return layout.Inset{Bottom: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-									return pg.topNav(gtx, common)
+									return pg.topNav(gtx)
 								})
 							}),
 							layout.Rigid(func(gtx C) D {
@@ -336,14 +341,13 @@ func (pg *sendPage) Layout(gtx layout.Context) layout.Dimensions {
 	return dims
 }
 
-func (pg *sendPage) topNav(gtx layout.Context, common *pageCommon) layout.Dimensions {
+func (pg *sendPage) topNav(gtx layout.Context) layout.Dimensions {
 	m := values.MarginPadding20
 	return layout.Flex{}.Layout(gtx,
 		layout.Rigid(func(gtx C) D {
 			return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					common.subPageBackButton.Icon = common.icons.contentClear
-					return common.subPageBackButton.Layout(gtx)
+					return pg.backButton.Layout(gtx)
 				}),
 				layout.Rigid(func(gtx C) D {
 					return layout.Inset{Left: m}.Layout(gtx, pg.theme.H6("Send DCR").Layout)
@@ -353,7 +357,7 @@ func (pg *sendPage) topNav(gtx layout.Context, common *pageCommon) layout.Dimens
 		layout.Flexed(1, func(gtx C) D {
 			return layout.E.Layout(gtx, func(gtx C) D {
 				return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
-					layout.Rigid(common.subPageInfoButton.Layout),
+					layout.Rigid(pg.infoButton.Layout),
 					layout.Rigid(func(gtx C) D {
 						return layout.Inset{Left: m}.Layout(gtx, pg.moreOption.Layout)
 					}),
@@ -978,13 +982,13 @@ func (pg *sendPage) handle() {
 
 	pg.sendToOption = pg.accountSwitch.SelectedOption()
 
-	if c.subPageBackButton.Button.Clicked() {
+	if pg.backButton.Button.Clicked() {
 		pg.resetErrorText()
 		pg.resetFields()
 		c.changePage(*c.returnPage)
 	}
 
-	if c.subPageInfoButton.Button.Clicked() {
+	if pg.infoButton.Button.Clicked() {
 		info := newInfoModal(c).
 			title("Send DCR").
 			body("Input or scan the destination wallet address and input the amount to send funds.").
@@ -1114,5 +1118,5 @@ func (pg *sendPage) handle() {
 }
 
 func (pg *sendPage) onClose() {
-	pg.common.subPageBackButton.Icon = pg.common.icons.navigationArrowBack
+
 }

--- a/ui/settings_page.go
+++ b/ui/settings_page.go
@@ -40,6 +40,7 @@ type settingsPage struct {
 	chevronRightIcon    *widget.Icon
 	confirm             decredmaterial.Button
 	cancel              decredmaterial.Button
+	backButton          decredmaterial.IconButton
 
 	isDarkModeOn     *widget.Bool
 	spendUnconfirmed *widget.Bool
@@ -89,6 +90,8 @@ func SettingsPage(common *pageCommon) Page {
 		cancel:  common.theme.Button(new(widget.Clickable), values.String(values.StrCancel)),
 	}
 
+	pg.backButton, _ = common.SubPageHeaderButtons()
+
 	languagePreference := preference.NewListPreference(common.wallet, common.theme, languagePreferenceKey,
 		values.DefaultLangauge, values.ArrLanguages).
 		Title(values.StrLanguage).
@@ -132,7 +135,8 @@ func (pg *settingsPage) Layout(gtx layout.Context) layout.Dimensions {
 
 	body := func(gtx C) D {
 		page := SubPage{
-			title: values.String(values.StrSettings),
+			title:      values.String(values.StrSettings),
+			backButton: pg.backButton,
 			back: func() {
 				common.changePage(PageMore)
 			},

--- a/ui/sign_message_page.go
+++ b/ui/sign_message_page.go
@@ -30,6 +30,9 @@ type signMessagePage struct {
 	copySignature                              *widget.Clickable
 	copyIcon                                   *widget.Image
 	gtx                                        *layout.Context
+
+	backButton decredmaterial.IconButton
+	infoButton decredmaterial.IconButton
 }
 
 func SignMessagePage(common *pageCommon) Page {
@@ -67,6 +70,7 @@ func SignMessagePage(common *pageCommon) Page {
 	}
 
 	pg.signedMessageLabel.Color = common.theme.Color.Gray
+	pg.backButton, pg.infoButton = common.SubPageHeaderButtons()
 
 	return pg
 }
@@ -86,6 +90,8 @@ func (pg *signMessagePage) Layout(gtx layout.Context) layout.Dimensions {
 		page := SubPage{
 			title:      "Sign message",
 			walletName: common.info.Wallets[*common.selectedWallet].Name,
+			backButton: pg.backButton,
+			infoButton: pg.infoButton,
 			back: func() {
 				pg.clearForm()
 				common.changePage(PageWallet)

--- a/ui/statistics_page.go
+++ b/ui/statistics_page.go
@@ -23,6 +23,8 @@ type statPage struct {
 	startupTime time.Time
 	syncStatus  *wallet.SyncStatus
 	netType     string
+
+	backButton decredmaterial.IconButton
 }
 
 func StatPage(common *pageCommon) Page {
@@ -41,6 +43,8 @@ func StatPage(common *pageCommon) Page {
 	} else {
 		pg.netType = strings.Title(common.wallet.Net)
 	}
+
+	pg.backButton, _ = common.SubPageHeaderButtons()
 
 	return pg
 }
@@ -114,7 +118,8 @@ func (pg *statPage) layoutStats(gtx C) D {
 func (pg *statPage) Layout(gtx layout.Context) layout.Dimensions {
 	container := func(gtx C) D {
 		page := SubPage{
-			title: "Statistics",
+			title:      "Statistics",
+			backButton: pg.backButton,
 			back: func() {
 				pg.common.changePage(PageDebug)
 			},

--- a/ui/tickets_activity_page.go
+++ b/ui/tickets_activity_page.go
@@ -28,6 +28,8 @@ type ticketsActivityPage struct {
 	common             *pageCommon
 
 	wallets []*dcrlibwallet.Wallet
+
+	backButton decredmaterial.IconButton
 }
 
 func TicketActivityPage(c *pageCommon) Page {
@@ -50,6 +52,8 @@ func TicketActivityPage(c *pageCommon) Page {
 		{Text: "Revoked"},
 	}, 1)
 
+	pg.backButton, _ = c.SubPageHeaderButtons()
+
 	return pg
 }
 
@@ -62,7 +66,8 @@ func (pg *ticketsActivityPage) Layout(gtx layout.Context) layout.Dimensions {
 	c.createOrUpdateWalletDropDown(&pg.walletDropDown, pg.wallets)
 	body := func(gtx C) D {
 		page := SubPage{
-			title: "Ticket activity",
+			title:      "Ticket activity",
+			backButton: pg.backButton,
 			back: func() {
 				c.changePage(PageTickets)
 			},

--- a/ui/tickets_list_page.go
+++ b/ui/tickets_list_page.go
@@ -33,6 +33,8 @@ type ticketPageList struct {
 	statusTooltips     []*decredmaterial.Tooltip
 
 	wallets []*dcrlibwallet.Wallet
+
+	backButton decredmaterial.IconButton
 }
 
 func TicketPageList(c *pageCommon) Page {
@@ -46,6 +48,8 @@ func TicketPageList(c *pageCommon) Page {
 
 		wallets: c.multiWallet.AllWallets(),
 	}
+	pg.backButton, _ = c.SubPageHeaderButtons()
+
 	pg.orderDropDown = createOrderDropDown(c)
 	pg.ticketTypeDropDown = c.theme.DropDown([]decredmaterial.DropDownItem{
 		{Text: "All"},
@@ -72,7 +76,8 @@ func (pg *ticketPageList) Layout(gtx layout.Context) layout.Dimensions {
 
 	body := func(gtx C) D {
 		page := SubPage{
-			title: "All tickets",
+			title:      "All tickets",
+			backButton: pg.backButton,
 			back: func() {
 				c.changePage(PageTickets)
 			},

--- a/ui/transaction_details_page.go
+++ b/ui/transaction_details_page.go
@@ -30,6 +30,8 @@ type transactionDetailsPage struct {
 	toDcrdata                       *widget.Clickable
 	outputsCollapsible              *decredmaterial.Collapsible
 	inputsCollapsible               *decredmaterial.Collapsible
+	backButton                      decredmaterial.IconButton
+	infoButton                      decredmaterial.IconButton
 	gtx                             *layout.Context
 
 	transaction *dcrlibwallet.Transaction
@@ -64,6 +66,8 @@ func TransactionDetailsPage(common *pageCommon, transaction *dcrlibwallet.Transa
 		transaction: transaction,
 		wallet:      common.multiWallet.WalletWithID(transaction.WalletID),
 	}
+
+	pg.backButton, pg.infoButton = common.SubPageHeaderButtons()
 
 	pg.copyTextBtn = make([]decredmaterial.Button, 0)
 
@@ -108,7 +112,9 @@ func (pg *transactionDetailsPage) Layout(gtx layout.Context) layout.Dimensions {
 	}
 	body := func(gtx C) D {
 		page := SubPage{
-			title: dcrlibwallet.TransactionDirectionName(pg.transaction.Direction),
+			title:      dcrlibwallet.TransactionDirectionName(pg.transaction.Direction),
+			backButton: pg.backButton,
+			infoButton: pg.infoButton,
 			back: func() {
 				common.changePage(*common.returnPage)
 			},

--- a/ui/validate_address.go
+++ b/ui/validate_address.go
@@ -31,6 +31,8 @@ type validateAddressPage struct {
 	walletID              int
 	stateValidate         int
 	walletName            string
+
+	backButton decredmaterial.IconButton
 }
 
 func ValidateAddressPage(common *pageCommon) Page {
@@ -41,6 +43,8 @@ func ValidateAddressPage(common *pageCommon) Page {
 		wallet:      common.wallet,
 		common:      common,
 	}
+
+	pg.backButton, _ = common.SubPageHeaderButtons()
 
 	pg.addressEditor = common.theme.Editor(new(widget.Editor), "Address")
 	pg.addressEditor.IsRequired = false
@@ -68,7 +72,8 @@ func (pg *validateAddressPage) Layout(gtx layout.Context) layout.Dimensions {
 	pg.walletID = common.info.Wallets[*common.selectedWallet].ID
 	body := func(gtx C) D {
 		page := SubPage{
-			title: "Validate address",
+			title:      "Validate address",
+			backButton: pg.backButton,
 			back: func() {
 				common.changePage(*common.returnPage)
 			},

--- a/ui/verify_message_page.go
+++ b/ui/verify_message_page.go
@@ -21,6 +21,9 @@ type verifyMessagePage struct {
 	verifyMessage                         decredmaterial.Label
 
 	verifyMessageStatus *widget.Icon
+
+	backButton decredmaterial.IconButton
+	infoButton decredmaterial.IconButton
 }
 
 func VerifyMessagePage(c *pageCommon) Page {
@@ -40,6 +43,8 @@ func VerifyMessagePage(c *pageCommon) Page {
 	pg.verifyBtn.TextSize, pg.clearBtn.TextSize, pg.clearBtn.TextSize = values.TextSize14, values.TextSize14, values.TextSize14
 	pg.clearBtn.Background = color.NRGBA{0, 0, 0, 0}
 
+	pg.backButton, pg.infoButton = c.SubPageHeaderButtons()
+
 	return pg
 }
 
@@ -58,6 +63,8 @@ func (pg *verifyMessagePage) Layout(gtx layout.Context) layout.Dimensions {
 		load := SubPage{
 			title:      "Verify message",
 			walletName: walletName,
+			backButton: pg.backButton,
+			infoButton: pg.infoButton,
 			back: func() {
 				pg.clearInputs(c)
 				c.changePage(PageWallet)

--- a/ui/wallet_settings_page.go
+++ b/ui/wallet_settings_page.go
@@ -24,6 +24,7 @@ type walletSettingsPage struct {
 	errorReceiver chan error
 
 	chevronRightIcon *widget.Icon
+	backButton       decredmaterial.IconButton
 }
 
 func WalletSettingsPage(common *pageCommon) Page {
@@ -43,6 +44,7 @@ func WalletSettingsPage(common *pageCommon) Page {
 	}
 
 	pg.chevronRightIcon.Color = pg.theme.Color.LightGray
+	pg.backButton, _ = common.SubPageHeaderButtons()
 
 	return pg
 }
@@ -64,6 +66,7 @@ func (pg *walletSettingsPage) Layout(gtx layout.Context) layout.Dimensions {
 		page := SubPage{
 			title:      values.String(values.StrSettings),
 			walletName: common.info.Wallets[*common.selectedWallet].Name,
+			backButton: pg.backButton,
 			back: func() {
 				common.changePage(PageWallet)
 			},
@@ -80,7 +83,6 @@ func (pg *walletSettingsPage) Layout(gtx layout.Context) layout.Dimensions {
 					layout.Rigid(pg.dangerZone()),
 				)
 			},
-			infoTemplate: "",
 		}
 		return common.SubPageLayout(gtx, page)
 	}


### PR DESCRIPTION
This fixes a bug where the sub-page buttons of a page can be overwritten from another page when the page is changed.