### PR TITLE
add hover effect to clickable fields, dropdown and account selector

### DIFF
--- a/ui/decredmaterial/card.go
+++ b/ui/decredmaterial/card.go
@@ -82,7 +82,7 @@ func (c Card) Layout(gtx layout.Context, w layout.Widget) layout.Dimensions {
 	return dims
 }
 
-func (c Card) HovarableLayout(gtx layout.Context, btn *widget.Clickable, w layout.Widget) layout.Dimensions {
+func (c Card) HoverableLayout(gtx layout.Context, btn *widget.Clickable, w layout.Widget) layout.Dimensions {
 	background := c.Color
 	dims := c.Inset.Layout(gtx, func(gtx C) D {
 		return layout.Stack{}.Layout(gtx,

--- a/ui/decredmaterial/card.go
+++ b/ui/decredmaterial/card.go
@@ -12,9 +12,11 @@ import (
 
 type Card struct {
 	layout.Inset
-	Color      color.NRGBA
-	HoverColor color.NRGBA
-	Radius     CornerRadius
+	Border      bool
+	BorderParam widget.Border
+	Color       color.NRGBA
+	HoverColor  color.NRGBA
+	Radius      CornerRadius
 }
 
 type CornerRadius struct {
@@ -56,6 +58,11 @@ func (t *Theme) Card() Card {
 		Color:      t.Color.Surface,
 		HoverColor: t.Color.ActiveGray,
 		Radius:     Radius(defaultRadius),
+		BorderParam: widget.Border{
+			Color:        t.Color.Gray1,
+			Width:        unit.Dp(1),
+			CornerRadius: unit.Dp(defaultRadius),
+		},
 	}
 }
 
@@ -79,6 +86,12 @@ func (c Card) Layout(gtx layout.Context, w layout.Widget) layout.Dimensions {
 			layout.Stacked(w),
 		)
 	})
+	if c.Border {
+		border := widget.Border{Color: c.BorderParam.Color, CornerRadius: c.BorderParam.CornerRadius, Width: c.BorderParam.Width}
+		return border.Layout(gtx, func(gtx C) D {
+			return dims
+		})
+	}
 	return dims
 }
 
@@ -109,5 +122,11 @@ func (c Card) HoverableLayout(gtx layout.Context, btn *widget.Clickable, w layou
 			layout.Stacked(w),
 		)
 	})
+	if c.Border {
+		border := widget.Border{Color: c.BorderParam.Color, CornerRadius: c.BorderParam.CornerRadius, Width: c.BorderParam.Width}
+		return border.Layout(gtx, func(gtx C) D {
+			return dims
+		})
+	}
 	return dims
 }

--- a/ui/decredmaterial/clickable_list.go
+++ b/ui/decredmaterial/clickable_list.go
@@ -1,6 +1,8 @@
 package decredmaterial
 
 import (
+	"image/color"
+
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
@@ -48,23 +50,40 @@ func (cl *ClickableList) handleClickables(count int) {
 func (cl *ClickableList) Layout(gtx layout.Context, count int, w layout.ListElement) layout.Dimensions {
 	cl.handleClickables(count)
 	return cl.List.Layout(gtx, count, func(gtx layout.Context, i int) layout.Dimensions {
-		row := Clickable(gtx, cl.clickables[i], func(gtx layout.Context) layout.Dimensions {
-			return w(gtx, i)
-		})
-
-		// add divider to all rows except last
-		if i < (count-1) && cl.DividerHeight.V > 0 {
-			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
-					return row
-				}),
-				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
-					gtx.Constraints.Min.Y += gtx.Px(cl.DividerHeight)
-
-					return layout.Dimensions{Size: gtx.Constraints.Min}
-				}),
-			)
-		}
-		return row
+		return cl.clickableLayout(gtx, count, i, w)
 	})
+}
+
+func (cl *ClickableList) HoverableLayout(gtx layout.Context, count int, w layout.ListElement) layout.Dimensions {
+	cl.handleClickables(count)
+
+	card := cl.theme.Card()
+	card.Color = color.NRGBA{}
+	card.Radius = Radius(0)
+	return cl.List.Layout(gtx, count, func(gtx layout.Context, i int) layout.Dimensions {
+		return card.HovarableLayout(gtx, cl.clickables[i], func(gtx layout.Context) layout.Dimensions {
+			return cl.clickableLayout(gtx, count, i, w)
+		})
+	})
+}
+
+func (cl *ClickableList) clickableLayout(gtx layout.Context, count, i int, w layout.ListElement) layout.Dimensions {
+	row := Clickable(gtx, cl.clickables[i], func(gtx layout.Context) layout.Dimensions {
+		return w(gtx, i)
+	})
+
+	// add divider to all rows except last
+	if i < (count-1) && cl.DividerHeight.V > 0 {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				return row
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				gtx.Constraints.Min.Y += gtx.Px(cl.DividerHeight)
+
+				return layout.Dimensions{Size: gtx.Constraints.Min}
+			}),
+		)
+	}
+	return row
 }

--- a/ui/decredmaterial/clickable_list.go
+++ b/ui/decredmaterial/clickable_list.go
@@ -61,7 +61,7 @@ func (cl *ClickableList) HoverableLayout(gtx layout.Context, count int, w layout
 	card.Color = color.NRGBA{}
 	card.Radius = Radius(0)
 	return cl.List.Layout(gtx, count, func(gtx layout.Context, i int) layout.Dimensions {
-		return card.HovarableLayout(gtx, cl.clickables[i], func(gtx layout.Context) layout.Dimensions {
+		return card.HoverableLayout(gtx, cl.clickables[i], func(gtx layout.Context) layout.Dimensions {
 			return cl.clickableLayout(gtx, count, i, w)
 		})
 	})

--- a/ui/decredmaterial/dropdown.go
+++ b/ui/decredmaterial/dropdown.go
@@ -175,14 +175,6 @@ func (c *DropDown) layoutOption(gtx layout.Context, itemIndex int, isFirstOption
 func (c *DropDown) Layout(gtx C, dropPos int, reversePos bool) D {
 	c.handleEvents()
 
-	return layout.Stack{Alignment: layout.Center}.Layout(gtx,
-		layout.Expanded(func(gtx C) D {
-			return c.drawLayout(gtx, false, func(gtx C) D {
-				return c.layoutOption(gtx, 0, true)
-			})
-		}),
-	}
-
 	iLeft := dropPos
 	iRight := 0
 	alig := layout.NW
@@ -192,40 +184,52 @@ func (c *DropDown) Layout(gtx C, dropPos int, reversePos bool) D {
 		iRight = dropPos
 	}
 
-	if c.isOpen {
-		return layout.Stack{Alignment: alig}.Layout(gtx,
-			layout.Expanded(func(gtx C) D {
-				gtx.Constraints.Min = gtx.Constraints.Max
-				return c.backdrop.Layout(gtx)
-			}),
-			layout.Stacked(func(gtx C) D {
-				return layout.Inset{
-					Left:  unit.Dp(float32(iLeft)),
-					Right: unit.Dp(float32(iRight)),
-				}.Layout(gtx, func(gtx C) D {
-					lay := c.dropDownItemMenu(gtx)
-					w := (lay.Size.X * 800) / gtx.Px(MaxWidth)
-					c.Width = w
-					return lay
-				})
-			}),
-		)
-	}
 	return layout.Stack{Alignment: alig}.Layout(gtx,
-		layout.Stacked(func(gtx C) D {
-			return layout.Inset{
-				Left:  unit.Dp(float32(iLeft)),
-				Right: unit.Dp(float32(iRight)),
-			}.Layout(gtx, func(gtx C) D {
-				return c.drawLayout(gtx, false, func(gtx C) D {
-					lay := layout.Flex{Axis: layout.Vertical}.Layout(gtx, children...)
-					w := (lay.Size.X * 800) / gtx.Px(MaxWidth)
-					c.Width = w + 10
-					return lay
-				})
+		layout.Expanded(func(gtx C) D {
+			return c.drawLayout(gtx, false, func(gtx C) D {
+				return c.layoutOption(gtx, 0, true)
 			})
 		}),
+		layout.Stacked(func(gtx C) D {
+			if c.isOpen {
+				return layout.Stack{Alignment: alig}.Layout(gtx,
+					layout.Expanded(func(gtx C) D {
+						gtx.Constraints.Min = gtx.Constraints.Max
+						return c.backdrop.Layout(gtx)
+					}),
+					layout.Stacked(func(gtx C) D {
+						return layout.Inset{
+							Left:  unit.Dp(float32(iLeft)),
+							Right: unit.Dp(float32(iRight)),
+						}.Layout(gtx, func(gtx C) D {
+							lay := c.dropDownItemMenu(gtx)
+							w := (lay.Size.X * 800) / gtx.Px(MaxWidth)
+							c.Width = w
+							return lay
+						})
+					}),
+				)
+			}
+			return D{}
+		}),
 	)
+
+	
+	// return layout.Stack{Alignment: alig}.Layout(gtx,
+	// 	layout.Stacked(func(gtx C) D {
+	// 		return layout.Inset{
+	// 			Left:  unit.Dp(float32(iLeft)),
+	// 			Right: unit.Dp(float32(iRight)),
+	// 		}.Layout(gtx, func(gtx C) D {
+	// 			return c.drawLayout(gtx, false, func(gtx C) D {
+	// 				lay := layout.Flex{Axis: layout.Vertical}.Layout(gtx, children...)
+	// 				w := (lay.Size.X * 800) / gtx.Px(MaxWidth)
+	// 				c.Width = w + 10
+	// 				return lay
+	// 			})
+	// 		})
+	// 	}),
+	// )
 }
 
 func (c *DropDown) dropDownItemMenu(gtx C) D {

--- a/ui/decredmaterial/linearlayout.go
+++ b/ui/decredmaterial/linearlayout.go
@@ -7,6 +7,7 @@ import (
 	"gioui.org/layout"
 	"gioui.org/op/clip"
 	"gioui.org/unit"
+	"gioui.org/widget"
 )
 
 const (
@@ -26,6 +27,9 @@ type LinearLayout struct {
 	Direction   layout.Direction
 	Spacing     layout.Spacing
 	Alignment   layout.Alignment
+	Hoverable   bool
+	HoverColor  color.NRGBA
+	HoverButton *widget.Clickable
 }
 
 // Layout2 displays a linear layout with a single child.
@@ -34,7 +38,7 @@ func (ll LinearLayout) Layout2(gtx C, wdg layout.Widget) D {
 }
 
 func (ll LinearLayout) Layout(gtx C, children ...layout.FlexChild) D {
-
+	background := ll.Background
 	// draw layout direction
 	return ll.Direction.Layout(gtx, func(gtx C) D {
 		// draw margin
@@ -56,7 +60,15 @@ func (ll LinearLayout) Layout(gtx C, children ...layout.FlexChild) D {
 							}},
 							NW: tl, NE: tr, SE: br, SW: bl,
 						}.Add(gtx.Ops)
-						return fill(gtx, ll.Background)
+						if ll.Hoverable && ll.HoverButton != nil {
+							switch {
+							case gtx.Queue == nil:
+								background = Disabled(ll.Background)
+							case ll.HoverButton.Hovered():
+								background = Hovered(ll.HoverColor)
+							}
+						}
+						return fill(gtx, background)
 					}),
 					layout.Stacked(func(gtx C) D {
 						ll.applyDimension(&gtx)

--- a/ui/decredmaterial/linearlayout.go
+++ b/ui/decredmaterial/linearlayout.go
@@ -15,6 +15,11 @@ const (
 	MatchParent = -2
 )
 
+type Hover struct {
+	HoverColor  color.NRGBA
+	HoverButton *widget.Clickable
+}
+
 type LinearLayout struct {
 	Width       int
 	Height      int
@@ -27,9 +32,7 @@ type LinearLayout struct {
 	Direction   layout.Direction
 	Spacing     layout.Spacing
 	Alignment   layout.Alignment
-	Hoverable   bool
-	HoverColor  color.NRGBA
-	HoverButton *widget.Clickable
+	HoverEffect Hover
 }
 
 // Layout2 displays a linear layout with a single child.
@@ -60,12 +63,12 @@ func (ll LinearLayout) Layout(gtx C, children ...layout.FlexChild) D {
 							}},
 							NW: tl, NE: tr, SE: br, SW: bl,
 						}.Add(gtx.Ops)
-						if ll.Hoverable && ll.HoverButton != nil {
+						if ll.HoverEffect.HoverButton != nil {
 							switch {
 							case gtx.Queue == nil:
 								background = Disabled(ll.Background)
-							case ll.HoverButton.Hovered():
-								background = Hovered(ll.HoverColor)
+							case ll.HoverEffect.HoverButton.Hovered():
+								background = Hovered(ll.HoverEffect.HoverColor)
 							}
 						}
 						return fill(gtx, background)

--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -375,7 +375,7 @@ func (asm *AccountSelectorModal) Layout(gtx layout.Context) layout.Dimensions {
 							card.Color = color.NRGBA{}
 							card.Radius = decredmaterial.Radius(0)
 							return asm.accountsList.Layout(gtx, len(accounts), func(gtx C, aindex int) D {
-								return card.HovarableLayout(gtx, accounts[aindex].button, func(gtx C) D {
+								return card.HoverableLayout(gtx, accounts[aindex].button, func(gtx C) D {
 									return asm.walletAccountLayout(gtx, accounts[aindex])
 								})
 							})

--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -3,11 +3,9 @@ package components
 import (
 	"errors"
 	"fmt"
-	"image"
+	"image/color"
 
-	"gioui.org/gesture"
 	"gioui.org/io/event"
-	"gioui.org/io/pointer"
 	"gioui.org/layout"
 	"gioui.org/text"
 	"gioui.org/widget"
@@ -211,7 +209,7 @@ type AccountSelectorModal struct {
 
 type selectorAccount struct {
 	*dcrlibwallet.Account
-	clickEvent *gesture.Click
+	button *widget.Clickable
 }
 
 func newAccountSelectorModal(l *load.Load, currentSelectedAccount *dcrlibwallet.Account, wallets []*dcrlibwallet.Wallet) *AccountSelectorModal {
@@ -252,8 +250,8 @@ func (asm *AccountSelectorModal) OnResume() {
 		for _, account := range accounts {
 			if asm.accountIsValid(account) {
 				walletAccounts[wal.ID] = append(walletAccounts[wal.ID], &selectorAccount{
-					Account:    account,
-					clickEvent: &gesture.Click{},
+					Account: account,
+					button:  new(widget.Clickable),
 				})
 			}
 		}
@@ -289,11 +287,9 @@ func (asm *AccountSelectorModal) Handle() {
 	if asm.eventQueue != nil {
 		for _, accounts := range asm.accounts {
 			for _, account := range accounts {
-				for _, e := range account.clickEvent.Events(asm.eventQueue) {
-					if e.Type == gesture.TypeClick {
-						asm.callback(account.Account)
-						asm.Dismiss()
-					}
+				if account.button.Clicked() {
+					asm.callback(account.Account)
+					asm.Dismiss()
 				}
 			}
 		}
@@ -374,8 +370,14 @@ func (asm *AccountSelectorModal) Layout(gtx layout.Context) layout.Dimensions {
 						wal := asm.filteredWallets[windex]
 						return wallAcctGroup(gtx, wal.Name, func(gtx C) D {
 							accounts := asm.accounts[wal.ID]
+
+							card := asm.Theme.Card()
+							card.Color = color.NRGBA{}
+							card.Radius = decredmaterial.Radius(0)
 							return asm.accountsList.Layout(gtx, len(accounts), func(gtx C, aindex int) D {
-								return asm.walletAccountLayout(gtx, accounts[aindex])
+								return card.HovarableLayout(gtx, accounts[aindex].button, func(gtx C) D {
+									return asm.walletAccountLayout(gtx, accounts[aindex])
+								})
 							})
 						})
 					})
@@ -401,66 +403,63 @@ func (asm *AccountSelectorModal) Layout(gtx layout.Context) layout.Dimensions {
 }
 
 func (asm *AccountSelectorModal) walletAccountLayout(gtx layout.Context, account *selectorAccount) layout.Dimensions {
-
-	// click listeners
-	pointer.Rect(image.Rectangle{Max: gtx.Constraints.Max}).Add(gtx.Ops)
-	account.clickEvent.Add(gtx.Ops)
-
 	accountIcon := asm.Icons.AccountIcon
+	gtx.Constraints.Min.X = gtx.Constraints.Max.X
 
-	return layout.Inset{
-		Bottom: values.MarginPadding20,
-	}.Layout(gtx, func(gtx C) D {
-		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-			layout.Rigid(func(gtx C) D {
-				return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-					layout.Flexed(0.1, func(gtx C) D {
-						return layout.Inset{
-							Right: values.MarginPadding18,
-						}.Layout(gtx, func(gtx C) D {
-							return accountIcon.Layout24dp(gtx)
-						})
-					}),
-					layout.Flexed(0.8, func(gtx C) D {
-						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								acct := asm.Theme.Label(values.TextSize18, account.Name)
-								acct.Color = asm.Theme.Color.Text
-								return EndToEndRow(gtx, acct.Layout, func(gtx C) D {
-									return LayoutBalance(gtx, asm.Load, dcrutil.Amount(account.TotalBalance).String())
+	return Container{Padding: layout.UniformInset(values.MarginPadding8)}.Layout(gtx, func(gtx C) D {
+		return layout.Stack{}.Layout(gtx,
+			layout.Stacked(func(gtx C) D {
+				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+							layout.Flexed(0.1, func(gtx C) D {
+								return layout.Inset{
+									Right: values.MarginPadding18,
+								}.Layout(gtx, func(gtx C) D {
+									return accountIcon.Layout24dp(gtx)
 								})
 							}),
-							layout.Rigid(func(gtx C) D {
-								spendable := asm.Theme.Label(values.TextSize14, values.String(values.StrLabelSpendable))
-								spendable.Color = asm.Theme.Color.Gray
-								spendableBal := asm.Theme.Label(values.TextSize14, dcrutil.Amount(account.Balance.Spendable).String())
-								spendableBal.Color = asm.Theme.Color.Gray
-								return EndToEndRow(gtx, spendable.Layout, spendableBal.Layout)
+							layout.Flexed(0.7, func(gtx C) D {
+								return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										acct := asm.Theme.Label(values.TextSize18, account.Name)
+										acct.Color = asm.Theme.Color.Text
+										return EndToEndRow(gtx, acct.Layout, func(gtx C) D {
+											return LayoutBalance(gtx, asm.Load, dcrutil.Amount(account.TotalBalance).String())
+										})
+									}),
+									layout.Rigid(func(gtx C) D {
+										spendable := asm.Theme.Label(values.TextSize14, values.String(values.StrLabelSpendable))
+										spendable.Color = asm.Theme.Color.Gray
+										spendableBal := asm.Theme.Label(values.TextSize14, dcrutil.Amount(account.Balance.Spendable).String())
+										spendableBal.Color = asm.Theme.Color.Gray
+										return EndToEndRow(gtx, spendable.Layout, spendableBal.Layout)
+									}),
+								)
+							}),
+							layout.Flexed(0.1, func(gtx C) D {
+								inset := layout.Inset{
+									Top: values.MarginPadding10,
+								}
+								sections := func(gtx layout.Context) layout.Dimensions {
+									return layout.E.Layout(gtx, func(gtx C) D {
+										return inset.Layout(gtx, func(gtx C) D {
+											return asm.Icons.NavigationCheck.Layout(gtx, values.MarginPadding20)
+										})
+									})
+								}
+
+								if account.Number == asm.currentSelectedAccount.Number &&
+									account.WalletID == asm.currentSelectedAccount.WalletID {
+									return sections(gtx)
+								}
+								return layout.Dimensions{}
 							}),
 						)
 					}),
-
-					layout.Flexed(0.1, func(gtx C) D {
-						inset := layout.Inset{
-							Right: values.MarginPadding10,
-							Top:   values.MarginPadding10,
-						}
-						sections := func(gtx layout.Context) layout.Dimensions {
-							return layout.E.Layout(gtx, func(gtx C) D {
-								return inset.Layout(gtx, func(gtx C) D {
-									return asm.Icons.NavigationCheck.Layout(gtx, values.MarginPadding20)
-								})
-							})
-						}
-
-						if account.Number == asm.currentSelectedAccount.Number &&
-							account.WalletID == asm.currentSelectedAccount.WalletID {
-							return sections(gtx)
-						}
-						return layout.Dimensions{}
-					}),
 				)
 			}),
+			layout.Expanded(account.button.Layout),
 		)
 	})
 }

--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -469,34 +469,33 @@ func (asm *AccountSelectorModal) walletInfoPopup(gtx layout.Context) layout.Dime
 	desc := "Some accounts are disabled by StakeShuffle settings to protect your privacy."
 	card := asm.Theme.Card()
 	card.Radius = decredmaterial.Radius(7)
-	border := widget.Border{Color: asm.Theme.Color.Background, CornerRadius: values.MarginPadding7, Width: values.MarginPadding1}
+	card.Border = true
+	card.BorderParam.CornerRadius = values.MarginPadding7
 	gtx.Constraints.Max.X = gtx.Px(values.MarginPadding280)
-	return border.Layout(gtx, func(gtx C) D {
-		return card.Layout(gtx, func(gtx C) D {
-			return layout.UniformInset(values.MarginPadding12).Layout(gtx, func(gtx C) D {
-				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
-						return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								txt := asm.Theme.Body2(title)
-								txt.Color = asm.Theme.Color.DeepBlue
-								txt.Font.Weight = text.Bold
-								return txt.Layout(gtx)
-							}),
-							layout.Rigid(func(gtx C) D {
-								txt := asm.Theme.Body2("Tx direction")
-								txt.Color = asm.Theme.Color.Gray
-								return txt.Layout(gtx)
-							}),
-						)
-					}),
-					layout.Rigid(func(gtx C) D {
-						txt := asm.Theme.Body2(desc)
-						txt.Color = asm.Theme.Color.Gray
-						return txt.Layout(gtx)
-					}),
-				)
-			})
+	return card.Layout(gtx, func(gtx C) D {
+		return layout.UniformInset(values.MarginPadding12).Layout(gtx, func(gtx C) D {
+			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							txt := asm.Theme.Body2(title)
+							txt.Color = asm.Theme.Color.DeepBlue
+							txt.Font.Weight = text.Bold
+							return txt.Layout(gtx)
+						}),
+						layout.Rigid(func(gtx C) D {
+							txt := asm.Theme.Body2("Tx direction")
+							txt.Color = asm.Theme.Color.Gray
+							return txt.Layout(gtx)
+						}),
+					)
+				}),
+				layout.Rigid(func(gtx C) D {
+					txt := asm.Theme.Body2(desc)
+					txt.Color = asm.Theme.Color.Gray
+					return txt.Layout(gtx)
+				}),
+			)
 		})
 	})
 }

--- a/ui/page/components/nav_drawer.go
+++ b/ui/page/components/nav_drawer.go
@@ -163,7 +163,7 @@ func (nd *NavDrawer) layoutNavRow(gtx layout.Context, background color.NRGBA, Cl
 	card := nd.Theme.Card()
 	card.Color = background
 	card.Radius = decredmaterial.Radius(0)
-	return card.HovarableLayout(gtx, Clickable, body)
+	return card.HoverableLayout(gtx, Clickable, body)
 }
 
 func (nd *NavDrawer) DrawerToggled(min bool) {

--- a/ui/page/debug_page.go
+++ b/ui/page/debug_page.go
@@ -91,17 +91,37 @@ func (pg *DebugPage) debugItem(gtx C, i int) D {
 	})
 }
 
-func (pg *DebugPage) layoutDebugItems(gtx C) {
-	background := pg.Theme.Color.Surface
+func (pg *DebugPage) layoutDebugItems(gtx C) D {
 	card := pg.Theme.Card()
-	card.Color = background
-	card.Layout(gtx, func(gtx C) D {
+	card.Border = true
+	return card.Layout(gtx, func(gtx C) D {
 		list := layout.List{Axis: layout.Vertical}
 		return list.Layout(gtx, len(pg.debugItems), func(gtx C, i int) D {
 			return layout.Inset{}.Layout(gtx, func(gtx C) D {
 				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 					layout.Rigid(func(gtx C) D {
-						return pg.debugItem(gtx, i)
+						zero := float32(0)
+						ten := float32(10)
+						card := pg.Theme.Card()
+						if i == len(pg.debugItems)-1 {
+							card.Radius = decredmaterial.CornerRadius{
+								TopLeft:     zero,
+								TopRight:    zero,
+								BottomRight: ten,
+								BottomLeft:  ten,
+							}
+						} else {
+							card.Radius = decredmaterial.CornerRadius{
+								TopLeft:     ten,
+								TopRight:    ten,
+								BottomRight: zero,
+								BottomLeft:  zero,
+							}
+						}
+
+						return card.HoverableLayout(gtx, pg.debugItems[i].clickable, func(gtx C) D {
+							return pg.debugItem(gtx, i)
+						})
 					}),
 					layout.Rigid(func(gtx C) D {
 						if i == len(pg.debugItems)-1 {

--- a/ui/page/help_page.go
+++ b/ui/page/help_page.go
@@ -75,21 +75,21 @@ func (pg *HelpPage) document() layout.Widget {
 }
 
 func (pg *HelpPage) pageSections(gtx layout.Context, icon *decredmaterial.Image, action *widget.Clickable, body layout.Widget) layout.Dimensions {
-	return layout.Inset{Bottom: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
-		return pg.Theme.Card().Layout(gtx, func(gtx C) D {
-			return decredmaterial.Clickable(gtx, action, func(gtx C) D {
-				return layout.UniformInset(values.MarginPadding15).Layout(gtx, func(gtx C) D {
-					return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle, Spacing: layout.SpaceAround}.Layout(gtx,
-						layout.Rigid(func(gtx C) D {
-							return icon.Layout24dp(gtx)
-						}),
-						layout.Rigid(body),
-						layout.Rigid(func(gtx C) D {
-							size := image.Point{X: gtx.Constraints.Max.X, Y: gtx.Constraints.Min.Y}
-							return layout.Dimensions{Size: size}
-						}),
-					)
-				})
+	card := pg.Theme.Card()
+	card.Border = true
+	return card.HoverableLayout(gtx, action, func(gtx C) D {
+		return decredmaterial.Clickable(gtx, action, func(gtx C) D {
+			return layout.UniformInset(values.MarginPadding15).Layout(gtx, func(gtx C) D {
+				return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle, Spacing: layout.SpaceAround}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return icon.Layout24dp(gtx)
+					}),
+					layout.Rigid(body),
+					layout.Rigid(func(gtx C) D {
+						size := image.Point{X: gtx.Constraints.Max.X, Y: gtx.Constraints.Min.Y}
+						return layout.Dimensions{Size: size}
+					}),
+				)
 			})
 		})
 	})

--- a/ui/page/more_page.go
+++ b/ui/page/more_page.go
@@ -114,8 +114,12 @@ func (pg *MorePage) layoutMoreItems(gtx layout.Context) layout.Dimensions {
 					Height:     decredmaterial.WrapContent,
 					Background: pg.Theme.Color.Surface,
 					Shadow:     pg.Theme.Shadow(),
-					Border:     decredmaterial.Border{Radius: decredmaterial.Radius(14)},
-					Padding:    layout.UniformInset(values.MarginPadding15)}.Layout(gtx,
+					HoverEffect: decredmaterial.Hover{
+						HoverButton: pg.morePageListItems[i].clickable,
+						HoverColor:  pg.Theme.Color.ActiveGray,
+					},
+					Border:  decredmaterial.Border{Radius: decredmaterial.Radius(14)},
+					Padding: layout.UniformInset(values.MarginPadding15)}.Layout(gtx,
 					layout.Rigid(func(gtx C) D {
 						return layout.Center.Layout(gtx, pg.morePageListItems[i].image.Layout24dp)
 					}),

--- a/ui/page/overview_page.go
+++ b/ui/page/overview_page.go
@@ -198,7 +198,7 @@ func (pg *OverviewPage) recentTransactionsSection(gtx layout.Context) layout.Dim
 						}}.Layout(gtx, message.Layout)
 					}
 
-					return pg.transactionsList.Layout(gtx, len(pg.transactions), func(gtx C, i int) D {
+					return pg.transactionsList.HoverableLayout(gtx, len(pg.transactions), func(gtx C, i int) D {
 						var row = components.TransactionRow{
 							Transaction: pg.transactions[i],
 							Index:       i,

--- a/ui/page/proposal/proposals_page.go
+++ b/ui/page/proposal/proposals_page.go
@@ -373,7 +373,7 @@ func (pg *ProposalsPage) layoutTabs(gtx C) D {
 			Left:  values.MarginPadding12,
 			Right: values.MarginPadding12,
 		}.Layout(gtx, func(gtx C) D {
-			return pg.categoryList.Layout(gtx, len(proposalCategoryTitles), func(gtx C, i int) D {
+			return pg.categoryList.HoverableLayout(gtx, len(proposalCategoryTitles), func(gtx C, i int) D {
 				gtx.Constraints.Min.X = int(width)
 				return layout.Stack{Alignment: layout.S}.Layout(gtx,
 					layout.Stacked(func(gtx C) D {

--- a/ui/page/security_tools_page.go
+++ b/ui/page/security_tools_page.go
@@ -89,21 +89,21 @@ func (pg *SecurityToolsPage) address() layout.Widget {
 }
 
 func (pg *SecurityToolsPage) pageSections(gtx layout.Context, icon *decredmaterial.Image, action *widget.Clickable, body layout.Widget) layout.Dimensions {
-	return layout.Inset{Bottom: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
-		return pg.Theme.Card().Layout(gtx, func(gtx C) D {
-			return decredmaterial.Clickable(gtx, action, func(gtx C) D {
-				return layout.UniformInset(values.MarginPadding15).Layout(gtx, func(gtx C) D {
-					return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle, Spacing: layout.SpaceAround}.Layout(gtx,
-						layout.Rigid(func(gtx C) D {
-							return icon.Layout24dp(gtx)
-						}),
-						layout.Rigid(body),
-						layout.Rigid(func(gtx C) D {
-							size := image.Point{X: gtx.Constraints.Max.X, Y: gtx.Constraints.Min.Y}
-							return layout.Dimensions{Size: size}
-						}),
-					)
-				})
+	card := pg.Theme.Card()
+	card.Border = true
+	return card.HoverableLayout(gtx, action, func(gtx C) D {
+		return decredmaterial.Clickable(gtx, action, func(gtx C) D {
+			return layout.UniformInset(values.MarginPadding15).Layout(gtx, func(gtx C) D {
+				return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle, Spacing: layout.SpaceAround}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return icon.Layout24dp(gtx)
+					}),
+					layout.Rigid(body),
+					layout.Rigid(func(gtx C) D {
+						size := image.Point{X: gtx.Constraints.Max.X, Y: gtx.Constraints.Min.Y}
+						return layout.Dimensions{Size: size}
+					}),
+				)
 			})
 		})
 	})

--- a/ui/page/sign_message_page.go
+++ b/ui/page/sign_message_page.go
@@ -168,23 +168,21 @@ func (pg *SignMessagePage) drawResult() layout.Widget {
 			layout.Rigid(func(gtx C) D {
 				return layout.Stack{}.Layout(gtx,
 					layout.Stacked(func(gtx C) D {
-						border := widget.Border{Color: pg.Theme.Color.LightGray, CornerRadius: values.MarginPadding10, Width: values.MarginPadding2}
 						wrapper := pg.Theme.Card()
 						wrapper.Color = pg.Theme.Color.LightGray
-						return border.Layout(gtx, func(gtx C) D {
-							return wrapper.Layout(gtx, func(gtx C) D {
-								return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
-									return layout.Flex{}.Layout(gtx,
-										layout.Flexed(0.9, pg.signedMessageLabel.Layout),
-										layout.Flexed(0.1, func(gtx C) D {
-											return layout.E.Layout(gtx, func(gtx C) D {
-												return layout.Inset{Top: values.MarginPadding7}.Layout(gtx, func(gtx C) D {
-													return decredmaterial.Clickable(gtx, pg.copySignature, pg.copyIcon.Layout24dp)
-												})
+						wrapper.Border = true
+						return wrapper.Layout(gtx, func(gtx C) D {
+							return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
+								return layout.Flex{}.Layout(gtx,
+									layout.Flexed(0.9, pg.signedMessageLabel.Layout),
+									layout.Flexed(0.1, func(gtx C) D {
+										return layout.E.Layout(gtx, func(gtx C) D {
+											return layout.Inset{Top: values.MarginPadding7}.Layout(gtx, func(gtx C) D {
+												return decredmaterial.Clickable(gtx, pg.copySignature, pg.copyIcon.Layout24dp)
 											})
-										}),
-									)
-								})
+										})
+									}),
+								)
 							})
 						})
 					}),

--- a/ui/page/tickets/list_page.go
+++ b/ui/page/tickets/list_page.go
@@ -205,7 +205,7 @@ func (pg *ListPage) Layout(gtx C) D {
 						return pg.orderDropDown.Layout(gtx, 0, true)
 					}),
 					layout.Expanded(func(gtx C) D {
-						return pg.ticketTypeDropDown.Layout(gtx, pg.orderDropDown.Width+10, true)
+						return pg.ticketTypeDropDown.Layout(gtx, pg.orderDropDown.Width, true)
 					}),
 				)
 			},

--- a/ui/page/transactions_page.go
+++ b/ui/page/transactions_page.go
@@ -168,7 +168,7 @@ func (pg *TransactionsPage) Layout(gtx layout.Context) layout.Dimensions {
 				return pg.orderDropDown.Layout(gtx, 0, true)
 			}),
 			layout.Expanded(func(gtx C) D {
-				return pg.txTypeDropDown.Layout(gtx, pg.orderDropDown.Width+10, true)
+				return pg.txTypeDropDown.Layout(gtx, pg.orderDropDown.Width, true)
 			}),
 		)
 	}

--- a/ui/page/transactions_page.go
+++ b/ui/page/transactions_page.go
@@ -132,7 +132,7 @@ func (pg *TransactionsPage) Layout(gtx layout.Context) layout.Dimensions {
 							})
 						}
 
-						return pg.transactionList.Layout(gtx, len(wallTxs), func(gtx C, index int) D {
+						return pg.transactionList.HoverableLayout(gtx, len(wallTxs), func(gtx C, index int) D {
 							var row = components.TransactionRow{
 								Transaction: wallTxs[index],
 								Index:       index,

--- a/ui/page/wallet_page.go
+++ b/ui/page/wallet_page.go
@@ -397,11 +397,15 @@ func (pg *WalletPage) layoutOptionsMenu(gtx layout.Context, optionsMenuIndex int
 				return (&layout.List{Axis: layout.Vertical}).Layout(gtx, len(menu), func(gtx C, i int) D {
 					return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 						layout.Rigid(func(gtx C) D {
-							return material.Clickable(gtx, menu[i].button, func(gtx C) D {
-								m10 := values.MarginPadding10
-								return layout.Inset{Top: m10, Bottom: m10, Left: m10, Right: m10}.Layout(gtx, func(gtx C) D {
-									gtx.Constraints.Min.X = gtx.Constraints.Max.X
-									return pg.Theme.Body1(menu[i].text).Layout(gtx)
+							card := pg.Theme.Card()
+							card.Radius = decredmaterial.Radius(0)
+							return card.HoverableLayout(gtx, menu[i].button, func(gtx C) D {
+								return material.Clickable(gtx, menu[i].button, func(gtx C) D {
+									m10 := values.MarginPadding10
+									return layout.Inset{Top: m10, Bottom: m10, Left: m10, Right: m10}.Layout(gtx, func(gtx C) D {
+										gtx.Constraints.Min.X = gtx.Constraints.Max.X
+										return pg.Theme.Body1(menu[i].text).Layout(gtx)
+									})
 								})
 							})
 						}),
@@ -454,7 +458,7 @@ func (pg *WalletPage) walletSection(gtx layout.Context) layout.Dimensions {
 						}.Layout(gtx, pg.Theme.Separator().Layout)
 					}),
 					layout.Rigid(func(gtx C) D {
-						return listItem.accountsList.Layout(gtx, len(listItem.accounts), func(gtx C, x int) D {
+						return listItem.accountsList.HoverableLayout(gtx, len(listItem.accounts), func(gtx C, x int) D {
 							return pg.walletAccountsLayout(gtx, listItem.accounts[x])
 						})
 					}),
@@ -786,13 +790,11 @@ func (pg *WalletPage) layoutAddWalletMenu(gtx layout.Context) layout.Dimensions 
 	}
 
 	return inset.Layout(gtx, func(gtx C) D {
-		border := widget.Border{Color: pg.Theme.Color.LightGray, CornerRadius: unit.Dp(5), Width: unit.Dp(2)}
-		return border.Layout(gtx, func(gtx C) D {
-			return pg.optionsMenuCard.Layout(gtx, func(gtx C) D {
-				return (&layout.List{Axis: layout.Vertical}).Layout(gtx, len(pg.addWalletMenu), func(gtx C, i int) D {
-					return material.Clickable(gtx, pg.addWalletMenu[i].button, func(gtx C) D {
-						return layout.UniformInset(unit.Dp(10)).Layout(gtx, pg.Theme.Body2(pg.addWalletMenu[i].text).Layout)
-					})
+		pg.optionsMenuCard.Border = true
+		return pg.optionsMenuCard.Layout(gtx, func(gtx C) D {
+			return (&layout.List{Axis: layout.Vertical}).Layout(gtx, len(pg.addWalletMenu), func(gtx C, i int) D {
+				return material.Clickable(gtx, pg.addWalletMenu[i].button, func(gtx C) D {
+					return layout.UniformInset(unit.Dp(10)).Layout(gtx, pg.Theme.Body2(pg.addWalletMenu[i].text).Layout)
 				})
 			})
 		})


### PR DESCRIPTION
Fix #608
Fix #606

- add hover effect to transactions and overview tx tables
- add hover effect to drop down
- add hover effect to account selector
- add hover to linear layout
- add border option to card widget
- add hoverable card and clickable layout

![ezgif com-gif-maker(5)](https://user-images.githubusercontent.com/27733432/133004137-1a5b4bff-4307-46d7-ad65-536610424c29.gif)
