### PR TITLE
Adds editor icons

### DIFF
--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -79,7 +79,7 @@ func (t *Theme) RestoreEditor(editor *widget.Editor, hint string, title string) 
 
 //CREATES AN EDITOR WIDGET WITH ICON OF CHOICE.
 func (t *Theme) IconEditor(editor *widget.Editor, hint string, editorIcon []byte, showEditorIcon bool) Editor {
-	e:= t.Editor(editor, hint)
+	e := t.Editor(editor, hint)
 	e.showEditorIcon = showEditorIcon
 	e.editorIconButton.IconButtonStyle.Icon = MustIcon(widget.NewIcon(editorIcon))
 	return e

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -255,10 +255,8 @@ func (e Editor) editor(gtx layout.Context) layout.Dimensions {
 				return inset.Layout(gtx, func(gtx C) D {
 					if e.isEditorButtonClickable {
 						return e.editorIconButton.Layout(gtx)
-					} else {
-						return e.editorIcon.Layout(gtx, unit.Dp(25))
 					}
-
+					return e.editorIcon.Layout(gtx, unit.Dp(25))
 				})
 			} else if e.isPassword {
 				inset := layout.Inset{

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -36,18 +36,23 @@ type Editor struct {
 	IsRequired bool
 	// IsTitleLabel if true makes the title label visible.
 	IsTitleLabel bool
-	// Bordered if true makes the adds a border around the editor.
+
 	HasCustomButton bool
 	CustomButton    Button
 
+	// Bordered if true makes the adds a border around the editor.
 	Bordered bool
 	// isPassword if true, displays the show and hide button.
 	isPassword bool
 	// If showEditorIcon is true, displays the editor widget Icon of choice
 	showEditorIcon bool
 
+	// isEditorButtonClickable passes a clickable icon button if true and regular icon if false
+	isEditorButtonClickable bool
+
 	requiredErrorText string
 
+	editorIcon       Icon
 	editorIconButton IconButton
 	showHidePassword IconButton
 
@@ -79,10 +84,13 @@ func (t *Theme) RestoreEditor(editor *widget.Editor, hint string, title string) 
 	}
 }
 
-// IconEditor func creates an editor widget with icon of choice
-func (t *Theme) IconEditor(editor *widget.Editor, hint string, editorIcon []byte, showEditorIcon bool, editorIconEvent func()) Editor {
+// IconEditor creates an editor widget with icon of choice
+func (t *Theme) IconEditor(editor *widget.Editor, hint string, editorIcon []byte, showEditorIcon bool, clickableIcon bool, editorIconEvent func()) Editor {
 	e := t.Editor(editor, hint)
 	e.showEditorIcon = showEditorIcon
+	e.isEditorButtonClickable = clickableIcon
+	e.editorIcon = *NewIcon(MustIcon(widget.NewIcon(editorIcon)))
+	e.editorIcon.Color = t.Color.Gray
 	e.editorIconButton.IconButtonStyle.Icon = MustIcon(widget.NewIcon(editorIcon))
 	e.editorIconButtonEvent = editorIconEvent
 	return e
@@ -115,6 +123,7 @@ func (t *Theme) Editor(editor *widget.Editor, hint string) Editor {
 		m2: unit.Dp(2),
 		m5: unit.Dp(5),
 
+		editorIcon: *NewIcon(MustIcon(widget.NewIcon(icons.AVAVTimer))),
 		editorIconButton: IconButton{
 			material.IconButtonStyle{
 				Icon:       MustIcon(widget.NewIcon(icons.ActionVisibilityOff)),
@@ -244,7 +253,12 @@ func (e Editor) editor(gtx layout.Context) layout.Dimensions {
 					Left: e.m5,
 				}
 				return inset.Layout(gtx, func(gtx C) D {
-					return e.editorIconButton.Layout(gtx)
+					if e.isEditorButtonClickable {
+						return e.editorIconButton.Layout(gtx)
+					} else {
+						return e.editorIcon.Layout(gtx, unit.Dp(25))
+					}
+
 				})
 			} else if e.isPassword {
 				inset := layout.Inset{

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -89,7 +89,7 @@ func (t *Theme) IconEditor(editor *widget.Editor, hint string, editorIcon []byte
 	e := t.Editor(editor, hint)
 	e.showEditorIcon = showEditorIcon
 	e.isEditorButtonClickable = clickableIcon
-	e.editorIcon = *NewIcon(MustIcon(widget.NewIcon(editorIcon)))
+	e.editorIcon.Icon = MustIcon(widget.NewIcon(editorIcon))
 	e.editorIcon.Color = t.Color.Gray
 	e.editorIconButton.IconButtonStyle.Icon = MustIcon(widget.NewIcon(editorIcon))
 	e.editorIconButtonEvent = editorIconEvent
@@ -123,10 +123,8 @@ func (t *Theme) Editor(editor *widget.Editor, hint string) Editor {
 		m2: unit.Dp(2),
 		m5: unit.Dp(5),
 
-		editorIcon: *NewIcon(MustIcon(widget.NewIcon(icons.AVAVTimer))),
 		editorIconButton: IconButton{
 			material.IconButtonStyle{
-				Icon:       MustIcon(widget.NewIcon(icons.ActionVisibilityOff)),
 				Size:       values.MarginPadding24,
 				Background: color.NRGBA{},
 				Color:      t.Color.Gray,
@@ -136,7 +134,6 @@ func (t *Theme) Editor(editor *widget.Editor, hint string) Editor {
 		},
 		showHidePassword: IconButton{
 			material.IconButtonStyle{
-				Icon:       MustIcon(widget.NewIcon(icons.ActionVisibilityOff)),
 				Size:       values.MarginPadding24,
 				Background: color.NRGBA{},
 				Color:      t.Color.Gray,

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -49,7 +49,7 @@ type Editor struct {
 
 	requiredErrorText string
 
-	showHidePassword IconButton
+	editorIconButton IconButton
 
 	m2 unit.Value
 	m5 unit.Value
@@ -77,47 +77,12 @@ func (t *Theme) RestoreEditor(editor *widget.Editor, hint string, title string) 
 	}
 }
 
-//CREATES AN EDITOR WIDGET WITH DYNAMIC ICONS.
-func (t *Theme) NewEditor(editor *widget.Editor, hint string, editorIcon []byte, showEditorIcon bool) Editor {
-	errorLabel := t.Caption("")
-	errorLabel.Color = t.Color.Danger
-
-	m := material.Editor(t.Base, editor, hint)
-	m.TextSize = t.TextSize
-	m.Color = t.Color.Text
-	m.Hint = hint
-	m.HintColor = t.Color.Hint
-
-	var m0 = unit.Dp(0)
-
-	return Editor{
-		t:               t,
-		EditorStyle:     m,
-		TitleLabel:      t.Body2(""),
-		IsTitleLabel:    true,
-		Bordered:        true,
-		LineColor:       t.Color.Gray1,
-		TitleLabelColor: t.Color.Gray3,
-		showEditorIcon:  showEditorIcon,
-
-		errorLabel:        errorLabel,
-		requiredErrorText: "Field is required",
-
-		m2: unit.Dp(2),
-		m5: unit.Dp(5),
-
-		showHidePassword: IconButton{
-			material.IconButtonStyle{
-				Icon:       MustIcon(widget.NewIcon(editorIcon)),
-				Size:       values.MarginPadding24,
-				Background: color.NRGBA{},
-				Color:      t.Color.Gray,
-				Inset:      layout.UniformInset(m0),
-				Button:     new(widget.Clickable),
-			},
-		},
-		CustomButton: t.Button(""),
-	}
+//CREATES AN EDITOR WIDGET WITH ICON OF CHOICE.
+func (t *Theme) IconEditor(editor *widget.Editor, hint string, editorIcon []byte, showEditorIcon bool) Editor {
+	e:= t.Editor(editor, hint)
+	e.showEditorIcon = showEditorIcon
+	e.editorIconButton.IconButtonStyle.Icon = MustIcon(widget.NewIcon(editorIcon))
+	return e
 }
 
 func (t *Theme) Editor(editor *widget.Editor, hint string) Editor {
@@ -147,7 +112,7 @@ func (t *Theme) Editor(editor *widget.Editor, hint string) Editor {
 		m2: unit.Dp(2),
 		m5: unit.Dp(5),
 
-		showHidePassword: IconButton{
+		editorIconButton: IconButton{
 			material.IconButtonStyle{
 				Icon:       MustIcon(widget.NewIcon(icons.ActionVisibilityOff)),
 				Size:       values.MarginPadding24,
@@ -266,12 +231,7 @@ func (e Editor) editor(gtx layout.Context) layout.Dimensions {
 					Left: e.m5,
 				}
 				return inset.Layout(gtx, func(gtx C) D {
-					// icon := MustIcon(widget.NewIcon(icons.ActionVisibilityOff))
-					// if e.Editor.Mask == '*' {
-					// 	icon = MustIcon(widget.NewIcon(icons.ActionVisibility))
-					// }
-					//e.showHidePassword.Icon = MustIcon(widget.NewIcon(icons.AVAVTimer))
-					return e.showHidePassword.Layout(gtx)
+					return e.editorIconButton.Layout(gtx)
 				})
 			} else if e.isPassword {
 				inset := layout.Inset{
@@ -283,8 +243,8 @@ func (e Editor) editor(gtx layout.Context) layout.Dimensions {
 					if e.Editor.Mask == '*' {
 						icon = MustIcon(widget.NewIcon(icons.ActionVisibility))
 					}
-					e.showHidePassword.Icon = icon
-					return e.showHidePassword.Layout(gtx)
+					e.editorIconButton.Icon = icon
+					return e.editorIconButton.Layout(gtx)
 				})
 			}
 			return layout.Dimensions{}
@@ -307,7 +267,7 @@ func (e Editor) editor(gtx layout.Context) layout.Dimensions {
 }
 
 func (e Editor) handleEvents() {
-	if e.showHidePassword.Button.Clicked() {
+	if e.editorIconButton.Button.Clicked() {
 		if e.Editor.Mask == '*' {
 			e.Editor.Mask = 0
 		} else if e.Editor.Mask == 0 {

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Unlicense OR MIT
 
 package decredmaterial
-
+//
 import (
 	"image/color"
 
@@ -43,6 +43,8 @@ type Editor struct {
 	Bordered bool
 	//IsPassword if true, displays the show and hide button.
 	isPassword bool
+	//If ShowEditorIcon is true, displays the editor widget Icon of choice
+	showEditorIcon bool
 
 	requiredErrorText string
 
@@ -56,6 +58,7 @@ func (t *Theme) EditorPassword(editor *widget.Editor, hint string) Editor {
 	editor.Mask = '*'
 	e := t.Editor(editor, hint)
 	e.isPassword = true
+	e.showEditorIcon = false
 	return e
 }
 
@@ -70,6 +73,49 @@ func (t *Theme) RestoreEditor(editor *widget.Editor, hint string, title string) 
 		TitleLabel: t.Body2(title),
 		LineColor:  t.Color.Gray1,
 		height:     31,
+	}
+}
+//CREATES AN EDITOR WIDGET WITH DYNAMIC ICONS.
+func (t *Theme) NewEditor(editor *widget.Editor, hint string, editorIcon []byte, showEditorIcon bool) Editor {
+	errorLabel := t.Caption("")
+	errorLabel.Color = t.Color.Danger
+
+	m := material.Editor(t.Base, editor, hint)
+	m.TextSize = t.TextSize
+	m.Color = t.Color.Text
+	m.Hint = hint
+	m.HintColor = t.Color.Hint
+
+	var m0 = unit.Dp(0)
+
+	return Editor{
+		t:               t,
+		EditorStyle:     m,
+		TitleLabel:      t.Body2(""),
+		IsTitleLabel:    true,
+		Bordered:        true,
+		LineColor:       t.Color.Gray1,
+		TitleLabelColor: t.Color.Gray3,
+		showEditorIcon: showEditorIcon,
+		
+
+		errorLabel:        errorLabel,
+		requiredErrorText: "Field is required",
+
+		m2: unit.Dp(2),
+		m5: unit.Dp(5),
+
+		showHidePassword: IconButton{
+			material.IconButtonStyle{
+				Icon:       MustIcon(widget.NewIcon(editorIcon)),
+				Size:       values.MarginPadding24,
+				Background: color.NRGBA{},
+				Color:      t.Color.Gray,
+				Inset:      layout.UniformInset(m0),
+				Button:     new(widget.Clickable),
+			},
+		},
+		CustomButton: t.Button(""),
 	}
 }
 
@@ -93,6 +139,7 @@ func (t *Theme) Editor(editor *widget.Editor, hint string) Editor {
 		Bordered:        true,
 		LineColor:       t.Color.Gray1,
 		TitleLabelColor: t.Color.Gray3,
+	
 
 		errorLabel:        errorLabel,
 		requiredErrorText: "Field is required",
@@ -213,7 +260,20 @@ func (e Editor) editor(gtx layout.Context) layout.Dimensions {
 			)
 		}),
 		layout.Rigid(func(gtx C) D {
-			if e.isPassword {
+			if e.showEditorIcon{
+				inset := layout.Inset{
+					Top:  e.m2,
+					Left: e.m5,
+				}
+				return inset.Layout(gtx, func(gtx C) D {
+					// icon := MustIcon(widget.NewIcon(icons.ActionVisibilityOff))
+					// if e.Editor.Mask == '*' {
+					// 	icon = MustIcon(widget.NewIcon(icons.ActionVisibility))
+					// }
+					//e.showHidePassword.Icon = MustIcon(widget.NewIcon(icons.AVAVTimer))
+					return e.showHidePassword.Layout(gtx)
+				})
+			} else if e.isPassword {
 				inset := layout.Inset{
 					Top:  e.m2,
 					Left: e.m5,

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Unlicense OR MIT
 
 package decredmaterial
+
 //
 import (
 	"image/color"
@@ -75,6 +76,7 @@ func (t *Theme) RestoreEditor(editor *widget.Editor, hint string, title string) 
 		height:     31,
 	}
 }
+
 //CREATES AN EDITOR WIDGET WITH DYNAMIC ICONS.
 func (t *Theme) NewEditor(editor *widget.Editor, hint string, editorIcon []byte, showEditorIcon bool) Editor {
 	errorLabel := t.Caption("")
@@ -96,8 +98,7 @@ func (t *Theme) NewEditor(editor *widget.Editor, hint string, editorIcon []byte,
 		Bordered:        true,
 		LineColor:       t.Color.Gray1,
 		TitleLabelColor: t.Color.Gray3,
-		showEditorIcon: showEditorIcon,
-		
+		showEditorIcon:  showEditorIcon,
 
 		errorLabel:        errorLabel,
 		requiredErrorText: "Field is required",
@@ -139,7 +140,6 @@ func (t *Theme) Editor(editor *widget.Editor, hint string) Editor {
 		Bordered:        true,
 		LineColor:       t.Color.Gray1,
 		TitleLabelColor: t.Color.Gray3,
-	
 
 		errorLabel:        errorLabel,
 		requiredErrorText: "Field is required",
@@ -260,7 +260,7 @@ func (e Editor) editor(gtx layout.Context) layout.Dimensions {
 			)
 		}),
 		layout.Rigid(func(gtx C) D {
-			if e.showEditorIcon{
+			if e.showEditorIcon {
 				inset := layout.Inset{
 					Top:  e.m2,
 					Left: e.m5,

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -69,7 +69,7 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 	//PLEASE UNCOMMENT TO SEE AN EXAMPLE OF THE ICONEDITOR FUNCTION USED ON THE WALLET NAME EDITOR
 	// showEditorIcon := true
 	// editorIcon := icons.AVArtTrack
-	// cm.walletName = l.Theme.IconEditor(new(widget.Editor), "Wallet Name", editorIcon, showEditorIcon)
+	// cm.walletName = l.Theme.IconEditor(new(widget.Editor), "Wallet Name", editorIcon, showEditorIcon, cm.walletNameEvent)
 	// cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
 
 	cm.passwordEditor = l.Theme.EditorPassword(new(widget.Editor), "Spending password")
@@ -83,6 +83,15 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 
 	return cm
 }
+
+//PLEASE UNCOMMENT TO SEE AN EXAMPLE OF THE ICONEDITOR FUNCTION USED ON THE WALLET NAME EDITOR
+// func (cm *CreatePasswordModal) walletNameEvent() {
+// 	info:= NewInfoModal(cm.Load).
+// 			Title("Set up startup password").
+// 			Body("Startup password helps protect your wallet from unauthorized access.").
+// 			PositiveButton("Got it", func() {})
+// 		cm.ShowModal(info)
+// }
 
 func (cm *CreatePasswordModal) ModalID() string {
 	return cm.randomID

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -10,6 +10,7 @@ import (
 	"gioui.org/text"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+	"golang.org/x/exp/shiny/materialdesign/icons"
 
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
@@ -67,10 +68,12 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 	cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
 
 	//PLEASE UNCOMMENT TO SEE AN EXAMPLE OF THE ICONEDITOR FUNCTION USED ON THE WALLET NAME EDITOR
-	// showEditorIcon := true
-	// editorIcon := icons.AVArtTrack
-	// cm.walletName = l.Theme.IconEditor(new(widget.Editor), "Wallet Name", editorIcon, showEditorIcon, cm.walletNameEvent)
-	// cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
+	showEditorIcon := true
+	editorIcon := icons.AVArtTrack
+	clickableIcon := false
+	emptyfunc := func() {}
+	cm.walletName = l.Theme.IconEditor(new(widget.Editor), "Wallet Name", editorIcon, showEditorIcon, clickableIcon, emptyfunc)
+	cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
 
 	cm.passwordEditor = l.Theme.EditorPassword(new(widget.Editor), "Spending password")
 	cm.passwordEditor.Editor.SingleLine, cm.passwordEditor.Editor.Submit = true, true
@@ -86,11 +89,11 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 
 //PLEASE UNCOMMENT TO SEE AN EXAMPLE OF THE ICONEDITOR FUNCTION USED ON THE WALLET NAME EDITOR
 // func (cm *CreatePasswordModal) walletNameEvent() {
-// 	info:= NewInfoModal(cm.Load).
-// 			Title("Set up startup password").
-// 			Body("Startup password helps protect your wallet from unauthorized access.").
-// 			PositiveButton("Got it", func() {})
-// 		cm.ShowModal(info)
+// 	// info := NewInfoModal(cm.Load).
+// 	// 	Title("Set up startup password").
+// 	// 	Body("Startup password helps protect your wallet from unauthorized access.").
+// 	// 	PositiveButton("Got it", func() {})
+// 	// cm.ShowModal(info)
 // }
 
 func (cm *CreatePasswordModal) ModalID() string {

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -10,7 +10,7 @@ import (
 	"gioui.org/text"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
-	"golang.org/x/exp/shiny/materialdesign/icons"
+
 
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
@@ -64,14 +64,14 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 	cm.btnNegative.Font.Weight = text.Medium
 	cm.btnNegative.Margin = layout.Inset{Right: values.MarginPadding8}
 
-	//cm.walletName = l.Theme.Editor(new(widget.Editor), "Wallet name")
-	//cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
-
-	//TEST RUN OF NEW EDITOR
-	showEditorIcon := true
-	editorIcon := icons.AVArtTrack
-	cm.walletName = l.Theme.NewEditor(new(widget.Editor), "Wallet Name", editorIcon, showEditorIcon)
+	cm.walletName = l.Theme.Editor(new(widget.Editor), "Wallet name")
 	cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
+
+	//PLEASE UNCOMMENT TO SEE AN EXAMPLE OF THE ICONEDITOR FUNCTION USED ON THE WALLET NAME EDITOR
+	// showEditorIcon := true
+	// editorIcon := icons.AVArtTrack
+	// cm.walletName = l.Theme.IconEditor(new(widget.Editor), "Wallet Name", editorIcon, showEditorIcon)
+	// cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
 
 	cm.passwordEditor = l.Theme.EditorPassword(new(widget.Editor), "Spending password")
 	cm.passwordEditor.Editor.SingleLine, cm.passwordEditor.Editor.Submit = true, true

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -10,7 +10,6 @@ import (
 	"gioui.org/text"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
-	"golang.org/x/exp/shiny/materialdesign/icons"
 
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
@@ -67,14 +66,6 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 	cm.walletName = l.Theme.Editor(new(widget.Editor), "Wallet name")
 	cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
 
-	//PLEASE UNCOMMENT TO SEE AN EXAMPLE OF THE ICONEDITOR FUNCTION USED ON THE WALLET NAME EDITOR
-	showEditorIcon := true
-	editorIcon := icons.AVArtTrack
-	clickableIcon := false
-	emptyfunc := func() {}
-	cm.walletName = l.Theme.IconEditor(new(widget.Editor), "Wallet Name", editorIcon, showEditorIcon, clickableIcon, emptyfunc)
-	cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
-
 	cm.passwordEditor = l.Theme.EditorPassword(new(widget.Editor), "Spending password")
 	cm.passwordEditor.Editor.SingleLine, cm.passwordEditor.Editor.Submit = true, true
 
@@ -86,15 +77,6 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 
 	return cm
 }
-
-//PLEASE UNCOMMENT TO SEE AN EXAMPLE OF THE ICONEDITOR FUNCTION USED ON THE WALLET NAME EDITOR
-// func (cm *CreatePasswordModal) walletNameEvent() {
-// 	// info := NewInfoModal(cm.Load).
-// 	// 	Title("Set up startup password").
-// 	// 	Body("Startup password helps protect your wallet from unauthorized access.").
-// 	// 	PositiveButton("Got it", func() {})
-// 	// cm.ShowModal(info)
-// }
 
 func (cm *CreatePasswordModal) ModalID() string {
 	return cm.randomID

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -11,7 +11,6 @@ import (
 	"gioui.org/widget"
 	"gioui.org/widget/material"
 
-
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
 	"github.com/planetdecred/godcr/ui/values"

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -10,6 +10,7 @@ import (
 	"gioui.org/text"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+	"golang.org/x/exp/shiny/materialdesign/icons"
 
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
@@ -63,7 +64,13 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 	cm.btnNegative.Font.Weight = text.Medium
 	cm.btnNegative.Margin = layout.Inset{Right: values.MarginPadding8}
 
-	cm.walletName = l.Theme.Editor(new(widget.Editor), "Wallet name")
+	//cm.walletName = l.Theme.Editor(new(widget.Editor), "Wallet name")
+	//cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
+	
+	//TEST RUN OF NEW EDITOR
+	showEditorIcon := true
+	editorIcon:= icons.AVArtTrack
+	cm.walletName = l.Theme.NewEditor(new(widget.Editor), "Wallet Name", editorIcon, showEditorIcon)
 	cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
 
 	cm.passwordEditor = l.Theme.EditorPassword(new(widget.Editor), "Spending password")

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -66,10 +66,10 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 
 	//cm.walletName = l.Theme.Editor(new(widget.Editor), "Wallet name")
 	//cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
-	
+
 	//TEST RUN OF NEW EDITOR
 	showEditorIcon := true
-	editorIcon:= icons.AVArtTrack
+	editorIcon := icons.AVArtTrack
 	cm.walletName = l.Theme.NewEditor(new(widget.Editor), "Wallet Name", editorIcon, showEditorIcon)
 	cm.walletName.Editor.SingleLine, cm.walletName.Editor.Submit = true, true
 


### PR DESCRIPTION
This draft PR creates a function that supports dynamic Icons when creating editor widgets. 
A Test was done on the wallet name Editor to show how the function works. Screenshots attached.

<img width="361" alt="Screenshot 2021-10-26 034645" src="https://user-images.githubusercontent.com/76660305/138800425-ba957240-18ee-40aa-9706-71ba07b90992.png">


Closes #673 