### PR TITLE
Add deduction prefix to sent transaction amount

### DIFF
--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -174,7 +174,11 @@ func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow) 
 									return layout.Inset{Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
 										return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 											layout.Rigid(func(gtx C) D {
-												return LayoutBalance(gtx, l, dcrutil.Amount(row.Transaction.Amount).String())
+												amount := dcrutil.Amount(row.Transaction.Amount).String()
+												if row.Transaction.Direction == dcrlibwallet.TxDirectionSent {
+													amount = "-" + amount
+												}
+												return LayoutBalance(gtx, l, amount)
 											}),
 											layout.Rigid(func(gtx C) D {
 												if row.ShowBadge {

--- a/ui/page/transaction_details_page.go
+++ b/ui/page/transaction_details_page.go
@@ -187,7 +187,11 @@ func (pg *TransactionDetailsPage) txnBalanceAndStatus(gtx layout.Context) layout
 						amount := strings.Split(dcrutil.Amount(pg.transaction.Amount).String(), " ")
 						return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Baseline}.Layout(gtx,
 							layout.Rigid(func(gtx C) D {
-								return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, pg.Theme.H4(amount[0]).Layout)
+								amt := amount[0]
+								if pg.transaction.Direction == dcrlibwallet.TxDirectionSent {
+									amt = "-" + amt
+								}
+								return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, pg.Theme.H4(amt).Layout)
 							}),
 							layout.Rigid(pg.Theme.H6(amount[1]).Layout),
 						)


### PR DESCRIPTION
This PR implements #554 
It adds the "-" prefix to the sent transaction amount on transaction details page, transactions page and overview page as seen below:

Transactions Details Page:
![txn details](https://user-images.githubusercontent.com/66803475/129601845-9e56782c-43fc-44dd-b2cc-0b3f3e657862.png)

Transactions page:
![txn](https://user-images.githubusercontent.com/66803475/129601878-dd399a2b-0d8b-4eb4-99a2-24b3b57db81a.png)


Overview page:
![overview](https://user-images.githubusercontent.com/66803475/129601906-782bb7cd-1644-4b3d-a8b8-52427b4d311a.png)
