### PR TITLE
Fix Clickable widget effect highlight.

### DIFF
--- a/ui/decredmaterial/button.go
+++ b/ui/decredmaterial/button.go
@@ -5,10 +5,15 @@ package decredmaterial
 import (
 	"image"
 	"image/color"
+	"math"
 
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget/material"
+	"gioui.org/op/clip"
+	"gioui.org/f32"
+	"gioui.org/op"
+	"gioui.org/op/paint"
 
 	"gioui.org/widget"
 )
@@ -45,6 +50,39 @@ func (t *Theme) PlainIconButton(button *widget.Clickable, icon *widget.Icon) Ico
 
 func Clickable(gtx layout.Context, button *widget.Clickable, w layout.Widget) layout.Dimensions {
 	return material.Clickable(gtx, button, w)
+}
+
+func Clickable2(gtx layout.Context, button *widget.Clickable, w layout.Widget) layout.Dimensions {
+	return layout.Stack{}.Layout(gtx,
+		layout.Expanded(button.Layout),
+		layout.Expanded(func(gtx layout.Context) layout.Dimensions {
+			// clip.Rect{Max: gtx.Constraints.Min}.Add(gtx.Ops)
+			rr := float32(gtx.Px(unit.Dp(4)))
+			clip.UniformRRect(f32.Rectangle{Max: f32.Point{
+				X: float32(gtx.Constraints.Min.X),
+				Y: float32(gtx.Constraints.Min.Y),
+			}}, rr).Add(gtx.Ops)
+			// background := b.Background
+			// switch {
+			// case gtx.Queue == nil:
+			// 	background = Disabled(b.Background)
+			// case b.Button.Hovered():
+			// 	background = Hovered(b.Background)
+			// }
+			// paint.Fill(gtx.Ops, background)
+			for _, c := range button.History() {
+				layoutInfoTooltip(gtx, c)
+			}
+			return layout.Dimensions{Size: gtx.Constraints.Min}
+		}),
+		layout.Stacked(w),
+	)
+}
+
+func layoutInfoTooltip(gtx layout.Context, c widget.Press) {
+	layout.Inset{}.Layout(gtx, func(gtx C) D {
+		return drawInk(gtx, c)
+	})
 }
 
 func (b *Button) SetEnabled(enabled bool) {
@@ -125,4 +163,116 @@ func (b TextAndIconButton) Layout(gtx layout.Context) layout.Dimensions {
 			return iconAndLabel.Layout(gtx, layLabel, layIcon)
 		})
 	})
+}
+
+func drawInk(gtx layout.Context, c widget.Press) {
+	// duration is the number of seconds for the
+	// completed animation: expand while fading in, then
+	// out.
+	const (
+		expandDuration = float32(0.5)
+		fadeDuration   = float32(0.9)
+	)
+
+	now := gtx.Now
+
+	t := float32(now.Sub(c.Start).Seconds())
+
+	end := c.End
+	if end.IsZero() {
+		// If the press hasn't ended, don't fade-out.
+		end = now
+	}
+
+	endt := float32(end.Sub(c.Start).Seconds())
+
+	// Compute the fade-in/out position in [0;1].
+	var alphat float32
+	{
+		var haste float32
+		if c.Cancelled {
+			// If the press was cancelled before the inkwell
+			// was fully faded in, fast forward the animation
+			// to match the fade-out.
+			if h := 0.5 - endt/fadeDuration; h > 0 {
+				haste = h
+			}
+		}
+		// Fade in.
+		half1 := t/fadeDuration + haste
+		if half1 > 0.5 {
+			half1 = 0.5
+		}
+
+		// Fade out.
+		half2 := float32(now.Sub(end).Seconds())
+		half2 /= fadeDuration
+		half2 += haste
+		if half2 > 0.5 {
+			// Too old.
+			return
+		}
+
+		alphat = half1 + half2
+	}
+
+	// Compute the expand position in [0;1].
+	sizet := t
+	if c.Cancelled {
+		// Freeze expansion of cancelled presses.
+		sizet = endt
+	}
+	sizet /= expandDuration
+
+	// Animate only ended presses, and presses that are fading in.
+	if !c.End.IsZero() || sizet <= 1.0 {
+		op.InvalidateOp{}.Add(gtx.Ops)
+	}
+
+	if sizet > 1.0 {
+		sizet = 1.0
+	}
+
+	if alphat > .5 {
+		// Start fadeout after half the animation.
+		alphat = 1.0 - alphat
+	}
+	// Twice the speed to attain fully faded in at 0.5.
+	t2 := alphat * 2
+	// Beziér ease-in curve.
+	alphaBezier := t2 * t2 * (3.0 - 2.0*t2)
+	sizeBezier := sizet * sizet * (3.0 - 2.0*sizet)
+	size := float32(gtx.Constraints.Min.X)
+	if h := float32(gtx.Constraints.Min.Y); h > size {
+		size = h
+	}
+	// Cover the entire constraints min rectangle.
+	size *= 2 * float32(math.Sqrt(2))
+	// Apply curve values to size and color.
+	size *= sizeBezier
+	alpha := 0.7 * alphaBezier
+	const col = 0.8
+	ba, bc := byte(alpha*0xff), byte(col*0xff)
+	defer op.Save(gtx.Ops).Load()
+	rgba := mulAlpha(color.NRGBA{A: 0xff, R: bc, G: bc, B: bc}, ba)
+	ink := paint.ColorOp{Color: rgba}
+	ink.Add(gtx.Ops)
+	// rr := size * .5
+	// op.Offset(c.Position.Add(f32.Point{
+	// 	X: -rr,
+	// 	Y: -rr,
+	// })).Add(gtx.Ops)
+	// tr := float32(gtx.Px(unit.Dp(4)))
+	// tl := float32(gtx.Px(unit.Dp(4)))
+	// br := float32(gtx.Px(unit.Dp(4)))
+	// bl := float32(gtx.Px(unit.Dp(4)))
+	// clip.RRect{
+	// 	Rect: f32.Rectangle{Max: f32.Point{
+	// 		X: float32(gtx.Constraints.Min.X),
+	// 		Y: float32(gtx.Constraints.Min.Y),
+	// 	}},
+	// 	NW: tl, NE: tr, SE: br, SW: bl,
+	// }.Add(gtx.Ops)
+	// clip.UniformRRect(f32.Rectangle{Max: f32.Pt(size, size)}, rr).Add(gtx.Ops)
+	paint.PaintOp{}.Add(gtx.Ops)
 }

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -302,6 +302,17 @@ func Disabled(c color.NRGBA) (d color.NRGBA) {
 	}
 }
 
+// Hovered blends color towards a brighter color.
+func Hovered(c color.NRGBA) (d color.NRGBA) {
+	const r = 0x20 // lighten ratio
+	return color.NRGBA{
+		R: byte(255 - int(255-c.R)*(255-r)/256),
+		G: byte(255 - int(255-c.G)*(255-r)/256),
+		B: byte(255 - int(255-c.B)*(255-r)/256),
+		A: c.A,
+	}
+}
+
 // approxLuminance is a fast approximate version of RGBA.Luminance.
 func approxLuminance(c color.NRGBA) byte {
 	const (

--- a/ui/page/overview_page.go
+++ b/ui/page/overview_page.go
@@ -180,10 +180,12 @@ func (pg *OverviewPage) syncDetail(name, status, headersFetched, progress string
 
 // recentTransactionsSection lays out the list of recent transactions.
 func (pg *OverviewPage) recentTransactionsSection(gtx layout.Context) layout.Dimensions {
-	return pg.Theme.Card().Layout(gtx, func(gtx layout.Context) layout.Dimensions {
-		padding := values.MarginPadding15
-		return components.Container{Padding: layout.Inset{Top: padding}}.Layout(gtx, func(gtx C) D {
-			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+		return decredmaterial.LinearLayout{Orientation: layout.Vertical,
+					Width:      decredmaterial.MatchParent,
+					Height:     decredmaterial.WrapContent,
+					Background: pg.Theme.Color.Surface,
+					Border:     decredmaterial.Border{Radius: decredmaterial.Radius(14)},
+					Padding:    layout.Inset{Top: values.MarginPadding15}}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
 					title := pg.Theme.Body2(values.String(values.StrRecentTransactions))
 					title.Color = pg.Theme.Color.Gray3
@@ -231,8 +233,6 @@ func (pg *OverviewPage) recentTransactionsSection(gtx layout.Context) layout.Dim
 					})
 				}),
 			)
-		})
-	})
 }
 
 // syncStatusSection lays out content for displaying sync status.


### PR DESCRIPTION
Currently when the clickableList button is pressed, the button effect extends pass the card constraint.
![image](https://user-images.githubusercontent.com/27733432/131494486-ccc073fb-923d-48af-b89e-3f574d7031d8.png)

This PR is to have this resolved so it fix within the card and also to set custom highlight colors.