### PR TITLE
Add space to txn details info modal text

### DIFF
--- a/ui/modal/info_modal_layouts.go
+++ b/ui/modal/info_modal_layouts.go
@@ -96,7 +96,7 @@ func setupMixerInfo(th *decredmaterial.Theme) []layout.Widget {
 }
 
 func transactionDetailsInfo(th *decredmaterial.Theme) []layout.Widget {
-	text := `<span style="text-color: grayText2">Tap on <span style="text-color: primary">blue text</span> to copy the item</span>`
+	text := `<span style="text-color: grayText2">Tap on <span style="text-color: primary">blue text </span> to copy the item</span>`
 
 	return []layout.Widget{
 		renderers.RenderHTML(text, th).Layout,


### PR DESCRIPTION
Closes #716 
This PR adds space between "blue text" and to on transactions details page infor modal.

After fix:
![Screenshot from 2021-12-11 23-44-59](https://user-images.githubusercontent.com/66803475/145693888-394f1a8d-80b4-4918-90eb-e734725996af.png)
