### PR TITLE
Fix bug that reduces increment icon on Ubuntu on staking modal

### DIFF
--- a/ui/page/governance/proposal_vote_modal.go
+++ b/ui/page/governance/proposal_vote_modal.go
@@ -444,7 +444,7 @@ func (vm *voteModal) inputOptions(gtx layout.Context, wdg *inputVoteOptionsWidge
 											return wdg.decrement.Layout(gtx)
 										}),
 										layout.Rigid(func(gtx C) D {
-											gtx.Constraints.Min.X, gtx.Constraints.Max.X = 40, 40
+											gtx.Constraints.Min.X, gtx.Constraints.Max.X = 30, 30
 											return wdg.input.Layout(gtx)
 										}),
 										layout.Rigid(func(gtx C) D {

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -161,7 +161,7 @@ func (tp *stakingModal) Layout(gtx layout.Context) layout.Dimensions {
 										return tp.decrement.Layout(gtx)
 									}),
 									layout.Rigid(func(gtx C) D {
-										gtx.Constraints.Min.X, gtx.Constraints.Max.X = 100, 100
+										gtx.Constraints.Min.X, gtx.Constraints.Max.X = 90, 90
 										return tp.tickets.Layout(gtx)
 									}),
 									layout.Rigid(func(gtx C) D {


### PR DESCRIPTION
Closes #699 

Increment symbol before:
![142920897-45f81db3-c445-4b03-a1b2-72ae6b953d4c](https://user-images.githubusercontent.com/66803475/145525197-f96e0ddb-c76e-47c7-8558-055a799080d1.png)

Increment symbol after fix (Ubuntu):
![Screenshot from 2021-12-10 07-03-47](https://user-images.githubusercontent.com/66803475/145525344-b816fade-0cdd-4a2e-b467-a454acb51433.png)

Increment symbol after fix (Windows):
![StakeIcon](https://user-images.githubusercontent.com/66803475/145527269-c3a21a71-f39f-432f-b81d-a66b177f2258.PNG)
