### PR TITLE
Add a license page 

### DIFF
--- a/ui/about_page.go
+++ b/ui/about_page.go
@@ -23,6 +23,7 @@ type aboutPage struct {
 	network        decredmaterial.Label
 	networkValue   decredmaterial.Label
 	license        decredmaterial.Label
+	licenseRow     *widget.Clickable
 
 	chevronRightIcon *widget.Icon
 
@@ -42,6 +43,7 @@ func AboutPage(common *pageCommon) Page {
 		network:          common.theme.Body1("Network"),
 		networkValue:     common.theme.Body1(common.wallet.Net),
 		license:          common.theme.Body1("License"),
+		licenseRow:       new(widget.Clickable),
 		chevronRightIcon: common.icons.chevronRight,
 	}
 
@@ -90,8 +92,15 @@ func (pg *aboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 			return endToEndRow(gtx, pg.network.Layout, pg.networkValue.Layout)
 		},
 		func(gtx C) D {
-			return endToEndRow(gtx, pg.license.Layout, func(gtx C) D {
-				return pg.chevronRightIcon.Layout(gtx, values.MarginPadding20)
+			return decredmaterial.Clickable(gtx, pg.licenseRow, func(gtx C) D {
+				return layout.Flex{}.Layout(gtx,
+					layout.Rigid(pg.license.Layout),
+					layout.Flexed(1, func(gtx C) D {
+						return layout.E.Layout(gtx, func(gtx C) D {
+							return pg.chevronRightIcon.Layout(gtx, values.MarginPadding20)
+						})
+					}),
+				)
 			})
 		},
 	}
@@ -122,5 +131,9 @@ func (pg *aboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 	})
 }
 
-func (pg *aboutPage) handle()  {}
+func (pg *aboutPage) handle() {
+	if pg.licenseRow.Clicked() {
+		pg.common.changeFragment(LicensePage(pg.common), PageLicense)
+	}
+}
 func (pg *aboutPage) onClose() {}

--- a/ui/license_page.go
+++ b/ui/license_page.go
@@ -1,0 +1,77 @@
+package ui
+
+import (
+	"gioui.org/layout"
+	"github.com/planetdecred/godcr/ui/decredmaterial"
+	"github.com/planetdecred/godcr/ui/values"
+)
+
+const PageLicense = "License"
+
+const License = `ISC License
+
+Copyright (c) 2018-2021, Raedah Group
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.`
+
+type licensePage struct {
+	common        *pageCommon
+	pageContainer layout.List
+
+	backButton decredmaterial.IconButton
+}
+
+func LicensePage(common *pageCommon) Page {
+	pg := &licensePage{
+		common:        common,
+		pageContainer: layout.List{Axis: layout.Vertical},
+	}
+	pg.backButton, _ = common.SubPageHeaderButtons()
+
+	return pg
+}
+
+func (pg *licensePage) OnResume() {
+
+}
+
+//main page layout
+func (pg *licensePage) Layout(gtx layout.Context) layout.Dimensions {
+	common := pg.common
+	d := func(gtx C) D {
+		page := SubPage{
+			title:      "License",
+			backButton: pg.backButton,
+			back: func() {
+				pg.common.changePage(PageAbout)
+			},
+			body: func(gtx C) D {
+				return common.theme.Card().Layout(gtx, func(gtx C) D {
+					return layout.UniformInset(values.MarginPadding25).Layout(gtx, func(gtx C) D {
+						licenseText := common.theme.Body1(License)
+						licenseText.Color = common.theme.Color.Gray
+						return layout.Inset{Bottom: values.MarginPadding20}.Layout(gtx, licenseText.Layout)
+					})
+				})
+			},
+		}
+		return common.SubPageLayout(gtx, page)
+	}
+	return common.UniformPadding(gtx, d)
+}
+
+func (pg *licensePage) handle() {
+
+}
+
+func (pg *licensePage) onClose() {}


### PR DESCRIPTION
Implements #499 
This PR implements the following:

- Add a license page 
- Make the license row clickable on the about page 
- Change current page to license page when license row is clicked on the about page 