### PR TITLE
tooltip alignment in proposals page

### DIFF
--- a/ui/decredmaterial/votebar.go
+++ b/ui/decredmaterial/votebar.go
@@ -175,7 +175,8 @@ func (v *VoteBar) Layout(gtx C) D {
 }
 
 func (v *VoteBar) votesIndicatorTooltip(gtx C, r image.Rectangle, tipPos float32) {
-	inset := layout.Inset{Left: unit.Dp(tipPos / 3), Top: unit.Dp(20)}
+	insetLeft := tipPos - float32(voteBarThumbWidth/2) - 205
+	inset := layout.Inset{Left: unit.Dp(insetLeft), Top: unit.Dp(25)}
 	v.passTooltip.Layout(gtx, r, inset, func(gtx C) D {
 		return v.passTooltipLabel.Layout(gtx)
 	})

--- a/ui/page/proposal/proposals_page.go
+++ b/ui/page/proposal/proposals_page.go
@@ -495,13 +495,13 @@ func (pg *ProposalsPage) layoutAuthorAndDate(gtx C, item proposalItem) D {
 						return layout.Flex{}.Layout(gtx,
 							layout.Rigid(stateLabel.Layout),
 							layout.Rigid(func(gtx C) D {
-								rect := image.Rectangle{
-									Min: gtx.Constraints.Min,
-									Max: gtx.Constraints.Max,
-								}
-								rect.Max.Y = 20
-								pg.layoutInfoTooltip(gtx, rect, item)
 								return layout.Inset{Left: values.MarginPadding5}.Layout(gtx, func(gtx C) D {
+									rect := image.Rectangle{
+										Min: gtx.Constraints.Min,
+										Max: gtx.Constraints.Max,
+									}
+									rect.Max.Y = 20
+									pg.layoutInfoTooltip(gtx, rect, item)
 									return pg.infoIcon.Layout(gtx, unit.Dp(20))
 								})
 							}),
@@ -527,8 +527,10 @@ func (pg *ProposalsPage) layoutAuthorAndDate(gtx C, item proposalItem) D {
 }
 
 func (pg *ProposalsPage) layoutInfoTooltip(gtx C, rect image.Rectangle, item proposalItem) {
-	inset := layout.Inset{Top: values.MarginPadding20, Left: values.MarginPaddingMinus230}
+	inset := layout.Inset{Top: values.MarginPadding20, Left: values.MarginPaddingMinus195}
 	item.tooltip.Layout(gtx, rect, inset, func(gtx C) D {
+		gtx.Constraints.Min.X = gtx.Px(values.MarginPadding195)
+		gtx.Constraints.Max.X = gtx.Px(values.MarginPadding195)
 		return item.tooltipLabel.Layout(gtx)
 	})
 }

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -48,6 +48,8 @@ var (
 	MarginPadding100      = unit.Dp(100)
 	MarginPadding120      = unit.Dp(120)
 	MarginPadding150      = unit.Dp(150)
+	MarginPadding195      = unit.Dp(195)
+	MarginPaddingMinus195 = unit.Dp(-195)
 	MarginPadding200      = unit.Dp(200)
 	MarginPadding250      = unit.Dp(250)
 	MarginPaddingMinus230 = unit.Dp(-230)


### PR DESCRIPTION
Close #601
This PR fixed the tooltip to the right alignment in the proposals page

![image](https://user-images.githubusercontent.com/19331824/132114173-5da24cd7-9222-4cb4-88e7-3056fb323f27.png)
