### PR TITLE
Fix dropdown backdrop

### DIFF
--- a/ui/decredmaterial/dropdown.go
+++ b/ui/decredmaterial/dropdown.go
@@ -181,7 +181,7 @@ func (d *DropDown) layoutOption(gtx layout.Context, itemIndex int) D {
 			return item.Icon.Layout24dp(gtx)
 		}),
 		layout.Rigid(func(gtx C) D {
-			gtx.Constraints.Max.X = gtx.Px(unit.Dp(110))
+			gtx.Constraints.Max.X = gtx.Px(unit.Dp(115))
 			if d.revs {
 				gtx.Constraints.Max.X = gtx.Px(unit.Dp(100))
 			}
@@ -191,8 +191,8 @@ func (d *DropDown) layoutOption(gtx layout.Context, itemIndex int) D {
 				Left:  unit.Dp(5),
 			}.Layout(gtx, func(gtx C) D {
 				lbl := d.theme.Body2(item.Text)
-				if !d.isOpen && len(item.Text) > 9 {
-					lbl.Text = item.Text[:9] + "..."
+				if !d.isOpen && len(item.Text) > 14 {
+					lbl.Text = item.Text[:14] + "..."
 				}
 				return lbl.Layout(gtx)
 			})

--- a/ui/decredmaterial/dropdown.go
+++ b/ui/decredmaterial/dropdown.go
@@ -254,7 +254,7 @@ func (d *DropDown) Layout(gtx C, dropPos int, reversePos bool) D {
 	)
 }
 
-// openeLayout computes dropdown layout when dropdown is opened.
+// openedLayout computes dropdown layout when dropdown is opened.
 func (d *DropDown) openedLayout(gtx C, iLeft int, iRight int) D {
 	return layout.Inset{
 		Left:  unit.Dp(float32(iLeft)),

--- a/ui/decredmaterial/dropdown.go
+++ b/ui/decredmaterial/dropdown.go
@@ -41,6 +41,10 @@ type DropDownItem struct {
 	clickable *Clickable
 }
 
+// DropDown returns a dropdown component. {pos} parameter signifies the position
+// of the dropdown in a dropdown group on the UI, the first dropdown should be assigned
+// pos 0, next 1..etc. incorrectly assigned Dropdown pos will result in inconsistent
+// dropdown backdrop.
 func (t *Theme) DropDown(items []DropDownItem, group uint, pos uint) *DropDown {
 	d := &DropDown{
 		theme:          t,

--- a/ui/decredmaterial/dropdown.go
+++ b/ui/decredmaterial/dropdown.go
@@ -9,8 +9,11 @@ import (
 	"github.com/planetdecred/godcr/ui/values"
 )
 
+const (
+	DropdownBasePos uint = 0
+)
+
 var MaxWidth = unit.Dp(800)
-var DropdownBasePos uint = 0
 
 type DropDown struct {
 	theme          *Theme
@@ -221,12 +224,7 @@ func (d *DropDown) Layout(gtx C, dropPos int, reversePos bool) D {
 					return d.backdrop.Layout(gtx)
 				}),
 				layout.Stacked(func(gtx C) D {
-					return layout.Inset{
-						Left:  unit.Dp(float32(iLeft)),
-						Right: unit.Dp(float32(iRight)),
-					}.Layout(gtx, func(gtx C) D {
-						return d.dropDownItemMenu(gtx)
-					})
+					return d.openedLayout(gtx, iLeft, iRight)
 				}),
 			)
 		}
@@ -237,54 +235,51 @@ func (d *DropDown) Layout(gtx C, dropPos int, reversePos bool) D {
 				return d.backdrop.Layout(gtx)
 			}),
 			layout.Stacked(func(gtx C) D {
-				return layout.Inset{
-					Left:  unit.Dp(float32(iLeft)),
-					Right: unit.Dp(float32(iRight)),
-				}.Layout(gtx, func(gtx C) D {
-					return d.drawLayout(gtx, func(gtx C) D {
-						lay := layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								return d.layoutOption(gtx, d.selectedIndex)
-							}))
-						w := (lay.Size.X * 800) / gtx.Px(MaxWidth)
-						d.Width = w + 10
-						return lay
-					})
-				})
+				return d.closedLayout(gtx, iLeft, iRight)
 			}),
 		)
 
 	} else if d.isOpen {
 		return layout.Stack{Alignment: alig}.Layout(gtx,
 			layout.Stacked(func(gtx C) D {
-				return layout.Inset{
-					Left:  unit.Dp(float32(iLeft)),
-					Right: unit.Dp(float32(iRight)),
-				}.Layout(gtx, func(gtx C) D {
-					return d.dropDownItemMenu(gtx)
-				})
+				return d.openedLayout(gtx, iLeft, iRight)
 			}),
 		)
 	}
 
 	return layout.Stack{Alignment: alig}.Layout(gtx,
 		layout.Stacked(func(gtx C) D {
-			return layout.Inset{
-				Left:  unit.Dp(float32(iLeft)),
-				Right: unit.Dp(float32(iRight)),
-			}.Layout(gtx, func(gtx C) D {
-				return d.drawLayout(gtx, func(gtx C) D {
-					lay := layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-						layout.Rigid(func(gtx C) D {
-							return d.layoutOption(gtx, d.selectedIndex)
-						}))
-					w := (lay.Size.X * 800) / gtx.Px(MaxWidth)
-					d.Width = w + 10
-					return lay
-				})
-			})
+			return d.closedLayout(gtx, iLeft, iRight)
 		}),
 	)
+}
+
+// openeLayout computes dropdown layout when dropdown is opened.
+func (d *DropDown) openedLayout(gtx C, iLeft int, iRight int) D {
+	return layout.Inset{
+		Left:  unit.Dp(float32(iLeft)),
+		Right: unit.Dp(float32(iRight)),
+	}.Layout(gtx, func(gtx C) D {
+		return d.dropDownItemMenu(gtx)
+	})
+}
+
+// closedLayout computes dropdown layout when dropdown is closed.
+func (d *DropDown) closedLayout(gtx C, iLeft int, iRight int) D {
+	return layout.Inset{
+		Left:  unit.Dp(float32(iLeft)),
+		Right: unit.Dp(float32(iRight)),
+	}.Layout(gtx, func(gtx C) D {
+		return d.drawLayout(gtx, func(gtx C) D {
+			lay := layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					return d.layoutOption(gtx, d.selectedIndex)
+				}))
+			w := (lay.Size.X * 800) / gtx.Px(MaxWidth)
+			d.Width = w + 10
+			return lay
+		})
+	})
 }
 
 func (d *DropDown) dropDownItemMenu(gtx C) D {

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -228,7 +228,6 @@ func (t *Theme) isOpenDropdownGroup(group uint) bool {
 		if dropDown.group == group {
 			if dropDown.isOpen {
 				return true
-				break
 			}
 		}
 	}

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -221,8 +221,8 @@ func (t *Theme) closeAllDropdownMenus(group uint) {
 	}
 }
 
-// isOpenDropdownGroup interate over Dropdowns registered as a member
-// {group}, returns true if any of the drop down state is open.
+// isOpenDropdownGroup iterate over Dropdowns registered as a member
+// of {group}, returns true if any of the drop down state is open.
 func (t *Theme) isOpenDropdownGroup(group uint) bool {
 	for _, dropDown := range t.dropDownMenus {
 		if dropDown.group == group {

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -221,6 +221,20 @@ func (t *Theme) closeAllDropdownMenus(group uint) {
 	}
 }
 
+// isOpenDropdownGroup interate over Dropdowns registered as a member
+// {group}, returns true if any of the drop down state is open.
+func (t *Theme) isOpenDropdownGroup(group uint) bool {
+	for _, dropDown := range t.dropDownMenus {
+		if dropDown.group == group {
+			if dropDown.isOpen {
+				return true
+				break
+			}
+		}
+	}
+	return false
+}
+
 // Disabled blends color towards the luminance and multiplies alpha.
 // Blending towards luminance will desaturate the color.
 // Multiplying alpha blends the color together more with the background.

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -635,7 +635,7 @@ func TimeFormat(secs int, long bool) string {
 
 // createOrUpdateWalletDropDown check for len of wallets to create dropDown,
 // also update the list when create, update, delete a wallet.
-func CreateOrUpdateWalletDropDown(l *load.Load, dwn **decredmaterial.DropDown, wallets []*dcrlibwallet.Wallet) *decredmaterial.DropDown {
+func CreateOrUpdateWalletDropDown(l *load.Load, dwn **decredmaterial.DropDown, wallets []*dcrlibwallet.Wallet, pos uint) *decredmaterial.DropDown {
 	var walletDropDownItems []decredmaterial.DropDownItem
 	walletIcon := l.Icons.WalletIcon
 	walletIcon.Scale = 1
@@ -646,13 +646,13 @@ func CreateOrUpdateWalletDropDown(l *load.Load, dwn **decredmaterial.DropDown, w
 		}
 		walletDropDownItems = append(walletDropDownItems, item)
 	}
-	*dwn = l.Theme.DropDown(walletDropDownItems, 1)
+	*dwn = l.Theme.DropDown(walletDropDownItems, 1, pos)
 	return *dwn
 }
 
-func CreateOrderDropDown(l *load.Load) *decredmaterial.DropDown {
+func CreateOrderDropDown(l *load.Load, pos uint) *decredmaterial.DropDown {
 	return l.Theme.DropDown([]decredmaterial.DropDownItem{{Text: values.String(values.StrNewest)},
-		{Text: values.String(values.StrOldest)}}, 1)
+		{Text: values.String(values.StrOldest)}}, 1, pos)
 }
 
 func TranslateErr(err error) string {

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -635,7 +635,7 @@ func TimeFormat(secs int, long bool) string {
 
 // createOrUpdateWalletDropDown check for len of wallets to create dropDown,
 // also update the list when create, update, delete a wallet.
-func CreateOrUpdateWalletDropDown(l *load.Load, dwn **decredmaterial.DropDown, wallets []*dcrlibwallet.Wallet, pos uint) *decredmaterial.DropDown {
+func CreateOrUpdateWalletDropDown(l *load.Load, dwn **decredmaterial.DropDown, wallets []*dcrlibwallet.Wallet, grp uint, pos uint) *decredmaterial.DropDown {
 	var walletDropDownItems []decredmaterial.DropDownItem
 	walletIcon := l.Icons.WalletIcon
 	walletIcon.Scale = 1
@@ -646,13 +646,13 @@ func CreateOrUpdateWalletDropDown(l *load.Load, dwn **decredmaterial.DropDown, w
 		}
 		walletDropDownItems = append(walletDropDownItems, item)
 	}
-	*dwn = l.Theme.DropDown(walletDropDownItems, 1, pos)
+	*dwn = l.Theme.DropDown(walletDropDownItems, grp, pos)
 	return *dwn
 }
 
-func CreateOrderDropDown(l *load.Load, pos uint) *decredmaterial.DropDown {
+func CreateOrderDropDown(l *load.Load, grp uint, pos uint) *decredmaterial.DropDown {
 	return l.Theme.DropDown([]decredmaterial.DropDownItem{{Text: values.String(values.StrNewest)},
-		{Text: values.String(values.StrOldest)}}, 1, pos)
+		{Text: values.String(values.StrOldest)}}, grp, pos)
 }
 
 func TranslateErr(err error) string {

--- a/ui/page/governance/proposals_page.go
+++ b/ui/page/governance/proposals_page.go
@@ -75,7 +75,7 @@ func NewProposalsPage(l *load.Load) *ProposalsPage {
 
 	// orderDropDown is the first dropdown when page is laid out. Its
 	// position should be 0 for consistent backdrop.
-	pg.orderDropDown = components.CreateOrderDropDown(l, 0)
+	pg.orderDropDown = components.CreateOrderDropDown(l, values.ProposalDropdownGroup, 0)
 	pg.categoryDropDown = l.Theme.DropDown([]decredmaterial.DropDownItem{
 		{
 			Text: "Under Review",
@@ -89,7 +89,7 @@ func NewProposalsPage(l *load.Load) *ProposalsPage {
 		{
 			Text: "Abandoned",
 		},
-	}, 1, 1)
+	}, values.ProposalDropdownGroup, 1)
 
 	pg.initializeWidget()
 

--- a/ui/page/governance/proposals_page.go
+++ b/ui/page/governance/proposals_page.go
@@ -73,7 +73,9 @@ func NewProposalsPage(l *load.Load) *ProposalsPage {
 
 	pg.backButton, pg.infoButton = components.SubpageHeaderButtons(l)
 
-	pg.orderDropDown = components.CreateOrderDropDown(l)
+	// orderDropDown is the first dropdown when page is laid out. Its
+	// position should be 0 for consistent backdrop.
+	pg.orderDropDown = components.CreateOrderDropDown(l, 0)
 	pg.categoryDropDown = l.Theme.DropDown([]decredmaterial.DropDownItem{
 		{
 			Text: "Under Review",
@@ -87,7 +89,7 @@ func NewProposalsPage(l *load.Load) *ProposalsPage {
 		{
 			Text: "Abandoned",
 		},
-	}, 1)
+	}, 1, 1)
 
 	pg.initializeWidget()
 

--- a/ui/page/staking/list_page.go
+++ b/ui/page/staking/list_page.go
@@ -60,7 +60,7 @@ func newListPage(l *load.Load) *ListPage {
 
 	pg.orderDropDown = createOrderDropDown(l.Theme)
 	pg.wallets = pg.WL.SortedWalletList()
-	components.CreateOrUpdateWalletDropDown(pg.Load, &pg.walletDropDown, pg.wallets)
+	components.CreateOrUpdateWalletDropDown(pg.Load, &pg.walletDropDown, pg.wallets, 0) // first in the set during layout pos 0
 	pg.ticketTypeDropDown = l.Theme.DropDown([]decredmaterial.DropDownItem{
 		{Text: "All"},
 		{Text: "Unmined"},
@@ -69,7 +69,7 @@ func newListPage(l *load.Load) *ListPage {
 		{Text: "Voted"},
 		{Text: "Expired"},
 		{Text: "Revoked"},
-	}, 1)
+	}, 1, 2)
 
 	return pg
 }

--- a/ui/page/staking/list_page.go
+++ b/ui/page/staking/list_page.go
@@ -60,7 +60,7 @@ func newListPage(l *load.Load) *ListPage {
 
 	pg.orderDropDown = createOrderDropDown(l.Theme)
 	pg.wallets = pg.WL.SortedWalletList()
-	components.CreateOrUpdateWalletDropDown(pg.Load, &pg.walletDropDown, pg.wallets, 0) // first in the set during layout pos 0
+	components.CreateOrUpdateWalletDropDown(pg.Load, &pg.walletDropDown, pg.wallets, values.StakingDropdownGroup, 0) // first in the set during layout pos 0
 	pg.ticketTypeDropDown = l.Theme.DropDown([]decredmaterial.DropDownItem{
 		{Text: "All"},
 		{Text: "Unmined"},
@@ -69,7 +69,7 @@ func newListPage(l *load.Load) *ListPage {
 		{Text: "Voted"},
 		{Text: "Expired"},
 		{Text: "Revoked"},
-	}, 1, 2)
+	}, values.StakingDropdownGroup, 2)
 
 	return pg
 }

--- a/ui/page/staking/utils.go
+++ b/ui/page/staking/utils.go
@@ -673,7 +673,7 @@ func ticketListLayout(gtx C, l *load.Load, ticket *transactionItem, i int, showW
 // todo: cleanup
 func createOrderDropDown(th *decredmaterial.Theme) *decredmaterial.DropDown {
 	return th.DropDown([]decredmaterial.DropDownItem{{Text: values.String(values.StrNewest)},
-		{Text: values.String(values.StrOldest)}}, 1, 1)
+		{Text: values.String(values.StrOldest)}}, values.StakingDropdownGroup, 1)
 }
 
 func maturityTimeFormat(maturityTimeMinutes int) string {

--- a/ui/page/staking/utils.go
+++ b/ui/page/staking/utils.go
@@ -673,7 +673,7 @@ func ticketListLayout(gtx C, l *load.Load, ticket *transactionItem, i int, showW
 // todo: cleanup
 func createOrderDropDown(th *decredmaterial.Theme) *decredmaterial.DropDown {
 	return th.DropDown([]decredmaterial.DropDownItem{{Text: values.String(values.StrNewest)},
-		{Text: values.String(values.StrOldest)}}, 1)
+		{Text: values.String(values.StrOldest)}}, 1, 1)
 }
 
 func maturityTimeFormat(maturityTimeMinutes int) string {

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -48,9 +48,9 @@ func NewTransactionsPage(l *load.Load) *TransactionsPage {
 
 	pg.transactionList.Radius = decredmaterial.Radius(values.MarginPadding14.V)
 
-	pg.orderDropDown = components.CreateOrderDropDown(l, 1)
+	pg.orderDropDown = components.CreateOrderDropDown(l, values.TxDropdownGroup, 1)
 	pg.wallets = pg.WL.SortedWalletList()
-	pg.walletDropDown = components.CreateOrUpdateWalletDropDown(pg.Load, &pg.walletDropDown, pg.wallets, 0)
+	pg.walletDropDown = components.CreateOrUpdateWalletDropDown(pg.Load, &pg.walletDropDown, pg.wallets, values.TxDropdownGroup, 0)
 	pg.txTypeDropDown = l.Theme.DropDown([]decredmaterial.DropDownItem{
 		{
 			Text: values.String(values.StrAll),
@@ -70,7 +70,7 @@ func NewTransactionsPage(l *load.Load) *TransactionsPage {
 		{
 			Text: values.String(values.StrStaking),
 		},
-	}, 1, 2)
+	}, values.TxDropdownGroup, 2)
 
 	return pg
 }

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -48,9 +48,9 @@ func NewTransactionsPage(l *load.Load) *TransactionsPage {
 
 	pg.transactionList.Radius = decredmaterial.Radius(values.MarginPadding14.V)
 
-	pg.orderDropDown = components.CreateOrderDropDown(l)
+	pg.orderDropDown = components.CreateOrderDropDown(l, 1)
 	pg.wallets = pg.WL.SortedWalletList()
-	pg.walletDropDown = components.CreateOrUpdateWalletDropDown(pg.Load, &pg.walletDropDown, pg.wallets)
+	pg.walletDropDown = components.CreateOrUpdateWalletDropDown(pg.Load, &pg.walletDropDown, pg.wallets, 0)
 	pg.txTypeDropDown = l.Theme.DropDown([]decredmaterial.DropDownItem{
 		{
 			Text: values.String(values.StrAll),
@@ -70,7 +70,7 @@ func NewTransactionsPage(l *load.Load) *TransactionsPage {
 		{
 			Text: values.String(values.StrStaking),
 		},
-	}, 1)
+	}, 1, 2)
 
 	return pg
 }

--- a/ui/test/testapp.go
+++ b/ui/test/testapp.go
@@ -166,7 +166,7 @@ func (t *TestStruct) initWidgets() {
 			Text: "Semi All",
 		},
 	}
-	t.dropDown = theme.DropDown(dropDownItems, 1)
+	t.dropDown = theme.DropDown(dropDownItems, 1, 0)
 }
 
 func (t *TestStruct) TestPage(gtx layout.Context) {

--- a/ui/values/const.go
+++ b/ui/values/const.go
@@ -1,0 +1,7 @@
+package values
+
+const (
+	TxDropdownGroup = iota
+	StakingDropdownGroup
+	ProposalDropdownGroup
+)


### PR DESCRIPTION
This PR fixes issue #706 where if a dropdown is opened its backdrop covers other dropdowns on the page. 
Result being that the other dropdowns on the page are not clickable.
Also closes #697 