### PR TITLE
Fix app freezing when running account mixer

### DIFF
--- a/ui/page/listeners.go
+++ b/ui/page/listeners.go
@@ -39,8 +39,19 @@ func (mp *MainPage) OnTransactionConfirmed(walletID int, hash string, blockHeigh
 }
 
 // Account mixer
-func (mp *MainPage) OnAccountMixerStarted(walletID int) {}
-func (mp *MainPage) OnAccountMixerEnded(walletID int)   {}
+func (mp *MainPage) OnAccountMixerStarted(walletID int) {
+	mp.UpdateNotification(wallet.AccountMixer{
+		WalletID:  walletID,
+		RunStatus: wallet.MixerStarted,
+	})
+}
+
+func (mp *MainPage) OnAccountMixerEnded(walletID int) {
+	mp.UpdateNotification(wallet.AccountMixer{
+		WalletID:  walletID,
+		RunStatus: wallet.MixerEnded,
+	})
+}
 
 // Politeia notifications
 func (mp *MainPage) OnProposalsSynced() {

--- a/ui/page/wallets/privacy_page.go
+++ b/ui/page/wallets/privacy_page.go
@@ -370,8 +370,9 @@ func (pg *PrivacyPage) Handle() {
 	}
 
 	if pg.mixerCompleted {
-		pg.toggleMixer.SetChecked(pg.wallet.IsAccountMixerActive())
+		pg.toggleMixer.SetChecked(false)
 		pg.mixerCompleted = false
+		pg.RefreshWindow()
 	}
 
 	if pg.allowUnspendUnmixedAcct.Changed() {


### PR DESCRIPTION
Fix #687 

This PR adds mixer sync listener and prevents the app from freezing when account mixer is running especially when mixing is complete.