### PR TITLE
Fix cpu usage spike in some pages caused by an infinite loop

### DIFF
--- a/ui/page/overview_page.go
+++ b/ui/page/overview_page.go
@@ -613,10 +613,8 @@ func (pg *OverviewPage) listenForSyncNotifications() {
 
 			select {
 			case notification = <-pg.Receiver.NotificationsUpdate:
-			default:
-				if components.ContextDone(pg.ctx) {
-					return
-				}
+			case <-pg.ctx.Done():
+				return
 			}
 
 			switch n := notification.(type) {

--- a/ui/page/proposal/proposal_details_page.go
+++ b/ui/page/proposal/proposal_details_page.go
@@ -125,10 +125,8 @@ func (pg *proposalDetails) listenForSyncNotifications() {
 
 			select {
 			case notification = <-pg.Receiver.NotificationsUpdate:
-			default:
-				if components.ContextDone(pg.ctx) {
-					return
-				}
+			case <-pg.ctx.Done():
+				return
 			}
 
 			switch n := notification.(type) {

--- a/ui/page/proposal/proposals_page.go
+++ b/ui/page/proposal/proposals_page.go
@@ -199,10 +199,8 @@ func (pg *ProposalsPage) listenForSyncNotifications() {
 
 			select {
 			case notification = <-pg.Receiver.NotificationsUpdate:
-			default:
-				if components.ContextDone(pg.ctx) {
-					return
-				}
+			case <-pg.ctx.Done():
+				return
 			}
 
 			switch n := notification.(type) {

--- a/ui/page/transactions_page.go
+++ b/ui/page/transactions_page.go
@@ -194,10 +194,8 @@ func (pg *TransactionsPage) listenForTxNotifications() {
 
 			select {
 			case notification = <-pg.Receiver.NotificationsUpdate:
-			default:
-				if components.ContextDone(pg.ctx) {
-					return
-				}
+			case <-pg.ctx.Done():
+				return
 			}
 
 			switch n := notification.(type) {


### PR DESCRIPTION
CPU usage % goes up to about 150-200% when in pages that listen for sync notifications and it's caused by an infinite loop in the `listenForSyncNotifications` function, this pr fixes that.