### PR TITLE
Make separators on wallet options menu darker

### DIFF
--- a/ui/page/wallet_page.go
+++ b/ui/page/wallet_page.go
@@ -91,7 +91,7 @@ func NewWalletPage(l *load.Load) *WalletPage {
 		backupAcctIcon:           l.Icons.NavigationArrowForward,
 	}
 
-	pg.separator.Color = l.Theme.Color.Background
+	pg.separator.Color = l.Theme.Color.Gray1
 	pg.addAcctIcon.Color = l.Theme.Color.Text
 
 	pg.watchOnlyWalletLabel = pg.Theme.Body1(values.String(values.StrWatchOnlyWallets))


### PR DESCRIPTION
FIxes #593 
This PR darken the separator line on wallets menu options as seen below:
![wallets](https://user-images.githubusercontent.com/66803475/131958727-db19bf69-9fcd-4ac1-a76b-5e000cb2eb3c.png)
