### PR TITLE
adds clickable link to help page

### DIFF
--- a/ui/help_page.go
+++ b/ui/help_page.go
@@ -92,5 +92,9 @@ func (pg *helpPage) pageSections(gtx layout.Context, icon *widget.Image, action 
 	})
 }
 
-func (pg *helpPage) handle()  {}
+func (pg *helpPage) handle() {
+	if pg.documentation.Clicked() {
+		goToURL("https://docs.decred.org")
+	}
+}
 func (pg *helpPage) onClose() {}


### PR DESCRIPTION

Resolves #500 

This PR resolves;

- Clicking on the documentation button now redirects to the official decred docs website (https://docs.planetdecred.org)