### PR TITLE
Add separator to debug items

### DIFF
--- a/ui/page/debug_page.go
+++ b/ui/page/debug_page.go
@@ -98,7 +98,21 @@ func (pg *DebugPage) layoutDebugItems(gtx C) {
 	card.Layout(gtx, func(gtx C) D {
 		list := layout.List{Axis: layout.Vertical}
 		return list.Layout(gtx, len(pg.debugItems), func(gtx C, i int) D {
-			return pg.debugItem(gtx, i)
+			return layout.Inset{}.Layout(gtx, func(gtx C) D {
+				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return pg.debugItem(gtx, i)
+					}),
+					layout.Rigid(func(gtx C) D {
+						if i == len(pg.debugItems)-1 {
+							return layout.Dimensions{}
+						}
+						return layout.Inset{
+							Left: values.MarginPadding16,
+						}.Layout(gtx, pg.Theme.Separator().Layout)
+					}),
+				)
+			})
 		})
 	})
 }


### PR DESCRIPTION
This PR fixex #583 
It adds separator between the debug items on debug page.
Image below:
![Debug](https://user-images.githubusercontent.com/66803475/131175867-b5453828-a9a0-4a63-ab88-8ab77cbd7420.png)
