### PR TITLE
Add wallet seed backup notification modal

### DIFF
--- a/ui/decredmaterial/modal.go
+++ b/ui/decredmaterial/modal.go
@@ -58,7 +58,7 @@ func (m *Modal) Layout(gtx layout.Context, widgets []layout.Widget, margin int) 
 				widgetFuncs = append(widgetFuncs, widgets...)
 			}
 
-			gtx.Constraints.Max.X = gtx.Px(unit.Dp(450))
+			gtx.Constraints.Max.X = gtx.Px(unit.Dp(380))
 			inset := layout.Inset{
 				Top:    unit.Dp(50),
 				Bottom: unit.Dp(50),
@@ -68,7 +68,7 @@ func (m *Modal) Layout(gtx layout.Context, widgets []layout.Widget, margin int) 
 					Orientation: layout.Vertical,
 					Width:       WrapContent,
 					Height:      WrapContent,
-					Padding:     layout.UniformInset(unit.Dp(15)),
+					Padding:     layout.UniformInset(unit.Dp(16)),
 					Alignment:   layout.Middle,
 					Border: Border{
 						Radius: Radius(14),

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -271,14 +271,14 @@ func (cm *CreatePasswordModal) Layout(gtx layout.Context) D {
 						return layout.Flex{Spacing: layout.SpaceBetween}.Layout(gtx,
 							layout.Rigid(func(gtx C) D {
 								if cm.showWalletWarnInfo {
-									txt := cm.Theme.Label(values.MarginPadding14, "This spending password is for the new wallet only")
+									txt := cm.Theme.Label(values.MarginPadding12, "This spending password is for the new wallet only")
 									txt.Color = cm.Theme.Color.Gray4
 									return txt.Layout(gtx)
 								}
 								return layout.Dimensions{}
 							}),
 							layout.Rigid(func(gtx C) D {
-								txt := cm.Theme.Label(values.MarginPadding14, strconv.Itoa(cm.passwordEditor.Editor.Len()))
+								txt := cm.Theme.Label(values.MarginPadding12, strconv.Itoa(cm.passwordEditor.Editor.Len()))
 								txt.Color = cm.Theme.Color.Gray4
 								return layout.E.Layout(gtx, txt.Layout)
 							}),

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -37,6 +37,8 @@ type InfoModal struct {
 	negativeButtonClicked func()
 	btnNegative           decredmaterial.Button
 
+	checkbox decredmaterial.CheckBoxStyle
+
 	isCancelable bool
 
 	//TODO: neutral button
@@ -88,6 +90,11 @@ func (in *InfoModal) Icon(icon *widget.Icon) *InfoModal {
 	return in
 }
 
+func (in *InfoModal) CheckBox(checkbox decredmaterial.CheckBoxStyle) *InfoModal {
+	in.checkbox = checkbox
+	return in
+}
+
 func (in *InfoModal) Title(title string) *InfoModal {
 	in.dialogTitle = title
 	return in
@@ -106,6 +113,11 @@ func (in *InfoModal) PositiveButton(text string, clicked func()) *InfoModal {
 
 func (in *InfoModal) PositiveButtonStyle(background, text color.NRGBA) *InfoModal {
 	in.btnPositve.Background, in.btnPositve.Color = background, text
+	return in
+}
+
+func (in *InfoModal) NegativeButtonStyle(background, text color.NRGBA) *InfoModal {
+	in.btnNegative.Background, in.btnNegative.Color = background, text
 	return in
 }
 
@@ -133,6 +145,8 @@ func (in *InfoModal) SetupWithTemplate(template string) *InfoModal {
 		customTemplate = privacyInfo(in.Theme)
 	case SetupMixerInfoTemplate:
 		customTemplate = setupMixerInfo(in.Theme)
+	case WalletBackupInfoTemplate:
+		customTemplate = backupInfo(in.Theme)
 	}
 
 	in.dialogTitle = title
@@ -166,6 +180,10 @@ func (in *InfoModal) Handle() {
 	if in.modal.BackdropClicked(in.isCancelable) {
 		in.Dismiss()
 	}
+
+	if in.checkbox.CheckBox != nil {
+		in.btnNegative.SetEnabled(in.checkbox.CheckBox.Value)
+	}
 }
 
 func (in *InfoModal) Layout(gtx layout.Context) D {
@@ -179,6 +197,22 @@ func (in *InfoModal) Layout(gtx layout.Context) D {
 				gtx.Constraints.Min.X = gtx.Px(values.MarginPadding50)
 				return in.dialogIcon.Layout(gtx, in.Theme.Color.DeepBlue)
 			})
+		})
+	}
+
+	checkbox := func(gtx C) D {
+		if in.checkbox.CheckBox == nil {
+			return layout.Dimensions{}
+		}
+
+		return layout.Inset{Top: values.MarginPaddingMinus5, Left: values.MarginPaddingMinus5}.Layout(gtx, func(gtx C) D {
+			in.checkbox.TextSize = values.TextSize14
+			in.checkbox.Color = in.Theme.Color.Gray3
+			in.checkbox.IconColor = in.Theme.Color.Gray1
+			if in.checkbox.CheckBox.Value {
+				in.checkbox.IconColor = in.Theme.Color.Primary
+			}
+			return in.checkbox.Layout(gtx)
 		})
 	}
 
@@ -207,6 +241,10 @@ func (in *InfoModal) Layout(gtx layout.Context) D {
 		w = append(w, in.customTemplate...)
 	}
 
+	if in.checkbox.CheckBox != nil {
+		w = append(w, checkbox)
+	}
+
 	if in.negativeButtonText != "" || in.positiveButtonText != "" {
 		w = append(w, in.actionButtonsLayout())
 	}
@@ -224,7 +262,12 @@ func (in *InfoModal) titleLayout() layout.Widget {
 
 func (in *InfoModal) actionButtonsLayout() layout.Widget {
 	return func(gtx C) D {
-		return layout.E.Layout(gtx, func(gtx C) D {
+		alignment := layout.E
+		if in.checkbox.CheckBox != nil {
+			alignment = layout.Center
+		}
+
+		return alignment.Layout(gtx, func(gtx C) D {
 			return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
 					if in.negativeButtonText == "" {
@@ -232,7 +275,7 @@ func (in *InfoModal) actionButtonsLayout() layout.Widget {
 					}
 
 					in.btnNegative.Text = in.negativeButtonText
-					return in.btnNegative.Layout(gtx)
+					return layout.Inset{Right: values.MarginPadding5}.Layout(gtx, in.btnNegative.Layout)
 				}),
 				layout.Rigid(func(gtx C) D {
 					if in.positiveButtonText == "" {

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -116,11 +116,6 @@ func (in *InfoModal) PositiveButtonStyle(background, text color.NRGBA) *InfoModa
 	return in
 }
 
-func (in *InfoModal) NegativeButtonStyle(background, text color.NRGBA) *InfoModal {
-	in.btnNegative.Background, in.btnNegative.Color = background, text
-	return in
-}
-
 func (in *InfoModal) NegativeButton(text string, clicked func()) *InfoModal {
 	in.negativeButtonText = text
 	in.negativeButtonClicked = clicked

--- a/ui/modal/info_modal_layouts.go
+++ b/ui/modal/info_modal_layouts.go
@@ -104,21 +104,20 @@ func transactionDetailsInfo(th *decredmaterial.Theme) []layout.Widget {
 }
 
 func backupInfo(th *decredmaterial.Theme) []layout.Widget {
-	textGray := "Please backup your seed words and keep them in a safe place in order to recover your funds " +
-		"if your device gets lost or broken."
-
+	textGray := "Please backup your seed words and keep them in a safe place in order to recover your funds if your device gets lost or broken."
 	textDanger := "Anyone who has your seed words can spend your funds! Do not share them."
+
 	return []layout.Widget{
 		func(gtx C) D {
-			txt := th.Body1(textGray)
+			txt := th.Label(values.TextSize16, textGray)
 			txt.Color = th.Color.Gray3
 			return txt.Layout(gtx)
 		},
 		func(gtx C) D {
-			txt := th.Body1(textDanger)
+			txt := th.Label(values.TextSize16, textDanger)
 			txt.Color = th.Color.Danger
 			txt.Font.Weight = text.Medium
-			return layout.Inset{Top: values.MarginPaddingMinus10}.Layout(gtx, txt.Layout)
+			return layout.Inset{Top: values.MarginPaddingMinus15}.Layout(gtx, txt.Layout)
 		},
 	}
 }

--- a/ui/modal/info_modal_layouts.go
+++ b/ui/modal/info_modal_layouts.go
@@ -17,6 +17,7 @@ const (
 	PrivacyInfoTemplate            = "PrivacyInfo"
 	SetupMixerInfoTemplate         = "ConfirmSetupMixer"
 	TransactionDetailsInfoTemplate = "TransactionDetailsInfoInfo"
+	WalletBackupInfoTemplate       = "WalletBackupInfo"
 )
 
 func verifyMessageInfo(th *decredmaterial.Theme) []layout.Widget {
@@ -99,5 +100,25 @@ func transactionDetailsInfo(th *decredmaterial.Theme) []layout.Widget {
 
 	return []layout.Widget{
 		renderers.RenderHTML(text, th).Layout,
+	}
+}
+
+func backupInfo(th *decredmaterial.Theme) []layout.Widget {
+	textGray := "Please backup your seed words and keep them in a safe place in order to recover your funds " +
+		"if your device gets lost or broken."
+
+	textDanger := "Anyone who has your seed words can spend your funds! Do not share them."
+	return []layout.Widget{
+		func(gtx C) D {
+			txt := th.Body1(textGray)
+			txt.Color = th.Color.Gray3
+			return txt.Layout(gtx)
+		},
+		func(gtx C) D {
+			txt := th.Body1(textDanger)
+			txt.Color = th.Color.Danger
+			txt.Font.Weight = text.Medium
+			return layout.Inset{Top: values.MarginPaddingMinus10}.Layout(gtx, txt.Layout)
+		},
 	}
 }

--- a/ui/page/help_page.go
+++ b/ui/page/help_page.go
@@ -23,7 +23,7 @@ type HelpPage struct {
 func NewHelpPage(l *load.Load) *HelpPage {
 	pg := &HelpPage{
 		Load:          l,
-		documentation: l.Theme.NewClickable(false),
+		documentation: l.Theme.NewClickable(true),
 	}
 
 	pg.documentation.Radius = decredmaterial.Radius(14)

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -173,6 +173,7 @@ func (mp *MainPage) OnResume() {
 	mp.WL.MultiWallet.AddTxAndBlockNotificationListener(mp, MainPageID)
 	mp.WL.MultiWallet.AddSyncProgressListener(mp, MainPageID)
 	mp.WL.MultiWallet.SetBlocksRescanProgressListener(mp)
+	mp.WL.Wallet.SaveConfigValueForKey("seedBackupNotification", false)
 
 	mp.setLanguageSetting()
 	mp.UpdateBalance()
@@ -339,6 +340,7 @@ func (mp *MainPage) OnClose() {
 	mp.WL.MultiWallet.Politeia.RemoveNotificationListener(MainPageID)
 	mp.WL.MultiWallet.RemoveTxAndBlockNotificationListener(MainPageID)
 	mp.WL.MultiWallet.RemoveSyncProgressListener(MainPageID)
+	mp.WL.Wallet.SaveConfigValueForKey("seedBackupNotification", false)
 }
 
 func (mp *MainPage) currentPageID() string {

--- a/ui/page/security_tools_page.go
+++ b/ui/page/security_tools_page.go
@@ -24,8 +24,8 @@ type SecurityToolsPage struct {
 func NewSecurityToolsPage(l *load.Load) *SecurityToolsPage {
 	pg := &SecurityToolsPage{
 		Load:            l,
-		verifyMessage:   l.Theme.NewClickable(false),
-		validateAddress: l.Theme.NewClickable(false),
+		verifyMessage:   l.Theme.NewClickable(true),
+		validateAddress: l.Theme.NewClickable(true),
 	}
 
 	pg.verifyMessage.Radius = decredmaterial.Radius(14)

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -26,6 +26,7 @@ var (
 	MarginPadding14       = unit.Dp(14)
 	MarginPadding13       = unit.Dp(13)
 	MarginPadding15       = unit.Dp(15)
+	MarginPaddingMinus15  = unit.Dp(-15)
 	MarginPadding16       = unit.Dp(16)
 	MarginPadding18       = unit.Dp(18)
 	MarginPadding20       = unit.Dp(20)


### PR DESCRIPTION
This PR adds wallet seed backup notification when pages loads for the first time and there is a wallet that needs its seed words to be backed up. 

![image](https://user-images.githubusercontent.com/27733432/136553994-1828bc44-9f81-4aa0-89ec-a099ad416c91.png)

![image](https://user-images.githubusercontent.com/27733432/136554050-9595ad17-a005-402a-a689-6121d636bc18.png)
