### PR TITLE
Allow empty new password for wallet in serveral cases

### DIFF
--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -362,3 +362,18 @@ func approxLuminance(c color.NRGBA) byte {
 	)
 	return byte((r*int(c.R) + g*int(c.G) + b*int(c.B)) / t)
 }
+
+func HandleEditorEvents(editors ...*widget.Editor) (bool, bool) {
+	var submit, changed bool
+	for _, editor := range editors {
+		for _, evt := range editor.Events() {
+			switch evt.(type) {
+			case widget.ChangeEvent:
+				changed = true
+			case widget.SubmitEvent:
+				submit = true
+			}
+		}
+	}
+	return submit, changed
+}

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -30,7 +30,6 @@ type CreatePasswordModal struct {
 	isCancelable       bool
 	walletNameEnabled  bool
 	showWalletWarnInfo bool
-	isSubmit           bool
 	isEnabled          bool
 
 	dialogTitle string
@@ -153,7 +152,7 @@ func (cm *CreatePasswordModal) Handle() {
 		cm.isEnabled = false
 	}
 
-	isSubmit, isChanged := handleEditorEvents(cm.passwordEditor.Editor, cm.confirmPasswordEditor.Editor, cm.walletName.Editor)
+	isSubmit, isChanged := decredmaterial.HandleEditorEvents(cm.passwordEditor.Editor, cm.confirmPasswordEditor.Editor, cm.walletName.Editor)
 
 	if isChanged {
 		// reset editor errors

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -109,7 +109,7 @@ func (cm *CreateWatchOnlyModal) Handle() {
 		cm.isEnabled = false
 	}
 
-	isSubmit, isChanged := handleEditorEvents(cm.walletName.Editor, cm.extendedPubKey.Editor)
+	isSubmit, isChanged := decredmaterial.HandleEditorEvents(cm.walletName.Editor, cm.extendedPubKey.Editor)
 	if isChanged {
 		// reset editor errors
 		cm.walletName.SetError("")

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -32,6 +32,7 @@ type CreateWatchOnlyModal struct {
 
 	isLoading    bool
 	isCancelable bool
+	isEnabled    bool
 
 	callback func(walletName, extPubKey string, m *CreateWatchOnlyModal) bool // return true to dismiss dialog
 }
@@ -90,11 +91,7 @@ func (cm *CreateWatchOnlyModal) SetCancelable(min bool) *CreateWatchOnlyModal {
 }
 
 func (cm *CreateWatchOnlyModal) SetError(err string) {
-	if err == "" {
-		cm.extendedPubKey.ClearError()
-	} else {
-		cm.extendedPubKey.SetError(err)
-	}
+	cm.extendedPubKey.SetError(err)
 }
 
 func (cm *CreateWatchOnlyModal) WatchOnlyCreated(callback func(walletName, extPubKey string, m *CreateWatchOnlyModal) bool) *CreateWatchOnlyModal {
@@ -103,14 +100,36 @@ func (cm *CreateWatchOnlyModal) WatchOnlyCreated(callback func(walletName, extPu
 }
 
 func (cm *CreateWatchOnlyModal) Handle() {
+	if editorsNotEmpty(cm.walletName.Editor) ||
+		editorsNotEmpty(cm.extendedPubKey.Editor) {
+		cm.btnPositve.Background = cm.Theme.Color.Primary
+		cm.isEnabled = true
+	} else {
+		cm.btnPositve.Background = cm.Theme.Color.InactiveGray
+		cm.isEnabled = false
+	}
 
-	if editorsNotEmpty(cm.walletName.Editor, cm.extendedPubKey.Editor) ||
-		handleSubmitEvent(cm.walletName.Editor, cm.extendedPubKey.Editor) {
-		for cm.btnPositve.Button.Clicked() {
-			cm.SetLoading(true)
-			if cm.callback(cm.walletName.Editor.Text(), cm.extendedPubKey.Editor.Text(), cm) {
-				cm.Dismiss()
-			}
+	isSubmit, isChanged := handleEditorEvents(cm.walletName.Editor, cm.extendedPubKey.Editor)
+	if isChanged {
+		// reset editor errors
+		cm.walletName.SetError("")
+		cm.extendedPubKey.SetError("")
+	}
+
+	for (cm.btnPositve.Button.Clicked() || isSubmit) && cm.isEnabled {
+		if !editorsNotEmpty(cm.walletName.Editor) {
+			cm.walletName.SetError("enter wallet name")
+			return
+		}
+
+		if !editorsNotEmpty(cm.extendedPubKey.Editor) {
+			cm.extendedPubKey.SetError("enter a valid extendedPubKey")
+			return
+		}
+
+		cm.SetLoading(true)
+		if cm.callback(cm.walletName.Editor.Text(), cm.extendedPubKey.Editor.Text(), cm) {
+			cm.Dismiss()
 		}
 	}
 
@@ -156,7 +175,7 @@ func (cm *CreateWatchOnlyModal) Layout(gtx layout.Context) D {
 						if cm.isLoading {
 							return cm.materialLoader.Layout(gtx)
 						}
-						cm.btnPositve.Background, cm.btnPositve.Color = cm.Theme.Color.Surface, cm.Theme.Color.Primary
+
 						return cm.btnPositve.Layout(gtx)
 					}),
 				)

--- a/ui/modal/password_modal.go
+++ b/ui/modal/password_modal.go
@@ -50,7 +50,7 @@ func NewPasswordModal(l *load.Load) *PasswordModal {
 	pm.btnNegative.TextSize = values.TextSize16
 	pm.btnNegative.Background, pm.btnNegative.Color = pm.Theme.Color.Surface, pm.Theme.Color.Primary
 	pm.btnPositve.Font.Weight, pm.btnNegative.Font.Weight = text.Bold, text.Bold
-	pm.btnPositve.Background = pm.Theme.Color.InactiveGray
+	pm.btnPositve.Background = pm.Theme.Color.Primary
 
 	pm.password = l.Theme.EditorPassword(new(widget.Editor), "Spending password")
 	pm.password.Editor.SingleLine, pm.password.Editor.Submit = true, true
@@ -66,6 +66,7 @@ func (pm *PasswordModal) ModalID() string {
 }
 
 func (pm *PasswordModal) OnResume() {
+	pm.password.Editor.Focus()
 }
 
 func (pm *PasswordModal) OnDismiss() {
@@ -120,16 +121,20 @@ func (pm *PasswordModal) SetError(err string) {
 }
 
 func (pm *PasswordModal) Handle() {
-	if editorsNotEmpty(pm.password.Editor) {
-		pm.btnPositve.Background = pm.Theme.Color.Primary
-	} else {
-		pm.btnPositve.Background = pm.Theme.Color.InactiveGray
+	isSubmit, isChanged := handleEditorEvents(pm.password.Editor)
+	if isChanged {
+		pm.password.SetError("")
 	}
 
-	for pm.btnPositve.Button.Clicked() || handleSubmitEvent(pm.password.Editor) {
+	if pm.btnPositve.Button.Clicked() || isSubmit {
 
-		if pm.isLoading || !editorsNotEmpty(pm.password.Editor) {
-			continue
+		if !editorsNotEmpty(pm.password.Editor) {
+			pm.password.SetError("enter spending password")
+			return
+		}
+
+		if pm.isLoading {
+			return
 		}
 
 		pm.SetLoading(true)

--- a/ui/modal/password_modal.go
+++ b/ui/modal/password_modal.go
@@ -121,7 +121,7 @@ func (pm *PasswordModal) SetError(err string) {
 }
 
 func (pm *PasswordModal) Handle() {
-	isSubmit, isChanged := handleEditorEvents(pm.password.Editor)
+	isSubmit, isChanged := decredmaterial.HandleEditorEvents(pm.password.Editor)
 	if isChanged {
 		pm.password.SetError("")
 	}

--- a/ui/modal/text_input_modal.go
+++ b/ui/modal/text_input_modal.go
@@ -21,6 +21,7 @@ type TextInputModal struct {
 	IsLoading           bool
 	showAccountWarnInfo bool
 	isCancelable        bool
+	isEnabled           bool
 
 	textInput decredmaterial.Editor
 	callback  func(string, *TextInputModal) bool
@@ -42,6 +43,10 @@ func NewTextInputModal(l *load.Load) *TextInputModal {
 
 func (tm *TextInputModal) Show() {
 	tm.ShowModal(tm)
+}
+
+func (tm *TextInputModal) OnResume() {
+	tm.textInput.Editor.Focus()
 }
 
 func (tm *TextInputModal) Dismiss() {
@@ -85,13 +90,20 @@ func (tm *TextInputModal) SetCancelable(min bool) *TextInputModal {
 func (tm *TextInputModal) Handle() {
 	if editorsNotEmpty(tm.textInput.Editor) {
 		tm.btnPositve.Background = tm.Theme.Color.Primary
+		tm.isEnabled = true
 	} else {
 		tm.btnPositve.Background = tm.Theme.Color.InactiveGray
+		tm.isEnabled = false
 	}
 
-	for tm.btnPositve.Button.Clicked() || handleSubmitEvent(tm.textInput.Editor) {
+	isSubmit, isChanged := handleEditorEvents(tm.textInput.Editor)
+	if isChanged {
+		tm.textInput.SetError("")
+	}
+
+	if (tm.btnPositve.Button.Clicked() || isSubmit) && tm.isEnabled {
 		if tm.IsLoading {
-			continue
+			return
 		}
 
 		tm.IsLoading = true

--- a/ui/modal/text_input_modal.go
+++ b/ui/modal/text_input_modal.go
@@ -96,7 +96,7 @@ func (tm *TextInputModal) Handle() {
 		tm.isEnabled = false
 	}
 
-	isSubmit, isChanged := handleEditorEvents(tm.textInput.Editor)
+	isSubmit, isChanged := decredmaterial.HandleEditorEvents(tm.textInput.Editor)
 	if isChanged {
 		tm.textInput.SetError("")
 	}

--- a/ui/modal/utils.go
+++ b/ui/modal/utils.go
@@ -25,21 +25,6 @@ func editorsNotEmpty(editors ...*widget.Editor) bool {
 	return true
 }
 
-func handleEditorEvents(editors ...*widget.Editor) (bool, bool) {
-	var submit, changed bool
-	for _, editor := range editors {
-		for _, evt := range editor.Events() {
-			switch evt.(type) {
-			case widget.ChangeEvent:
-				changed = true
-			case widget.SubmitEvent:
-				submit = true
-			}
-		}
-	}
-	return submit, changed
-}
-
 func generateRandomNumber() int {
 	return rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 }

--- a/ui/modal/utils.go
+++ b/ui/modal/utils.go
@@ -25,16 +25,19 @@ func editorsNotEmpty(editors ...*widget.Editor) bool {
 	return true
 }
 
-func handleSubmitEvent(editors ...*widget.Editor) bool {
-	var submit bool
+func handleEditorEvents(editors ...*widget.Editor) (bool, bool) {
+	var submit, changed bool
 	for _, editor := range editors {
-		for _, e := range editor.Events() {
-			if _, ok := e.(widget.SubmitEvent); ok {
+		for _, evt := range editor.Events() {
+			switch evt.(type) {
+			case widget.ChangeEvent:
+				changed = true
+			case widget.SubmitEvent:
 				submit = true
 			}
 		}
 	}
-	return submit
+	return submit, changed
 }
 
 func generateRandomNumber() int {

--- a/ui/page/validate_address.go
+++ b/ui/page/validate_address.go
@@ -29,8 +29,8 @@ type ValidateAddressPage struct {
 	clearBtn, validateBtn decredmaterial.Button
 	stateValidate         int
 	walletName            string
-
-	backButton decredmaterial.IconButton
+	isEnabled             bool
+	backButton            decredmaterial.IconButton
 }
 
 func NewValidateAddressPage(l *load.Load) *ValidateAddressPage {
@@ -66,7 +66,7 @@ func (pg *ValidateAddressPage) ID() string {
 }
 
 func (pg *ValidateAddressPage) OnResume() {
-
+	pg.addressEditor.Editor.Focus()
 }
 
 func (pg *ValidateAddressPage) Layout(gtx layout.Context) layout.Dimensions {
@@ -227,16 +227,12 @@ func (pg *ValidateAddressPage) pageSections(gtx layout.Context, body layout.Widg
 func (pg *ValidateAddressPage) Handle() {
 	pg.updateButtonColors()
 
-	for _, evt := range pg.addressEditor.Editor.Events() {
-		if pg.addressEditor.Editor.Focused() {
-			switch evt.(type) {
-			case widget.ChangeEvent:
-				pg.stateValidate = none
-			}
-		}
+	isSubmit, isChanged := decredmaterial.HandleEditorEvents(pg.addressEditor.Editor)
+	if isChanged {
+		pg.stateValidate = none
 	}
 
-	if pg.validateBtn.Button.Clicked() {
+	if (pg.validateBtn.Button.Clicked() || isSubmit) && pg.isEnabled {
 		pg.validateAddress()
 	}
 
@@ -278,9 +274,11 @@ func (pg *ValidateAddressPage) updateButtonColors() {
 	if !components.StringNotEmpty(pg.addressEditor.Editor.Text()) {
 		pg.validateBtn.Background = pg.Theme.Color.Hint
 		pg.clearBtn.Color = pg.Theme.Color.Hint
+		pg.isEnabled = false
 	} else {
 		pg.validateBtn.Background = pg.Theme.Color.Primary
 		pg.clearBtn.Color = pg.Theme.Color.Primary
+		pg.isEnabled = true
 	}
 }
 


### PR DESCRIPTION
This will resolve #596 

Currently, when we send empty password, the server resolves in this:
![image](https://user-images.githubusercontent.com/19331824/132983638-80353850-4ab9-45d9-9c72-e2475871bd8d.png)

I have already work out a way to notify the user about the response.
![image](https://user-images.githubusercontent.com/19331824/132983649-a20004d6-3d8a-4136-b9c8-4860d43a97b2.png)

Whether or not this behavior is expected and/or desired is debateable.