### PR TITLE
Update radio button to be dark mode friendly in several modals

### DIFF
--- a/ui/decredmaterial/radiobutton.go
+++ b/ui/decredmaterial/radiobutton.go
@@ -3,6 +3,8 @@
 package decredmaterial
 
 import (
+	"image/color"
+
 	"gioui.org/widget"
 	"gioui.org/widget/material"
 )
@@ -13,6 +15,8 @@ type RadioButton struct {
 
 // RadioButton returns a RadioButton with a label. The key specifies
 // the value for the Enum.
-func (t *Theme) RadioButton(group *widget.Enum, key, label string) RadioButton {
-	return RadioButton{material.RadioButton(t.Base, group, key, label)}
+func (t *Theme) RadioButton(group *widget.Enum, key, label string, color color.NRGBA) RadioButton {
+	rb := RadioButton{material.RadioButton(t.Base, group, key, label)}
+	rb.Color = color
+	return rb
 }

--- a/ui/preference/list_preference.go
+++ b/ui/preference/list_preference.go
@@ -162,7 +162,7 @@ func (lp *ListPreference) layoutItems() []layout.FlexChild {
 
 	items := make([]layout.FlexChild, 0)
 	for _, k := range lp.itemKeys {
-		radioItem := layout.Rigid(lp.theme.RadioButton(lp.optionsRadioGroup, k, values.String(lp.items[k])).Layout)
+		radioItem := layout.Rigid(lp.theme.RadioButton(lp.optionsRadioGroup, k, values.String(lp.items[k]), lp.theme.Color.DeepBlue).Layout)
 
 		items = append(items, radioItem)
 	}

--- a/ui/test/testapp.go
+++ b/ui/test/testapp.go
@@ -151,7 +151,7 @@ func (t *TestStruct) initWidgets() {
 	t.customEditorOutput.test2btn = theme.Button(new(widget.Clickable), "Text2")
 	t.customEditorOutput.test3btn = theme.Button(new(widget.Clickable), "Text3")
 	t.customEditorOutput.test4btn = theme.Button(new(widget.Clickable), "Text4")
-	t.customEditorOutput.radiobtn = theme.RadioButton(new(widget.Enum), "btn1", "test radio button")
+	t.customEditorOutput.radiobtn = theme.RadioButton(new(widget.Enum), "btn1", "test radio button", theme.Color.DeepBlue)
 	t.customEditorOutput.checkbox = theme.CheckBox(new(widget.Bool), "test checkbox")
 	t.customEditorOutput.progressBar = theme.ProgressBar(60)
 	t.customEditorOutput.outline = theme.Outline()


### PR DESCRIPTION
This PR resolves #456

It allows radio button to be dark mode friendly in several modals includes:
- language preference modal in setting page.
- currency preference modal in setting page.