### PR TITLE
Disable disconnect button when clicked.

### DIFF
--- a/ui/decredmaterial/clickable.go
+++ b/ui/decredmaterial/clickable.go
@@ -15,6 +15,7 @@ type Clickable struct {
 	style     *values.ClickableStyle
 	Hoverable bool
 	Radius    CornerRadius
+	Enabled   bool
 }
 
 func (t *Theme) NewClickable(hoverable bool) *Clickable {
@@ -22,6 +23,7 @@ func (t *Theme) NewClickable(hoverable bool) *Clickable {
 		button:    &widget.Clickable{},
 		style:     t.Styles.ClickableStyle,
 		Hoverable: hoverable,
+		Enabled:   true,
 	}
 }
 

--- a/ui/decredmaterial/clickable.go
+++ b/ui/decredmaterial/clickable.go
@@ -15,7 +15,7 @@ type Clickable struct {
 	style     *values.ClickableStyle
 	Hoverable bool
 	Radius    CornerRadius
-	Enabled   bool
+	isEnabled bool
 }
 
 func (t *Theme) NewClickable(hoverable bool) *Clickable {
@@ -23,7 +23,7 @@ func (t *Theme) NewClickable(hoverable bool) *Clickable {
 		button:    &widget.Clickable{},
 		style:     t.Styles.ClickableStyle,
 		Hoverable: hoverable,
-		Enabled:   true,
+		isEnabled: true,
 	}
 }
 
@@ -37,6 +37,22 @@ func (cl *Clickable) ChangeStyle(style *values.ClickableStyle) {
 
 func (cl *Clickable) Clicked() bool {
 	return cl.button.Clicked()
+}
+
+// SetEnabled enables/disables the clickable.
+func (cl *Clickable) SetEnabled(enable bool, gtx *layout.Context) layout.Context {
+	var mGtx layout.Context
+	if gtx != nil && !enable {
+		mGtx = gtx.Disabled()
+	}
+
+	cl.isEnabled = enable
+	return mGtx
+}
+
+// Return clickable enabled/disabled state.
+func (cl *Clickable) Enabled() bool {
+	return cl.isEnabled
 }
 
 func (cl *Clickable) Layout(gtx C, w layout.Widget) D {

--- a/ui/page/overview/overview_layout.go
+++ b/ui/page/overview/overview_layout.go
@@ -247,7 +247,18 @@ func (pg *AppOverviewPage) Handle() {
 		if pg.rescanningBlocks {
 			pg.WL.MultiWallet.CancelRescan()
 		} else {
-			go pg.ToggleSync()
+			// If connected to the Decred network disable button. Prevents multiple clicks.
+			if pg.isConnnected {
+				pg.syncClickable.Enabled = false
+			}
+
+			// On exit of goroutine update button state.
+			go func() {
+				pg.ToggleSync()
+				if !pg.syncClickable.Enabled {
+					pg.syncClickable.Enabled = true
+				}
+			}()
 		}
 	}
 

--- a/ui/page/overview/overview_layout.go
+++ b/ui/page/overview/overview_layout.go
@@ -249,14 +249,14 @@ func (pg *AppOverviewPage) Handle() {
 		} else {
 			// If connected to the Decred network disable button. Prevents multiple clicks.
 			if pg.isConnnected {
-				pg.syncClickable.Enabled = false
+				pg.syncClickable.SetEnabled(false, nil)
 			}
 
 			// On exit update button state.
 			go func() {
 				pg.ToggleSync()
-				if !pg.syncClickable.Enabled {
-					pg.syncClickable.Enabled = true
+				if !pg.syncClickable.Enabled() {
+					pg.syncClickable.SetEnabled(true, nil)
 				}
 			}()
 		}

--- a/ui/page/overview/overview_layout.go
+++ b/ui/page/overview/overview_layout.go
@@ -252,7 +252,7 @@ func (pg *AppOverviewPage) Handle() {
 				pg.syncClickable.Enabled = false
 			}
 
-			// On exit of goroutine update button state.
+			// On exit update button state.
 			go func() {
 				pg.ToggleSync()
 				if !pg.syncClickable.Enabled {

--- a/ui/page/overview/sync_details.go
+++ b/ui/page/overview/sync_details.go
@@ -66,8 +66,8 @@ func (pg *AppOverviewPage) syncStatusTextRow(gtx layout.Context, inset layout.In
 			layout.Rigid(func(gtx C) D {
 
 				// Set gxt to Disabled (Sets Queue to nil) if syncClickable state is disabled, prevents double click.
-				if !pg.syncClickable.Enabled {
-					gtx = gtx.Disabled()
+				if !pg.syncClickable.Enabled() {
+					gtx = pg.syncClickable.SetEnabled(false, &gtx)
 				}
 
 				return decredmaterial.LinearLayout{

--- a/ui/page/overview/sync_details.go
+++ b/ui/page/overview/sync_details.go
@@ -64,6 +64,12 @@ func (pg *AppOverviewPage) syncStatusTextRow(gtx layout.Context, inset layout.In
 		return layout.Flex{Axis: layout.Horizontal, Spacing: layout.SpaceBetween}.Layout(gtx,
 			layout.Flexed(1, syncStatusLabel.Layout),
 			layout.Rigid(func(gtx C) D {
+
+				// Set gxt to Disabled (Sets Queue to nil) if syncClickable state is disabled, prevents double click.
+				if !pg.syncClickable.Enabled {
+					gtx = gtx.Disabled()
+				}
+
 				return decredmaterial.LinearLayout{
 					Width:     decredmaterial.WrapContent,
 					Height:    decredmaterial.WrapContent,


### PR DESCRIPTION
This PR fixes #724 and #385
Summary if issue fixed. If disconnect button isn't disabled after it is clicked it leads to a condition where it is possible to click it again and create another disconnect request. The issue is documented in #724 .