### PR TITLE
Show status for pending transactions

### DIFF
--- a/ui/page/transaction_details_page.go
+++ b/ui/page/transaction_details_page.go
@@ -201,8 +201,8 @@ func (pg *TransactionDetailsPage) txnBalanceAndStatus(gtx layout.Context) layout
 						return layout.Flex{}.Layout(gtx,
 							layout.Rigid(func(gtx C) D {
 								return layout.Inset{
-									Right: values.MarginPadding5,
-									Top:   values.MarginPadding2,
+									Right: values.MarginPadding4,
+									Top:   values.MarginPadding4,
 								}.Layout(gtx, txnWidgets.statusIcon.Layout)
 							}),
 							layout.Rigid(func(gtx layout.Context) layout.Dimensions {
@@ -211,6 +211,7 @@ func (pg *TransactionDetailsPage) txnBalanceAndStatus(gtx layout.Context) layout
 									txt.Text = strings.Title("confirmed")
 									txt.Color = pg.Theme.Color.Success
 								} else {
+									txt.Text = strings.Title("pending")
 									txt.Color = pg.Theme.Color.Gray
 								}
 								return txt.Layout(gtx)


### PR DESCRIPTION
Fixes #523 
This PR fixes status of pending transactions not showing up on the transaction details page and also corrects the layout of the trasaction status icon so that it is in line with the transaction status as shown below:
![125679743-f604425c-1814-460b-944d-ae735890a5ef](https://user-images.githubusercontent.com/66803475/125701825-86753ad6-df20-4079-bbf2-0d3d61352c94.png)

Below is the an image showing the "Pending" label when a transaction is pending
![Screenshot from 2021-07-16 22-03-56](https://user-images.githubusercontent.com/66803475/126008600-239630e4-d132-44c5-8a5a-3ef1d06e3755.png)

