### PR TITLE
Cleanup Wallet Page

### DIFF
--- a/ui/privacy_page.go
+++ b/ui/privacy_page.go
@@ -58,7 +58,7 @@ func (pg *privacyPage) Layout(gtx layout.Context) layout.Dimensions {
 	c := pg.common
 	d := func(gtx C) D {
 		load := SubPage{
-			title:      "Privacy",
+			title:      "StakeShuffle",
 			walletName: pg.wallet.Name,
 			backButton: pg.backButton,
 			infoButton: pg.infoButton,
@@ -178,9 +178,24 @@ func (pg *privacyPage) mixerInfoStatusTextLayout(gtx layout.Context, c *pageComm
 					c.icons.alertGray.Scale = 1.0
 					return c.icons.alertGray.Layout(gtx)
 				}),
-				layout.Rigid(subtxt.Layout),
+				layout.Rigid(func(gtx C) D {
+					return layout.Inset{Left: values.MarginPadding5}.Layout(gtx, subtxt.Layout)
+				}),
 			)
 		}),
+	)
+}
+
+func (pg *privacyPage) mixersubInfolayout(gtx layout.Context, c *pageCommon) layout.Dimensions {
+	txt := pg.theme.Body2("")
+
+	if pg.wallet.IsAccountMixerActive() {
+		txt = pg.theme.Body2("The mixer will automatically stop when unmixed balance are fully mixed.")
+		txt.Color = c.theme.Color.Gray
+	}
+
+	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+		layout.Rigid(txt.Layout),
 	)
 }
 
@@ -254,6 +269,13 @@ func (pg *privacyPage) mixerInfoLayout(gtx layout.Context, c *pageCommon) layout
 							)
 						})
 					})
+				}),
+				layout.Rigid(func(gtx C) D {
+					return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+						layout.Flexed(1, func(gtx C) D {
+							return pg.mixersubInfolayout(gtx, c)
+						}),
+					)
 				}),
 			)
 		})

--- a/ui/sign_message_page.go
+++ b/ui/sign_message_page.go
@@ -5,6 +5,7 @@ import (
 
 	"gioui.org/io/clipboard"
 	"gioui.org/layout"
+	"gioui.org/text"
 	"gioui.org/widget"
 
 	"github.com/planetdecred/dcrlibwallet"
@@ -40,6 +41,7 @@ func SignMessagePage(common *pageCommon, wallet *dcrlibwallet.Wallet) Page {
 	clearButton := common.theme.Button(new(widget.Clickable), "Clear all")
 	clearButton.Background = color.NRGBA{}
 	clearButton.Color = common.theme.Color.Gray
+	clearButton.Font.Weight = text.Bold
 	errorLabel := common.theme.Caption("")
 	errorLabel.Color = common.theme.Color.Danger
 	copyIcon := common.icons.copyIcon
@@ -67,6 +69,7 @@ func SignMessagePage(common *pageCommon, wallet *dcrlibwallet.Wallet) Page {
 
 	pg.signedMessageLabel.Color = common.theme.Color.Gray
 	pg.backButton, pg.infoButton = common.SubPageHeaderButtons()
+	pg.signButton.Font.Weight = text.Bold
 
 	return pg
 }
@@ -160,19 +163,23 @@ func (pg *signMessagePage) drawResult() layout.Widget {
 				return layout.Stack{}.Layout(gtx,
 					layout.Stacked(func(gtx C) D {
 						border := widget.Border{Color: pg.theme.Color.LightGray, CornerRadius: values.MarginPadding10, Width: values.MarginPadding2}
+						wrapper := pg.theme.Card()
+						wrapper.Color = pg.theme.Color.LightGray
 						return border.Layout(gtx, func(gtx C) D {
-							return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
-								return layout.Flex{}.Layout(gtx,
-									layout.Flexed(0.9, pg.signedMessageLabel.Layout),
-									layout.Flexed(0.1, func(gtx C) D {
-										return layout.E.Layout(gtx, func(gtx C) D {
-											return layout.Inset{Top: values.MarginPadding7}.Layout(gtx, func(gtx C) D {
-												pg.copyIcon.Scale = 1.0
-												return decredmaterial.Clickable(gtx, pg.copySignature, pg.copyIcon.Layout)
+							return wrapper.Layout(gtx, func(gtx C) D {
+								return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
+									return layout.Flex{}.Layout(gtx,
+										layout.Flexed(0.9, pg.signedMessageLabel.Layout),
+										layout.Flexed(0.1, func(gtx C) D {
+											return layout.E.Layout(gtx, func(gtx C) D {
+												return layout.Inset{Top: values.MarginPadding7}.Layout(gtx, func(gtx C) D {
+													pg.copyIcon.Scale = 1.0
+													return decredmaterial.Clickable(gtx, pg.copySignature, pg.copyIcon.Layout)
+												})
 											})
-										})
-									}),
-								)
+										}),
+									)
+								})
 							})
 						})
 					}),

--- a/ui/verify_message_page.go
+++ b/ui/verify_message_page.go
@@ -7,6 +7,7 @@ import (
 	"github.com/planetdecred/godcr/ui/values"
 
 	"gioui.org/layout"
+	"gioui.org/text"
 	"gioui.org/widget"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 )
@@ -42,6 +43,8 @@ func VerifyMessagePage(c *pageCommon) Page {
 	pg.signInput.Editor.Submit, pg.addressInput.Editor.Submit, pg.messageInput.Editor.Submit = true, true, true
 	pg.verifyBtn.TextSize, pg.clearBtn.TextSize, pg.clearBtn.TextSize = values.TextSize14, values.TextSize14, values.TextSize14
 	pg.clearBtn.Background = color.NRGBA{0, 0, 0, 0}
+	pg.verifyBtn.Font.Weight = text.Bold
+	pg.clearBtn.Font.Weight = text.Bold
 
 	pg.backButton, pg.infoButton = c.SubPageHeaderButtons()
 
@@ -155,14 +158,14 @@ func (pg *verifyMessagePage) handle() {
 			pg.verifyMessageStatus = nil
 			valid, err := c.wallet.VerifyMessage(pg.addressInput.Editor.Text(), pg.messageInput.Editor.Text(), pg.signInput.Editor.Text())
 			if err != nil {
-				pg.signInput.SetError("Invalid signature")
+				pg.signInput.SetError("Invalid signature or message")
 				return
 			}
 			pg.signInput.SetError("")
 
 			if !valid {
 				pg.verifyMessageStatus = c.icons.navigationCancel
-				pg.verifyMessage.Text = "Invalid signature"
+				pg.verifyMessage.Text = "Invalid signature or message"
 				pg.verifyMessage.Color = c.theme.Color.Danger
 				return
 			}

--- a/ui/wallet_page.go
+++ b/ui/wallet_page.go
@@ -212,7 +212,6 @@ func (pg *walletPage) getWalletMenu(wal *dcrlibwallet.Wallet) []menuItem {
 			button:   new(widget.Clickable),
 			separate: true,
 			action: func(common *pageCommon) {
-				common.changeFragment(HelpPage(common), PageHelp)
 			},
 		},
 		{


### PR DESCRIPTION
Resolves #485 
This PR implements:

- Use bold for “clear all” and “Sign message” button texts on Sign Message Page and Verify Message page
- use grey background for signature text
- remove navigation to help page when View property is clicked on wallets page 
- change page title to StakeShuffle on privacy page 
- add margin left to "keep this app opened" text on StakeShuffle page 
- add message stating “The mixer will automatically stop when unmixed balance are fully mixed.” on StakeShuffle page.