### PR TITLE
Fix entire license row not clickable on about page

### DIFF
--- a/ui/page/about_page.go
+++ b/ui/page/about_page.go
@@ -85,37 +85,27 @@ func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	return components.UniformPadding(gtx, body)
 }
 
-var inset = layout.Inset{
+var in = layout.Inset{
 	Top:    values.MarginPadding20,
 	Bottom: values.MarginPadding20,
 	Left:   values.MarginPadding16,
 	Right:  values.MarginPadding16,
 }
 
-func containerPadding() components.Container {
-	return components.Container{
-		Padding: inset,
-	}
-}
-
-func padding() layout.Inset {
-	return inset
-}
-
 func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 	w := []func(gtx C) D{
 		func(gtx C) D {
-			return containerPadding().Layout(gtx, func(gtx C) D {
+			return components.Container{Padding: in}.Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.version.Layout, pg.versionValue.Layout)
 			})
 		},
 		func(gtx C) D {
-			return containerPadding().Layout(gtx, func(gtx C) D {
+			return components.Container{Padding: in}.Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.buildDate.Layout, pg.buildDateValue.Layout)
 			})
 		},
 		func(gtx C) D {
-			return containerPadding().Layout(gtx, func(gtx C) D {
+			return components.Container{Padding: in}.Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.network.Layout, pg.networkValue.Layout)
 			})
 		},
@@ -123,11 +113,11 @@ func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 			return decredmaterial.Clickable(gtx, pg.licenseRow, func(gtx C) D {
 				return layout.Flex{}.Layout(gtx,
 					layout.Rigid(func(gtx C) D {
-						return padding().Layout(gtx, pg.license.Layout)
+						return in.Layout(gtx, pg.license.Layout)
 					}),
 					layout.Flexed(1, func(gtx C) D {
 						return layout.E.Layout(gtx, func(gtx C) D {
-							return padding().Layout(gtx, func(gtx C) D {
+							return in.Layout(gtx, func(gtx C) D {
 								return pg.chevronRightIcon.Layout(gtx, values.MarginPadding20)
 							})
 						})

--- a/ui/page/about_page.go
+++ b/ui/page/about_page.go
@@ -85,40 +85,37 @@ func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	return components.UniformPadding(gtx, body)
 }
 
-func unclickablePadding() components.Container {
+var inset = layout.Inset{
+	Top:    values.MarginPadding20,
+	Bottom: values.MarginPadding20,
+	Left:   values.MarginPadding16,
+	Right:  values.MarginPadding16,
+}
+
+func containerPadding() components.Container {
 	return components.Container{
-		Padding: layout.Inset{
-			Top:    values.MarginPadding20,
-			Bottom: values.MarginPadding20,
-			Left:   values.MarginPadding16,
-			Right:  values.MarginPadding16,
-		},
+		Padding: inset,
 	}
 }
 
-func clickablePadding() layout.Inset {
-	return layout.Inset{
-		Top:    values.MarginPadding20,
-		Bottom: values.MarginPadding20,
-		Left:   values.MarginPadding16,
-		Right:  values.MarginPadding16,
-	}
+func padding() layout.Inset {
+	return inset
 }
 
 func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 	w := []func(gtx C) D{
 		func(gtx C) D {
-			return unclickablePadding().Layout(gtx, func(gtx C) D {
+			return containerPadding().Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.version.Layout, pg.versionValue.Layout)
 			})
 		},
 		func(gtx C) D {
-			return unclickablePadding().Layout(gtx, func(gtx C) D {
+			return containerPadding().Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.buildDate.Layout, pg.buildDateValue.Layout)
 			})
 		},
 		func(gtx C) D {
-			return unclickablePadding().Layout(gtx, func(gtx C) D {
+			return containerPadding().Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.network.Layout, pg.networkValue.Layout)
 			})
 		},
@@ -126,11 +123,11 @@ func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 			return decredmaterial.Clickable(gtx, pg.licenseRow, func(gtx C) D {
 				return layout.Flex{}.Layout(gtx,
 					layout.Rigid(func(gtx C) D {
-						return clickablePadding().Layout(gtx, pg.license.Layout)
+						return padding().Layout(gtx, pg.license.Layout)
 					}),
 					layout.Flexed(1, func(gtx C) D {
 						return layout.E.Layout(gtx, func(gtx C) D {
-							return clickablePadding().Layout(gtx, func(gtx C) D {
+							return padding().Layout(gtx, func(gtx C) D {
 								return pg.chevronRightIcon.Layout(gtx, values.MarginPadding20)
 							})
 						})

--- a/ui/page/about_page.go
+++ b/ui/page/about_page.go
@@ -85,14 +85,14 @@ func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	return components.UniformPadding(gtx, body)
 }
 
-var in = layout.Inset{
-	Top:    values.MarginPadding20,
-	Bottom: values.MarginPadding20,
-	Left:   values.MarginPadding16,
-	Right:  values.MarginPadding16,
-}
-
 func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
+	var in = layout.Inset{
+		Top:    values.MarginPadding20,
+		Bottom: values.MarginPadding20,
+		Left:   values.MarginPadding16,
+		Right:  values.MarginPadding16,
+	}
+	
 	w := []func(gtx C) D{
 		func(gtx C) D {
 			return components.Container{Padding: in}.Layout(gtx, func(gtx C) D {

--- a/ui/page/about_page.go
+++ b/ui/page/about_page.go
@@ -7,12 +7,33 @@ import (
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
 	"github.com/planetdecred/godcr/ui/page/components"
-	"github.com/planetdecred/godcr/ui/values"
 )
 
 const AboutPageID = "About"
 
+type unclickableRow struct {
+	leftWidget  decredmaterial.Label
+	rightWidget decredmaterial.Label
+}
+
+type clickableLicense struct {
+	clickable   *widget.Clickable
+	leftWidget  decredmaterial.Label
+	rightWidget *widget.Icon
+}
+
 type AboutPage struct {
+	*load.Load
+	container    *layout.List
+	card         decredmaterial.Card
+	versionRow   unclickableRow
+	buildDateRow unclickableRow
+	networkRow   unclickableRow
+	licenseRow   clickableLicense
+	backButton   decredmaterial.IconButton
+}
+
+/*type AboutPage struct {
 	*load.Load
 	card      decredmaterial.Card
 	container *layout.List
@@ -30,28 +51,44 @@ type AboutPage struct {
 
 	backButton decredmaterial.IconButton
 }
+*/
 
-func NewAboutPage(l *load.Load) *AboutPage {
+func NewAboutPage2(l *load.Load) *AboutPage {
+	versionRow := unclickableRow{
+		leftWidget:  l.Theme.Body1("Version"),
+		rightWidget: l.Theme.Body1("v1.5.2"),
+	}
+
+	buildDateRow := unclickableRow{
+		leftWidget:  l.Theme.Body1("Build date"),
+		rightWidget: l.Theme.Body1("2020-09-10"),
+	}
+
+	networkRow := unclickableRow{
+		leftWidget:  l.Theme.Body1("Network"),
+		rightWidget: l.Theme.Body1(l.WL.Wallet.Net),
+	}
+
+	licenseRow := clickableLicense{
+		clickable:   new(widget.Clickable),
+		leftWidget:  l.Theme.Body1("License"),
+		rightWidget: l.Icons.ChevronRight,
+	}
 	pg := &AboutPage{
-		Load:             l,
-		card:             l.Theme.Card(),
-		container:        &layout.List{Axis: layout.Vertical},
-		version:          l.Theme.Body1("Version"),
-		versionValue:     l.Theme.Body1("v1.5.2"),
-		buildDate:        l.Theme.Body1("Build date"),
-		buildDateValue:   l.Theme.Body1("2020-09-10"),
-		network:          l.Theme.Body1("Network"),
-		networkValue:     l.Theme.Body1(l.WL.Wallet.Net),
-		license:          l.Theme.Body1("License"),
-		licenseRow:       new(widget.Clickable),
-		chevronRightIcon: l.Icons.ChevronRight,
+		Load:         l,
+		card:         l.Theme.Card(),
+		container:    &layout.List{Axis: layout.Vertical},
+		versionRow:   versionRow,
+		buildDateRow: buildDateRow,
+		networkRow:   networkRow,
+		licenseRow:   licenseRow,
 	}
 
 	pg.backButton, _ = components.SubpageHeaderButtons(l)
-	pg.versionValue.Color = pg.Theme.Color.Gray
-	pg.buildDateValue.Color = pg.Theme.Color.Gray
-	pg.networkValue.Color = pg.Theme.Color.Gray
-	pg.chevronRightIcon.Color = pg.Theme.Color.Gray
+	pg.versionRow.rightWidget.Color = pg.Theme.Color.Gray
+	pg.buildDateRow.rightWidget.Color = pg.Theme.Color.Gray
+	pg.networkRow.rightWidget.Color = pg.Theme.Color.Gray
+	pg.licenseRow.rightWidget.Color = pg.Theme.Color.Gray
 
 	return pg
 }
@@ -64,7 +101,7 @@ func (pg *AboutPage) OnResume() {
 
 }
 
-func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
+/*func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	body := func(gtx C) D {
 		page := components.SubPage{
 			Load:       pg.Load,
@@ -84,8 +121,9 @@ func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 
 	return components.UniformPadding(gtx, body)
 }
+*/
 
-func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
+/*func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 	w := []func(gtx C) D{
 		func(gtx C) D {
 			return components.EndToEndRow(gtx, pg.version.Layout, pg.versionValue.Layout)
@@ -135,11 +173,12 @@ func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 		})
 	})
 }
+*/
 
 func (pg *AboutPage) Handle() {
-	if pg.licenseRow.Clicked() {
+	/*if pg.licenseRow.Clicked() {
 		pg.ChangeFragment(NewLicensePage(pg.Load))
-	}
+	}*/
 }
 
 func (pg *AboutPage) OnClose() {}

--- a/ui/page/about_page.go
+++ b/ui/page/about_page.go
@@ -7,33 +7,12 @@ import (
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
 	"github.com/planetdecred/godcr/ui/page/components"
+	"github.com/planetdecred/godcr/ui/values"
 )
 
 const AboutPageID = "About"
 
-type unclickableRow struct {
-	leftWidget  decredmaterial.Label
-	rightWidget decredmaterial.Label
-}
-
-type clickableLicense struct {
-	clickable   *widget.Clickable
-	leftWidget  decredmaterial.Label
-	rightWidget *widget.Icon
-}
-
 type AboutPage struct {
-	*load.Load
-	container    *layout.List
-	card         decredmaterial.Card
-	versionRow   unclickableRow
-	buildDateRow unclickableRow
-	networkRow   unclickableRow
-	licenseRow   clickableLicense
-	backButton   decredmaterial.IconButton
-}
-
-/*type AboutPage struct {
 	*load.Load
 	card      decredmaterial.Card
 	container *layout.List
@@ -51,44 +30,28 @@ type AboutPage struct {
 
 	backButton decredmaterial.IconButton
 }
-*/
 
-func NewAboutPage2(l *load.Load) *AboutPage {
-	versionRow := unclickableRow{
-		leftWidget:  l.Theme.Body1("Version"),
-		rightWidget: l.Theme.Body1("v1.5.2"),
-	}
-
-	buildDateRow := unclickableRow{
-		leftWidget:  l.Theme.Body1("Build date"),
-		rightWidget: l.Theme.Body1("2020-09-10"),
-	}
-
-	networkRow := unclickableRow{
-		leftWidget:  l.Theme.Body1("Network"),
-		rightWidget: l.Theme.Body1(l.WL.Wallet.Net),
-	}
-
-	licenseRow := clickableLicense{
-		clickable:   new(widget.Clickable),
-		leftWidget:  l.Theme.Body1("License"),
-		rightWidget: l.Icons.ChevronRight,
-	}
+func NewAboutPage(l *load.Load) *AboutPage {
 	pg := &AboutPage{
-		Load:         l,
-		card:         l.Theme.Card(),
-		container:    &layout.List{Axis: layout.Vertical},
-		versionRow:   versionRow,
-		buildDateRow: buildDateRow,
-		networkRow:   networkRow,
-		licenseRow:   licenseRow,
+		Load:             l,
+		card:             l.Theme.Card(),
+		container:        &layout.List{Axis: layout.Vertical},
+		version:          l.Theme.Body1("Version"),
+		versionValue:     l.Theme.Body1("v1.5.2"),
+		buildDate:        l.Theme.Body1("Build date"),
+		buildDateValue:   l.Theme.Body1("2020-09-10"),
+		network:          l.Theme.Body1("Network"),
+		networkValue:     l.Theme.Body1(l.WL.Wallet.Net),
+		license:          l.Theme.Body1("License"),
+		licenseRow:       new(widget.Clickable),
+		chevronRightIcon: l.Icons.ChevronRight,
 	}
 
 	pg.backButton, _ = components.SubpageHeaderButtons(l)
-	pg.versionRow.rightWidget.Color = pg.Theme.Color.Gray
-	pg.buildDateRow.rightWidget.Color = pg.Theme.Color.Gray
-	pg.networkRow.rightWidget.Color = pg.Theme.Color.Gray
-	pg.licenseRow.rightWidget.Color = pg.Theme.Color.Gray
+	pg.versionValue.Color = pg.Theme.Color.Gray
+	pg.buildDateValue.Color = pg.Theme.Color.Gray
+	pg.networkValue.Color = pg.Theme.Color.Gray
+	pg.chevronRightIcon.Color = pg.Theme.Color.Gray
 
 	return pg
 }
@@ -112,7 +75,7 @@ func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 			},
 			Body: func(gtx C) D {
 				return pg.card.Layout(gtx, func(gtx C) D {
-					return pg.Layout(gtx)
+					return pg.layoutRows(gtx)
 				})
 			},
 		}
@@ -122,24 +85,65 @@ func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	return components.UniformPadding(gtx, body)
 }
 
-/*func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
+func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 	w := []func(gtx C) D{
 		func(gtx C) D {
-			return components.EndToEndRow(gtx, pg.version.Layout, pg.versionValue.Layout)
+			return components.Container{
+				Padding: layout.Inset{
+					Top:    values.MarginPadding20,
+					Bottom: values.MarginPadding20,
+					Left:   values.MarginPadding16,
+					Right:  values.MarginPadding16,
+				},
+			}.Layout(gtx, func(gtx C) D {
+				return components.EndToEndRow(gtx, pg.version.Layout, pg.versionValue.Layout)
+			})
 		},
 		func(gtx C) D {
-			return components.EndToEndRow(gtx, pg.buildDate.Layout, pg.buildDateValue.Layout)
+			return components.Container{
+				Padding: layout.Inset{
+					Top:    values.MarginPadding20,
+					Bottom: values.MarginPadding20,
+					Left:   values.MarginPadding16,
+					Right:  values.MarginPadding16,
+				},
+			}.Layout(gtx, func(gtx C) D {
+				return components.EndToEndRow(gtx, pg.buildDate.Layout, pg.buildDateValue.Layout)
+			})
 		},
 		func(gtx C) D {
-			return components.EndToEndRow(gtx, pg.network.Layout, pg.networkValue.Layout)
+			return components.Container{
+				Padding: layout.Inset{
+					Top:    values.MarginPadding20,
+					Bottom: values.MarginPadding20,
+					Left:   values.MarginPadding16,
+					Right:  values.MarginPadding16,
+				},
+			}.Layout(gtx, func(gtx C) D {
+				return components.EndToEndRow(gtx, pg.network.Layout, pg.networkValue.Layout)
+			})
 		},
 		func(gtx C) D {
 			return decredmaterial.Clickable(gtx, pg.licenseRow, func(gtx C) D {
 				return layout.Flex{}.Layout(gtx,
-					layout.Rigid(pg.license.Layout),
+					layout.Rigid(func(gtx C) D {
+						return layout.Inset{
+							Top:    values.MarginPadding20,
+							Bottom: values.MarginPadding20,
+							Left:   values.MarginPadding16,
+							Right:  values.MarginPadding16,
+						}.Layout(gtx, pg.license.Layout)
+					}),
 					layout.Flexed(1, func(gtx C) D {
 						return layout.E.Layout(gtx, func(gtx C) D {
-							return pg.chevronRightIcon.Layout(gtx, values.MarginPadding20)
+							return layout.Inset{
+								Top:    values.MarginPadding20,
+								Bottom: values.MarginPadding20,
+								Left:   values.MarginPadding16,
+								Right:  values.MarginPadding16,
+							}.Layout(gtx, func(gtx C) D {
+								return pg.chevronRightIcon.Layout(gtx, values.MarginPadding20)
+							})
 						})
 					}),
 				)
@@ -150,16 +154,7 @@ func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	return pg.container.Layout(gtx, len(w), func(gtx C, i int) D {
 		return layout.Inset{}.Layout(gtx, func(gtx C) D {
 			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-				layout.Rigid(func(gtx C) D {
-					return components.Container{
-						Padding: layout.Inset{
-							Top:    values.MarginPadding20,
-							Bottom: values.MarginPadding20,
-							Left:   values.MarginPadding16,
-							Right:  values.MarginPadding16,
-						},
-					}.Layout(gtx, w[i])
-				}),
+				layout.Rigid(w[i]),
 				layout.Rigid(func(gtx C) D {
 					if i == len(w)-1 {
 						return layout.Dimensions{}
@@ -172,12 +167,11 @@ func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 		})
 	})
 }
-*/
 
 func (pg *AboutPage) Handle() {
-	/*if pg.licenseRow.Clicked() {
+	if pg.licenseRow.Clicked() {
 		pg.ChangeFragment(NewLicensePage(pg.Load))
-	}*/
+	}
 }
 
 func (pg *AboutPage) OnClose() {}

--- a/ui/page/about_page.go
+++ b/ui/page/about_page.go
@@ -85,41 +85,40 @@ func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	return components.UniformPadding(gtx, body)
 }
 
+func unclickablePadding(gtx C) components.Container {
+	return components.Container{
+		Padding: layout.Inset{
+			Top:    values.MarginPadding20,
+			Bottom: values.MarginPadding20,
+			Left:   values.MarginPadding16,
+			Right:  values.MarginPadding16,
+		},
+	}
+}
+
+func clickablePadding(gtx C) layout.Inset {
+	return layout.Inset{
+		Top:    values.MarginPadding20,
+		Bottom: values.MarginPadding20,
+		Left:   values.MarginPadding16,
+		Right:  values.MarginPadding16,
+	}
+}
+
 func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 	w := []func(gtx C) D{
 		func(gtx C) D {
-			return components.Container{
-				Padding: layout.Inset{
-					Top:    values.MarginPadding20,
-					Bottom: values.MarginPadding20,
-					Left:   values.MarginPadding16,
-					Right:  values.MarginPadding16,
-				},
-			}.Layout(gtx, func(gtx C) D {
+			return unclickablePadding(gtx).Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.version.Layout, pg.versionValue.Layout)
 			})
 		},
 		func(gtx C) D {
-			return components.Container{
-				Padding: layout.Inset{
-					Top:    values.MarginPadding20,
-					Bottom: values.MarginPadding20,
-					Left:   values.MarginPadding16,
-					Right:  values.MarginPadding16,
-				},
-			}.Layout(gtx, func(gtx C) D {
+			return unclickablePadding(gtx).Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.buildDate.Layout, pg.buildDateValue.Layout)
 			})
 		},
 		func(gtx C) D {
-			return components.Container{
-				Padding: layout.Inset{
-					Top:    values.MarginPadding20,
-					Bottom: values.MarginPadding20,
-					Left:   values.MarginPadding16,
-					Right:  values.MarginPadding16,
-				},
-			}.Layout(gtx, func(gtx C) D {
+			return unclickablePadding(gtx).Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.network.Layout, pg.networkValue.Layout)
 			})
 		},
@@ -127,21 +126,11 @@ func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 			return decredmaterial.Clickable(gtx, pg.licenseRow, func(gtx C) D {
 				return layout.Flex{}.Layout(gtx,
 					layout.Rigid(func(gtx C) D {
-						return layout.Inset{
-							Top:    values.MarginPadding20,
-							Bottom: values.MarginPadding20,
-							Left:   values.MarginPadding16,
-							Right:  values.MarginPadding16,
-						}.Layout(gtx, pg.license.Layout)
+						return clickablePadding(gtx).Layout(gtx, pg.license.Layout)
 					}),
 					layout.Flexed(1, func(gtx C) D {
 						return layout.E.Layout(gtx, func(gtx C) D {
-							return layout.Inset{
-								Top:    values.MarginPadding20,
-								Bottom: values.MarginPadding20,
-								Left:   values.MarginPadding16,
-								Right:  values.MarginPadding16,
-							}.Layout(gtx, func(gtx C) D {
+							return clickablePadding(gtx).Layout(gtx, func(gtx C) D {
 								return pg.chevronRightIcon.Layout(gtx, values.MarginPadding20)
 							})
 						})

--- a/ui/page/about_page.go
+++ b/ui/page/about_page.go
@@ -85,7 +85,7 @@ func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	return components.UniformPadding(gtx, body)
 }
 
-func unclickablePadding(gtx C) components.Container {
+func unclickablePadding() components.Container {
 	return components.Container{
 		Padding: layout.Inset{
 			Top:    values.MarginPadding20,
@@ -96,7 +96,7 @@ func unclickablePadding(gtx C) components.Container {
 	}
 }
 
-func clickablePadding(gtx C) layout.Inset {
+func clickablePadding() layout.Inset {
 	return layout.Inset{
 		Top:    values.MarginPadding20,
 		Bottom: values.MarginPadding20,
@@ -108,17 +108,17 @@ func clickablePadding(gtx C) layout.Inset {
 func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 	w := []func(gtx C) D{
 		func(gtx C) D {
-			return unclickablePadding(gtx).Layout(gtx, func(gtx C) D {
+			return unclickablePadding().Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.version.Layout, pg.versionValue.Layout)
 			})
 		},
 		func(gtx C) D {
-			return unclickablePadding(gtx).Layout(gtx, func(gtx C) D {
+			return unclickablePadding().Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.buildDate.Layout, pg.buildDateValue.Layout)
 			})
 		},
 		func(gtx C) D {
-			return unclickablePadding(gtx).Layout(gtx, func(gtx C) D {
+			return unclickablePadding().Layout(gtx, func(gtx C) D {
 				return components.EndToEndRow(gtx, pg.network.Layout, pg.networkValue.Layout)
 			})
 		},
@@ -126,11 +126,11 @@ func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 			return decredmaterial.Clickable(gtx, pg.licenseRow, func(gtx C) D {
 				return layout.Flex{}.Layout(gtx,
 					layout.Rigid(func(gtx C) D {
-						return clickablePadding(gtx).Layout(gtx, pg.license.Layout)
+						return clickablePadding().Layout(gtx, pg.license.Layout)
 					}),
 					layout.Flexed(1, func(gtx C) D {
 						return layout.E.Layout(gtx, func(gtx C) D {
-							return clickablePadding(gtx).Layout(gtx, func(gtx C) D {
+							return clickablePadding().Layout(gtx, func(gtx C) D {
 								return pg.chevronRightIcon.Layout(gtx, values.MarginPadding20)
 							})
 						})

--- a/ui/page/about_page.go
+++ b/ui/page/about_page.go
@@ -101,7 +101,7 @@ func (pg *AboutPage) OnResume() {
 
 }
 
-/*func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
+func (pg *AboutPage) Layout(gtx layout.Context) layout.Dimensions {
 	body := func(gtx C) D {
 		page := components.SubPage{
 			Load:       pg.Load,
@@ -112,7 +112,7 @@ func (pg *AboutPage) OnResume() {
 			},
 			Body: func(gtx C) D {
 				return pg.card.Layout(gtx, func(gtx C) D {
-					return pg.layoutRows(gtx)
+					return pg.Layout(gtx)
 				})
 			},
 		}
@@ -121,7 +121,6 @@ func (pg *AboutPage) OnResume() {
 
 	return components.UniformPadding(gtx, body)
 }
-*/
 
 /*func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 	w := []func(gtx C) D{

--- a/ui/page/about_page.go
+++ b/ui/page/about_page.go
@@ -92,7 +92,6 @@ func (pg *AboutPage) layoutRows(gtx layout.Context) layout.Dimensions {
 		Left:   values.MarginPadding16,
 		Right:  values.MarginPadding16,
 	}
-	
 	w := []func(gtx C) D{
 		func(gtx C) D {
 			return components.Container{Padding: in}.Layout(gtx, func(gtx C) D {


### PR DESCRIPTION
This PR fixes #575 

It makes the whole license row on about page clickable:

Before:
![Screenshot from 2021-08-21 19-00-50](https://user-images.githubusercontent.com/66803475/130331148-0961a52c-2c2b-4da1-9779-60e4c1bc5fdb.png)

After:
![Screenshot from 2021-08-25 08-14-28](https://user-images.githubusercontent.com/66803475/130743886-192ef34c-d64b-4754-a318-d430deda419e.png)
