### PR TITLE
Fix transaction row highlight when pressed

### DIFF
--- a/ui/decredmaterial/linearlayout.go
+++ b/ui/decredmaterial/linearlayout.go
@@ -25,6 +25,7 @@ type LinearLayout struct {
 	Direction   layout.Direction
 }
 
+// Layout2 displays a linear layout with a single child.
 func (ll LinearLayout) Layout2(gtx C, wdg layout.Widget) D {
 	return ll.Layout(gtx, layout.Rigid(wdg))
 }

--- a/ui/decredmaterial/linearlayout.go
+++ b/ui/decredmaterial/linearlayout.go
@@ -25,6 +25,10 @@ type LinearLayout struct {
 	Direction   layout.Direction
 }
 
+func (ll LinearLayout) Layout2(gtx C, wdg layout.Widget) D {
+	return ll.Layout(gtx, layout.Rigid(wdg))
+}
+
 func (ll LinearLayout) Layout(gtx C, children ...layout.FlexChild) D {
 	// draw margin
 	return ll.Margin.Layout(gtx, func(gtx C) D {

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"gioui.org/layout"
-	"gioui.org/text"
 	"gioui.org/unit"
 
 	"github.com/ararog/timeago"
@@ -117,19 +116,11 @@ func LayoutBalance(gtx layout.Context, l *load.Load, amount string) layout.Dimen
 // direction, balance, status.
 func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow) layout.Dimensions {
 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
-	directionIconTopMargin := values.MarginPadding16
-
-	if row.Index == 0 && row.ShowBadge {
-		directionIconTopMargin = values.MarginPadding14
-	} else if row.Index == 0 {
-		// todo: remove top margin from container
-		directionIconTopMargin = values.MarginPadding0
-	}
 
 	wal := l.WL.MultiWallet.WalletWithID(row.Transaction.WalletID)
 
-	return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-		return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+	return layout.Inset{Top: values.MarginPadding16, Bottom: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
+		return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
 				icon := l.Icons.ReceiveIcon
 				if row.Transaction.Direction == dcrlibwallet.TxDirectionSent {
@@ -137,90 +128,56 @@ func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow) 
 				}
 				icon.Scale = 1.0
 
-				return layout.Inset{Top: directionIconTopMargin}.Layout(gtx, func(gtx C) D {
-					return icon.Layout(gtx)
-				})
+				return icon.Layout(gtx)
 			}),
 			layout.Rigid(func(gtx C) D {
-				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
-						if row.Index == 0 {
-							return layout.Dimensions{}
-						}
-						gtx.Constraints.Min.X = gtx.Constraints.Max.X
-						separator := l.Theme.Separator()
-						separator.Width = gtx.Constraints.Max.X - gtx.Px(unit.Dp(16))
-						return layout.E.Layout(gtx, func(gtx C) D {
-							// Todo: add comment
-							marginBottom := values.MarginPadding16
-							if row.ShowBadge {
-								marginBottom = values.MarginPadding5
+				return layout.Inset{Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
+					return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							amount := dcrutil.Amount(row.Transaction.Amount).String()
+							if row.Transaction.Direction == dcrlibwallet.TxDirectionSent {
+								amount = "-" + amount
 							}
-							return layout.Inset{Bottom: marginBottom}.Layout(gtx,
-								func(gtx C) D {
-									return separator.Layout(gtx)
-								})
-						})
+							return LayoutBalance(gtx, l, amount)
+						}),
+						layout.Rigid(func(gtx C) D {
+							if row.ShowBadge {
+								return WalletLabel(gtx, l, wal.Name)
+							}
+							return layout.Dimensions{}
+						}),
+					)
+				})
+			}),
+			layout.Flexed(1, func(gtx C) D {
+				return layout.Flex{
+					Axis:      layout.Horizontal,
+					Spacing:   layout.SpaceStart,
+					Alignment: layout.Middle,
+				}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
+							func(gtx C) D {
+								status := l.Theme.Body1("pending")
+								if TxConfirmations(l, row.Transaction) <= 1 {
+									status.Color = l.Theme.Color.Gray5
+								} else {
+									status.Color = l.Theme.Color.Gray4
+									status.Text = FormatDateOrTime(row.Transaction.Timestamp)
+								}
+								return status.Layout(gtx)
+							})
 					}),
-					layout.Rigid(func(gtx layout.Context) layout.Dimensions {
-						gtx.Constraints.Min.X = gtx.Constraints.Max.X
-						return layout.Inset{}.Layout(gtx, func(gtx C) D {
-							return layout.Flex{
-								Axis:      layout.Horizontal,
-								Spacing:   layout.SpaceBetween,
-								Alignment: layout.Middle,
-							}.Layout(gtx,
-								layout.Rigid(func(gtx C) D {
-									return layout.Inset{Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-										return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-											layout.Rigid(func(gtx C) D {
-												amount := dcrutil.Amount(row.Transaction.Amount).String()
-												if row.Transaction.Direction == dcrlibwallet.TxDirectionSent {
-													amount = "-" + amount
-												}
-												return LayoutBalance(gtx, l, amount)
-											}),
-											layout.Rigid(func(gtx C) D {
-												if row.ShowBadge {
-													return WalletLabel(gtx, l, wal.Name)
-												}
-												return layout.Dimensions{}
-											}),
-										)
-									})
-								}),
-								layout.Rigid(func(gtx C) D {
-									return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
-										layout.Rigid(func(gtx C) D {
-											return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
-												func(gtx C) D {
-													status := l.Theme.Body1("pending")
-													if TxConfirmations(l, row.Transaction) <= 1 {
-														status.Color = l.Theme.Color.Gray5
-													} else {
-														status.Color = l.Theme.Color.Gray4
-														status.Text = FormatDateOrTime(row.Transaction.Timestamp)
-													}
-													status.Alignment = text.Middle
-													return status.Layout(gtx)
-												})
-										}),
-										layout.Rigid(func(gtx C) D {
-											return layout.Inset{Right: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-												statusIcon := l.Icons.ConfirmIcon
-												if TxConfirmations(l, row.Transaction) <= 1 {
-													statusIcon = l.Icons.PendingIcon
-												}
-												statusIcon.Scale = 1.0
-												return statusIcon.Layout(gtx)
-											})
-										}),
-									)
-								}),
-							)
+					layout.Rigid(func(gtx C) D {
+						return layout.Inset{Right: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
+							statusIcon := l.Icons.ConfirmIcon
+							if TxConfirmations(l, row.Transaction) <= 1 {
+								statusIcon = l.Icons.PendingIcon
+							}
+							statusIcon.Scale = 1.0
+							return statusIcon.Layout(gtx)
 						})
-					}),
-				)
+					}))
 			}),
 		)
 	})

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -119,68 +119,77 @@ func LayoutTransactionRow(gtx layout.Context, l *load.Load, row TransactionRow) 
 
 	wal := l.WL.MultiWallet.WalletWithID(row.Transaction.WalletID)
 
-	return layout.Inset{Top: values.MarginPadding16, Bottom: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-		return layout.Flex{Axis: layout.Horizontal, Alignment: layout.Middle}.Layout(gtx,
-			layout.Rigid(func(gtx C) D {
-				icon := l.Icons.ReceiveIcon
-				if row.Transaction.Direction == dcrlibwallet.TxDirectionSent {
-					icon = l.Icons.SendIcon
-				}
-				icon.Scale = 1.0
+	return decredmaterial.LinearLayout{
+		Orientation: layout.Horizontal,
+		Width:       decredmaterial.MatchParent,
+		Height:      gtx.Px(values.MarginPadding56),
+		Direction:   layout.W,
+		Padding:     layout.Inset{Left: values.MarginPadding16, Right: values.MarginPadding16},
+	}.Layout(gtx,
+		layout.Rigid(func(gtx C) D {
+			gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
+			icon := l.Icons.ReceiveIcon
+			if row.Transaction.Direction == dcrlibwallet.TxDirectionSent {
+				icon = l.Icons.SendIcon
+			}
+			icon.Scale = 1.0
 
-				return icon.Layout(gtx)
-			}),
-			layout.Rigid(func(gtx C) D {
-				return layout.Inset{Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-					return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-						layout.Rigid(func(gtx C) D {
-							amount := dcrutil.Amount(row.Transaction.Amount).String()
-							if row.Transaction.Direction == dcrlibwallet.TxDirectionSent {
-								amount = "-" + amount
-							}
-							return LayoutBalance(gtx, l, amount)
-						}),
-						layout.Rigid(func(gtx C) D {
-							if row.ShowBadge {
-								return WalletLabel(gtx, l, wal.Name)
-							}
-							return layout.Dimensions{}
-						}),
-					)
-				})
-			}),
-			layout.Flexed(1, func(gtx C) D {
-				return layout.Flex{
-					Axis:      layout.Horizontal,
-					Spacing:   layout.SpaceStart,
-					Alignment: layout.Middle,
-				}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
-						return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
-							func(gtx C) D {
-								status := l.Theme.Body1("pending")
-								if TxConfirmations(l, row.Transaction) <= 1 {
-									status.Color = l.Theme.Color.Gray5
-								} else {
-									status.Color = l.Theme.Color.Gray4
-									status.Text = FormatDateOrTime(row.Transaction.Timestamp)
-								}
-								return status.Layout(gtx)
-							})
-					}),
-					layout.Rigid(func(gtx C) D {
-						return layout.Inset{Right: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-							statusIcon := l.Icons.ConfirmIcon
+			return layout.W.Layout(gtx, icon.Layout)
+		}),
+		layout.Rigid(func(gtx C) D {
+			return decredmaterial.LinearLayout{
+				Width:       decredmaterial.WrapContent,
+				Height:      decredmaterial.MatchParent,
+				Orientation: layout.Vertical,
+				Padding:     layout.Inset{Left: values.MarginPadding16},
+				Direction:   layout.W,
+			}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					amount := dcrutil.Amount(row.Transaction.Amount).String()
+					if row.Transaction.Direction == dcrlibwallet.TxDirectionSent {
+						amount = "-" + amount
+					}
+					return LayoutBalance(gtx, l, amount)
+				}),
+				layout.Rigid(func(gtx C) D {
+					if row.ShowBadge {
+						return WalletLabel(gtx, l, wal.Name)
+					}
+					return layout.Dimensions{}
+				}),
+			)
+		}),
+		layout.Flexed(1, func(gtx C) D {
+			return layout.Flex{
+				Axis:      layout.Horizontal,
+				Spacing:   layout.SpaceStart,
+				Alignment: layout.Middle,
+			}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
+						func(gtx C) D {
+							gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
+							status := l.Theme.Body1("pending")
 							if TxConfirmations(l, row.Transaction) <= 1 {
-								statusIcon = l.Icons.PendingIcon
+								status.Color = l.Theme.Color.Gray5
+							} else {
+								status.Color = l.Theme.Color.Gray4
+								status.Text = FormatDateOrTime(row.Transaction.Timestamp)
 							}
-							statusIcon.Scale = 1.0
-							return statusIcon.Layout(gtx)
+							return layout.E.Layout(gtx, status.Layout)
 						})
-					}))
-			}),
-		)
-	})
+				}),
+				layout.Rigid(func(gtx C) D {
+					gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
+					statusIcon := l.Icons.ConfirmIcon
+					if TxConfirmations(l, row.Transaction) <= 1 {
+						statusIcon = l.Icons.PendingIcon
+					}
+					statusIcon.Scale = 1.0
+					return layout.E.Layout(gtx, statusIcon.Layout)
+				}))
+		}),
+	)
 }
 
 func TxConfirmations(l *load.Load, transaction dcrlibwallet.Transaction) int32 {

--- a/ui/page/overview_page.go
+++ b/ui/page/overview_page.go
@@ -8,7 +8,6 @@ import (
 
 	"gioui.org/io/event"
 	"gioui.org/layout"
-	"gioui.org/unit"
 	"gioui.org/widget"
 
 	"github.com/planetdecred/dcrlibwallet"
@@ -211,27 +210,24 @@ func (pg *OverviewPage) recentTransactionsSection(gtx layout.Context) layout.Dim
 							ShowBadge:   len(pg.allWallets) > 1,
 						}
 
-						return layout.Inset{Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-							return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-								layout.Rigid(func(gtx C) D {
-									return components.LayoutTransactionRow(gtx, pg.Load, row)
-								}),
-								layout.Rigid(func(gtx C) D {
-									// No divider for last row
-									if row.Index == len(pg.transactions)-1 {
-										return layout.Dimensions{}
-									}
+						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								return components.LayoutTransactionRow(gtx, pg.Load, row)
+							}),
+							layout.Rigid(func(gtx C) D {
+								// No divider for last row
+								if row.Index == len(pg.transactions)-1 {
+									return layout.Dimensions{}
+								}
 
-									gtx.Constraints.Min.X = gtx.Constraints.Max.X
-									separator := pg.Theme.Separator()
-									separator.Width = gtx.Constraints.Max.X - gtx.Px(unit.Dp(16))
-									return layout.E.Layout(gtx, func(gtx C) D {
-										// Show bottom divider for all rows except last
-										return separator.Layout(gtx)
-									})
-								}),
-							)
-						})
+								gtx.Constraints.Min.X = gtx.Constraints.Max.X
+								separator := pg.Theme.Separator()
+								return layout.E.Layout(gtx, func(gtx C) D {
+									// Show bottom divider for all rows except last
+									return layout.Inset{Left: values.MarginPadding56}.Layout(gtx, separator.Layout)
+								})
+							}),
+						)
 					})
 				}),
 			)

--- a/ui/page/overview_page.go
+++ b/ui/page/overview_page.go
@@ -8,6 +8,7 @@ import (
 
 	"gioui.org/io/event"
 	"gioui.org/layout"
+	"gioui.org/unit"
 	"gioui.org/widget"
 
 	"github.com/planetdecred/dcrlibwallet"
@@ -182,7 +183,7 @@ func (pg *OverviewPage) syncDetail(name, status, headersFetched, progress string
 func (pg *OverviewPage) recentTransactionsSection(gtx layout.Context) layout.Dimensions {
 	return pg.Theme.Card().Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 		padding := values.MarginPadding15
-		return components.Container{Padding: layout.Inset{Top: padding, Bottom: padding}}.Layout(gtx, func(gtx C) D {
+		return components.Container{Padding: layout.Inset{Top: padding}}.Layout(gtx, func(gtx C) D {
 			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
 					title := pg.Theme.Body2(values.String(values.StrRecentTransactions))
@@ -197,8 +198,8 @@ func (pg *OverviewPage) recentTransactionsSection(gtx layout.Context) layout.Dim
 						message := pg.Theme.Body1(values.String(values.StrNoTransactionsYet))
 						message.Color = pg.Theme.Color.Gray2
 						return components.Container{Padding: layout.Inset{
-							Left:   values.MarginPadding16,
-							Bottom: values.MarginPadding3,
+							Left:   values.MarginPadding18,
+							Bottom: values.MarginPadding16,
 							Top:    values.MarginPadding18,
 						}}.Layout(gtx, message.Layout)
 					}
@@ -209,8 +210,27 @@ func (pg *OverviewPage) recentTransactionsSection(gtx layout.Context) layout.Dim
 							Index:       i,
 							ShowBadge:   len(pg.allWallets) > 1,
 						}
+
 						return layout.Inset{Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-							return components.LayoutTransactionRow(gtx, pg.Load, row)
+							return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+								layout.Rigid(func(gtx C) D {
+									return components.LayoutTransactionRow(gtx, pg.Load, row)
+								}),
+								layout.Rigid(func(gtx C) D {
+									// No divider for last row
+									if row.Index == len(pg.transactions)-1 {
+										return layout.Dimensions{}
+									}
+
+									gtx.Constraints.Min.X = gtx.Constraints.Max.X
+									separator := pg.Theme.Separator()
+									separator.Width = gtx.Constraints.Max.X - gtx.Px(unit.Dp(16))
+									return layout.E.Layout(gtx, func(gtx C) D {
+										// Show bottom divider for all rows except last
+										return separator.Layout(gtx)
+									})
+								}),
+							)
 						})
 					})
 				}),

--- a/ui/page/transactions_page.go
+++ b/ui/page/transactions_page.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gioui.org/layout"
+	"gioui.org/unit"
 	"gioui.org/widget"
 
 	"github.com/planetdecred/dcrlibwallet"
@@ -116,25 +117,45 @@ func (pg *TransactionsPage) Layout(gtx layout.Context) layout.Dimensions {
 				}.Layout(gtx, func(gtx C) D {
 					return pg.Theme.Card().Layout(gtx, func(gtx C) D {
 						padding := values.MarginPadding16
-						return components.Container{Padding: layout.Inset{Bottom: padding, Left: padding}}.Layout(gtx,
-							func(gtx C) D {
-								// return "No transactions yet" text if there are no transactions
-								if len(wallTxs) == 0 {
-									gtx.Constraints.Min.X = gtx.Constraints.Max.X
-									txt := pg.Theme.Body1(values.String(values.StrNoTransactionsYet))
-									txt.Color = pg.Theme.Color.Gray2
-									return layout.Center.Layout(gtx, txt.Layout)
-								}
-
-								return pg.transactionList.Layout(gtx, len(wallTxs), func(gtx C, index int) D {
-									var row = components.TransactionRow{
-										Transaction: wallTxs[index],
-										Index:       index,
-										ShowBadge:   false,
-									}
-									return components.LayoutTransactionRow(gtx, pg.Load, row)
-								})
+						// return "No transactions yet" text if there are no transactions
+						if len(wallTxs) == 0 {
+							gtx.Constraints.Min.X = gtx.Constraints.Max.X
+							txt := pg.Theme.Body1(values.String(values.StrNoTransactionsYet))
+							txt.Color = pg.Theme.Color.Gray2
+							return layout.Center.Layout(gtx, func(gtx C) D {
+								return layout.Inset{Top: padding, Bottom: padding}.Layout(gtx, txt.Layout)
 							})
+						}
+
+						return pg.transactionList.Layout(gtx, len(wallTxs), func(gtx C, index int) D {
+							var row = components.TransactionRow{
+								Transaction: wallTxs[index],
+								Index:       index,
+								ShowBadge:   false,
+							}
+
+							return layout.Inset{Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
+								return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										return components.LayoutTransactionRow(gtx, pg.Load, row)
+									}),
+									layout.Rigid(func(gtx C) D {
+										// No divider for last row
+										if row.Index == len(wallTxs)-1 {
+											return layout.Dimensions{}
+										}
+
+										gtx.Constraints.Min.X = gtx.Constraints.Max.X
+										separator := pg.Theme.Separator()
+										separator.Width = gtx.Constraints.Max.X - gtx.Px(unit.Dp(16))
+										return layout.E.Layout(gtx, func(gtx C) D {
+											// Show bottom divider for all rows except last
+											return separator.Layout(gtx)
+										})
+									}),
+								)
+							})
+						})
 					})
 				})
 			}),

--- a/ui/page/transactions_page.go
+++ b/ui/page/transactions_page.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"gioui.org/layout"
-	"gioui.org/unit"
 	"gioui.org/widget"
 
 	"github.com/planetdecred/dcrlibwallet"
@@ -116,9 +115,10 @@ func (pg *TransactionsPage) Layout(gtx layout.Context) layout.Dimensions {
 					Top: values.MarginPadding60,
 				}.Layout(gtx, func(gtx C) D {
 					return pg.Theme.Card().Layout(gtx, func(gtx C) D {
-						padding := values.MarginPadding16
+
 						// return "No transactions yet" text if there are no transactions
 						if len(wallTxs) == 0 {
+							padding := values.MarginPadding16
 							gtx.Constraints.Min.X = gtx.Constraints.Max.X
 							txt := pg.Theme.Body1(values.String(values.StrNoTransactionsYet))
 							txt.Color = pg.Theme.Color.Gray2
@@ -134,27 +134,24 @@ func (pg *TransactionsPage) Layout(gtx layout.Context) layout.Dimensions {
 								ShowBadge:   false,
 							}
 
-							return layout.Inset{Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-								return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-									layout.Rigid(func(gtx C) D {
-										return components.LayoutTransactionRow(gtx, pg.Load, row)
-									}),
-									layout.Rigid(func(gtx C) D {
-										// No divider for last row
-										if row.Index == len(wallTxs)-1 {
-											return layout.Dimensions{}
-										}
+							return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+								layout.Rigid(func(gtx C) D {
+									return components.LayoutTransactionRow(gtx, pg.Load, row)
+								}),
+								layout.Rigid(func(gtx C) D {
+									// No divider for last row
+									if row.Index == len(wallTxs)-1 {
+										return layout.Dimensions{}
+									}
 
-										gtx.Constraints.Min.X = gtx.Constraints.Max.X
-										separator := pg.Theme.Separator()
-										separator.Width = gtx.Constraints.Max.X - gtx.Px(unit.Dp(16))
-										return layout.E.Layout(gtx, func(gtx C) D {
-											// Show bottom divider for all rows except last
-											return separator.Layout(gtx)
-										})
-									}),
-								)
-							})
+									gtx.Constraints.Min.X = gtx.Constraints.Max.X
+									separator := pg.Theme.Separator()
+									return layout.E.Layout(gtx, func(gtx C) D {
+										// Show bottom divider for all rows except last
+										return layout.Inset{Left: values.MarginPadding56}.Layout(gtx, separator.Layout)
+									})
+								}),
+							)
 						})
 					})
 				})


### PR DESCRIPTION

The transaction row does not highlight the proper areas when pressed, this pr fixes the bug.
Before changes:
<img src="https://user-images.githubusercontent.com/19960200/129628412-29d871da-e51e-4204-a3aa-1cdc1b88b2bc.png" height="600">

After after:

<img src="https://user-images.githubusercontent.com/19960200/130363915-ef63a514-a013-4ee2-ac04-616ff015d678.png" height="600">
<img src="https://user-images.githubusercontent.com/19960200/130363918-b949ed29-474e-4cda-8f14-3f30af045714.png" height="600">