### PR TITLE
Max amount button bugs on Send  page

### DIFF
--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -392,6 +392,11 @@ func (pg *Page) Handle() {
 				pg.amount.SendMax = true
 				pg.amount.amountChanged()
 			}
+
+			editorsAreEmpty := len(pg.amount.dcrAmountEditor.Editor.Text()) < 1 || len(pg.amount.usdAmountEditor.Editor.Text()) < 1
+			if editorsAreEmpty {
+				pg.amount.SendMax = false
+			}
 		} else if len(addEditor.Editor.Text()) < 1 {
 			if len(pg.amount.dcrAmountEditor.Editor.Text()) < 1 || len(pg.amount.usdAmountEditor.Editor.Text()) < 1 {
 				pg.amount.SendMax = false

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -385,17 +385,26 @@ func (pg *Page) Handle() {
 
 	if pg.sendDestination.sendToAddress {
 		addEditor := pg.sendDestination.destinationAddressEditor
-		if pg.amount.IsMaxClicked() {
-			validAddress := pg.sendDestination.validate()
-			if validAddress {
+		validAddress := pg.sendDestination.validate()
+		if validAddress {
+			if pg.amount.IsMaxClicked() {
 				pg.amount.setError("")
 				pg.amount.Sendmax = true
 				pg.amount.amountChanged()
-			} else if len(addEditor.Editor.Text()) < 1 {
-				pg.Toast.NotifyError("Set destination amount")
 			}
-
+		} else if len(addEditor.Editor.Text()) < 1 {
+			if len(pg.amount.dcrAmountEditor.Editor.Text()) < 1 || len(pg.amount.usdAmountEditor.Editor.Text()) < 1 {
+				pg.amount.Sendmax = false
+			}
+			if pg.amount.IsMaxClicked() {
+				if pg.amount.amountIsValid() {
+					pg.amount.setError("")
+				} else {
+					pg.Toast.NotifyError("Set destination amount")
+				}
+			}
 		}
+
 	} else {
 		if pg.amount.IsMaxClicked() {
 			pg.amount.setError("")

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -382,6 +382,27 @@ func (pg *Page) Handle() {
 			decredmaterial.SwitchEditors(pg.keyEvent, pg.sendDestination.destinationAddressEditor.Editor, pg.amount.dcrAmountEditor.Editor, pg.amount.usdAmountEditor.Editor)
 		}
 	}
+
+	if pg.sendDestination.sendToAddress {
+		addEditor := pg.sendDestination.destinationAddressEditor
+		if pg.amount.IsMaxClicked() {
+			validAddress := pg.sendDestination.validate()
+			if validAddress {
+				pg.amount.setError("")
+				pg.amount.Sendmax = true
+				pg.amount.amountChanged()
+			} else if len(addEditor.Editor.Text()) < 1 {
+				pg.Toast.NotifyError("Set destination amount")
+			}
+
+		}
+	} else {
+		if pg.amount.IsMaxClicked() {
+			pg.amount.setError("")
+			pg.amount.Sendmax = true
+			pg.amount.amountChanged()
+		}
+	}
 }
 
 func (pg *Page) OnClose() {

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -205,7 +205,7 @@ func (pg *Page) constructTx() {
 	}
 	destinationAccount := pg.sendDestination.destinationAccount()
 
-	amountAtom, sendMax, err := pg.amount.validAmount()
+	amountAtom, SendMax, err := pg.amount.validAmount()
 	if err != nil {
 		pg.feeEstimationError(err.Error())
 		return
@@ -218,7 +218,7 @@ func (pg *Page) constructTx() {
 		return
 	}
 
-	err = unsignedTx.AddSendDestination(destinationAddress, amountAtom, sendMax)
+	err = unsignedTx.AddSendDestination(destinationAddress, amountAtom, SendMax)
 	if err != nil {
 		pg.feeEstimationError(err.Error())
 		return
@@ -231,7 +231,7 @@ func (pg *Page) constructTx() {
 	}
 
 	feeAtom := feeAndSize.Fee.AtomValue
-	if sendMax {
+	if SendMax {
 		amountAtom = sourceAccount.Balance.Spendable - feeAtom
 	}
 
@@ -248,7 +248,7 @@ func (pg *Page) constructTx() {
 	pg.destinationAccount = destinationAccount
 	pg.sourceAccount = sourceAccount
 
-	if sendMax {
+	if SendMax {
 		// TODO: this workaround ignores the change events from the
 		// amount input to avoid construct tx cycle.
 		pg.amount.setAmount(amountAtom)
@@ -389,12 +389,12 @@ func (pg *Page) Handle() {
 		if validAddress {
 			if pg.amount.IsMaxClicked() {
 				pg.amount.setError("")
-				pg.amount.Sendmax = true
+				pg.amount.SendMax = true
 				pg.amount.amountChanged()
 			}
 		} else if len(addEditor.Editor.Text()) < 1 {
 			if len(pg.amount.dcrAmountEditor.Editor.Text()) < 1 || len(pg.amount.usdAmountEditor.Editor.Text()) < 1 {
-				pg.amount.Sendmax = false
+				pg.amount.SendMax = false
 			}
 			if pg.amount.IsMaxClicked() {
 				if pg.amount.amountIsValid() {
@@ -408,7 +408,7 @@ func (pg *Page) Handle() {
 	} else {
 		if pg.amount.IsMaxClicked() {
 			pg.amount.setError("")
-			pg.amount.Sendmax = true
+			pg.amount.SendMax = true
 			pg.amount.amountChanged()
 		}
 	}

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -400,7 +400,7 @@ func (pg *Page) Handle() {
 				if pg.amount.amountIsValid() {
 					pg.amount.setError("")
 				} else {
-					pg.Toast.NotifyError("Set destination amount")
+					pg.Toast.NotifyError("Set destination address")
 				}
 			}
 		}
@@ -410,6 +410,16 @@ func (pg *Page) Handle() {
 			pg.amount.setError("")
 			pg.amount.SendMax = true
 			pg.amount.amountChanged()
+		}
+	}
+
+	if pg.sendDestination.accountSwitch.Changed() {
+		pg.amount.setError("")
+		if currencyValue == values.USDExchangeValue {
+			pg.amount.dcrAmountEditor.Editor.SetText("")
+			pg.amount.usdAmountEditor.Editor.SetText("")
+		} else {
+			pg.amount.dcrAmountEditor.Editor.SetText("")
 		}
 	}
 }

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -395,6 +395,8 @@ func (pg *Page) Handle() {
 
 			editorsAreEmpty := len(pg.amount.dcrAmountEditor.Editor.Text()) < 1 || len(pg.amount.usdAmountEditor.Editor.Text()) < 1
 			if editorsAreEmpty {
+				pg.amount.dcrAmountEditor.Editor.SetText("")
+				pg.amount.usdAmountEditor.Editor.SetText("")
 				pg.amount.SendMax = false
 			}
 		} else if len(addEditor.Editor.Text()) < 1 {
@@ -420,6 +422,8 @@ func (pg *Page) Handle() {
 		}
 
 		if len(pg.amount.dcrAmountEditor.Editor.Text()) < 1 || len(pg.amount.usdAmountEditor.Editor.Text()) < 1 {
+			pg.amount.dcrAmountEditor.Editor.SetText("")
+			pg.amount.usdAmountEditor.Editor.SetText("")
 			pg.amount.SendMax = false
 		}
 

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -383,9 +383,9 @@ func (pg *Page) Handle() {
 		}
 	}
 
+	validAddress := pg.sendDestination.validate()
 	if pg.sendDestination.sendToAddress {
 		addEditor := pg.sendDestination.destinationAddressEditor
-		validAddress := pg.sendDestination.validate()
 		if validAddress {
 			if pg.amount.IsMaxClicked() {
 				pg.amount.setError("")
@@ -406,11 +406,18 @@ func (pg *Page) Handle() {
 		}
 
 	} else {
-		if pg.amount.IsMaxClicked() {
-			pg.amount.setError("")
-			pg.amount.SendMax = true
-			pg.amount.amountChanged()
+		if validAddress {
+			if pg.amount.IsMaxClicked() {
+				pg.amount.setError("")
+				pg.amount.SendMax = true
+				pg.amount.amountChanged()
+			}
 		}
+
+		if len(pg.amount.dcrAmountEditor.Editor.Text()) < 1 || len(pg.amount.usdAmountEditor.Editor.Text()) < 1 {
+			pg.amount.SendMax = false
+		}
+
 	}
 
 	if pg.sendDestination.accountSwitch.Changed() {

--- a/ui/page/send/send_amount.go
+++ b/ui/page/send/send_amount.go
@@ -21,9 +21,9 @@ type sendAmount struct {
 	dcrAmountEditor decredmaterial.Editor
 	usdAmountEditor decredmaterial.Editor
 
-	sendMax               bool
-	dcrSendMaxChangeEvent bool
-	usdSendMaxChangeEvent bool
+	Sendmax               bool
+	dcrSendmaxChangeEvent bool
+	usdSendmaxChangeEvent bool
 	amountChanged         func()
 
 	amountErrorText string
@@ -69,13 +69,13 @@ func (sa *sendAmount) setExchangeRate(exchangeRate float64) {
 func (sa *sendAmount) setAmount(amount int64) {
 	// TODO: this workaround ignores the change events from the
 	// amount input to avoid construct tx cycle.
-	sa.dcrSendMaxChangeEvent = sa.sendMax
+	sa.dcrSendmaxChangeEvent = sa.Sendmax
 	sa.dcrAmountEditor.Editor.SetText(fmt.Sprintf("%.8f", dcrutil.Amount(amount).ToCoin()))
 
 	if sa.exchangeRate != -1 {
 		usdAmount := load.DCRToUSD(sa.exchangeRate, dcrutil.Amount(amount).ToCoin())
 
-		sa.usdSendMaxChangeEvent = true
+		sa.usdSendmaxChangeEvent = true
 		sa.usdAmountEditor.Editor.SetText(fmt.Sprintf("%.2f", usdAmount))
 
 	}
@@ -83,20 +83,20 @@ func (sa *sendAmount) setAmount(amount int64) {
 
 func (sa *sendAmount) amountIsValid() bool {
 	_, err := strconv.ParseFloat(sa.dcrAmountEditor.Editor.Text(), 64)
-	return err == nil || sa.sendMax
+	return err == nil || sa.Sendmax
 }
 
 func (sa *sendAmount) validAmount() (int64, bool, error) {
-	if sa.sendMax {
-		return 0, sa.sendMax, nil
+	if sa.Sendmax {
+		return 0, sa.Sendmax, nil
 	}
 
 	amount, err := strconv.ParseFloat(sa.dcrAmountEditor.Editor.Text(), 64)
 	if err != nil {
-		return -1, sa.sendMax, err
+		return -1, sa.Sendmax, err
 	}
 
-	return dcrlibwallet.AmountAtom(amount), sa.sendMax, nil
+	return dcrlibwallet.AmountAtom(amount), sa.Sendmax, nil
 }
 
 func (sa *sendAmount) validateDCRAmount() {
@@ -162,7 +162,7 @@ func (sa *sendAmount) setError(err string) {
 }
 
 func (sa *sendAmount) resetFields() {
-	sa.sendMax = false
+	sa.Sendmax = false
 
 	sa.clearAmount()
 }
@@ -184,10 +184,10 @@ func (sa *sendAmount) handle() {
 		sa.usdAmountEditor.LineColor = sa.Theme.Color.Gray2
 	}
 
-	if sa.sendMax {
+	if sa.Sendmax {
 		sa.dcrAmountEditor.CustomButton.Background = sa.Theme.Color.Primary
 		sa.usdAmountEditor.CustomButton.Background = sa.Theme.Color.Primary
-	} else if len(sa.dcrAmountEditor.Editor.Text()) < 1 || !sa.sendMax {
+	} else if len(sa.dcrAmountEditor.Editor.Text()) < 1 || !sa.Sendmax {
 		sa.dcrAmountEditor.CustomButton.Background = sa.Theme.Color.Gray1
 		sa.usdAmountEditor.CustomButton.Background = sa.Theme.Color.Gray1
 	}
@@ -196,11 +196,11 @@ func (sa *sendAmount) handle() {
 		if sa.dcrAmountEditor.Editor.Focused() {
 			switch evt.(type) {
 			case widget.ChangeEvent:
-				if sa.dcrSendMaxChangeEvent {
-					sa.dcrSendMaxChangeEvent = false
+				if sa.dcrSendmaxChangeEvent {
+					sa.dcrSendmaxChangeEvent = false
 					continue
 				}
-				sa.sendMax = false
+				sa.Sendmax = false
 				sa.validateDCRAmount()
 				sa.amountChanged()
 
@@ -212,21 +212,21 @@ func (sa *sendAmount) handle() {
 		if sa.usdAmountEditor.Editor.Focused() {
 			switch evt.(type) {
 			case widget.ChangeEvent:
-				if sa.usdSendMaxChangeEvent {
-					sa.usdSendMaxChangeEvent = false
+				if sa.usdSendmaxChangeEvent {
+					sa.usdSendmaxChangeEvent = false
 					continue
 				}
-				sa.sendMax = false
+				sa.Sendmax = false
 				sa.validateUSDAmount()
 				sa.amountChanged()
 			}
 		}
 	}
+}
 
-	for sa.dcrAmountEditor.CustomButton.Clicked() ||
-		sa.usdAmountEditor.CustomButton.Clicked() {
-		sa.setError("")
-		sa.sendMax = true
-		sa.amountChanged()
+func (sa *sendAmount) IsMaxClicked() bool {
+	if sa.dcrAmountEditor.CustomButton.Clicked() || sa.usdAmountEditor.CustomButton.Clicked() {
+		return true
 	}
+	return false
 }

--- a/ui/page/send/send_amount.go
+++ b/ui/page/send/send_amount.go
@@ -21,9 +21,9 @@ type sendAmount struct {
 	dcrAmountEditor decredmaterial.Editor
 	usdAmountEditor decredmaterial.Editor
 
-	Sendmax               bool
-	dcrSendmaxChangeEvent bool
-	usdSendmaxChangeEvent bool
+	SendMax               bool
+	dcrSendMaxChangeEvent bool
+	usdSendMaxChangeEvent bool
 	amountChanged         func()
 
 	amountErrorText string
@@ -69,13 +69,13 @@ func (sa *sendAmount) setExchangeRate(exchangeRate float64) {
 func (sa *sendAmount) setAmount(amount int64) {
 	// TODO: this workaround ignores the change events from the
 	// amount input to avoid construct tx cycle.
-	sa.dcrSendmaxChangeEvent = sa.Sendmax
+	sa.dcrSendMaxChangeEvent = sa.SendMax
 	sa.dcrAmountEditor.Editor.SetText(fmt.Sprintf("%.8f", dcrutil.Amount(amount).ToCoin()))
 
 	if sa.exchangeRate != -1 {
 		usdAmount := load.DCRToUSD(sa.exchangeRate, dcrutil.Amount(amount).ToCoin())
 
-		sa.usdSendmaxChangeEvent = true
+		sa.usdSendMaxChangeEvent = true
 		sa.usdAmountEditor.Editor.SetText(fmt.Sprintf("%.2f", usdAmount))
 
 	}
@@ -83,20 +83,20 @@ func (sa *sendAmount) setAmount(amount int64) {
 
 func (sa *sendAmount) amountIsValid() bool {
 	_, err := strconv.ParseFloat(sa.dcrAmountEditor.Editor.Text(), 64)
-	return err == nil || sa.Sendmax
+	return err == nil || sa.SendMax
 }
 
 func (sa *sendAmount) validAmount() (int64, bool, error) {
-	if sa.Sendmax {
-		return 0, sa.Sendmax, nil
+	if sa.SendMax {
+		return 0, sa.SendMax, nil
 	}
 
 	amount, err := strconv.ParseFloat(sa.dcrAmountEditor.Editor.Text(), 64)
 	if err != nil {
-		return -1, sa.Sendmax, err
+		return -1, sa.SendMax, err
 	}
 
-	return dcrlibwallet.AmountAtom(amount), sa.Sendmax, nil
+	return dcrlibwallet.AmountAtom(amount), sa.SendMax, nil
 }
 
 func (sa *sendAmount) validateDCRAmount() {
@@ -162,7 +162,7 @@ func (sa *sendAmount) setError(err string) {
 }
 
 func (sa *sendAmount) resetFields() {
-	sa.Sendmax = false
+	sa.SendMax = false
 
 	sa.clearAmount()
 }
@@ -184,10 +184,10 @@ func (sa *sendAmount) handle() {
 		sa.usdAmountEditor.LineColor = sa.Theme.Color.Gray2
 	}
 
-	if sa.Sendmax {
+	if sa.SendMax {
 		sa.dcrAmountEditor.CustomButton.Background = sa.Theme.Color.Primary
 		sa.usdAmountEditor.CustomButton.Background = sa.Theme.Color.Primary
-	} else if len(sa.dcrAmountEditor.Editor.Text()) < 1 || !sa.Sendmax {
+	} else if len(sa.dcrAmountEditor.Editor.Text()) < 1 || !sa.SendMax {
 		sa.dcrAmountEditor.CustomButton.Background = sa.Theme.Color.Gray1
 		sa.usdAmountEditor.CustomButton.Background = sa.Theme.Color.Gray1
 	}
@@ -196,11 +196,11 @@ func (sa *sendAmount) handle() {
 		if sa.dcrAmountEditor.Editor.Focused() {
 			switch evt.(type) {
 			case widget.ChangeEvent:
-				if sa.dcrSendmaxChangeEvent {
-					sa.dcrSendmaxChangeEvent = false
+				if sa.dcrSendMaxChangeEvent {
+					sa.dcrSendMaxChangeEvent = false
 					continue
 				}
-				sa.Sendmax = false
+				sa.SendMax = false
 				sa.validateDCRAmount()
 				sa.amountChanged()
 
@@ -212,11 +212,11 @@ func (sa *sendAmount) handle() {
 		if sa.usdAmountEditor.Editor.Focused() {
 			switch evt.(type) {
 			case widget.ChangeEvent:
-				if sa.usdSendmaxChangeEvent {
-					sa.usdSendmaxChangeEvent = false
+				if sa.usdSendMaxChangeEvent {
+					sa.usdSendMaxChangeEvent = false
 					continue
 				}
-				sa.Sendmax = false
+				sa.SendMax = false
 				sa.validateUSDAmount()
 				sa.amountChanged()
 			}

--- a/ui/page/send/send_amount.go
+++ b/ui/page/send/send_amount.go
@@ -187,7 +187,7 @@ func (sa *sendAmount) handle() {
 	if sa.sendMax {
 		sa.dcrAmountEditor.CustomButton.Background = sa.Theme.Color.Primary
 		sa.usdAmountEditor.CustomButton.Background = sa.Theme.Color.Primary
-	} else {
+	} else if len(sa.dcrAmountEditor.Editor.Text()) < 1 || !sa.sendMax {
 		sa.dcrAmountEditor.CustomButton.Background = sa.Theme.Color.Gray1
 		sa.usdAmountEditor.CustomButton.Background = sa.Theme.Color.Gray1
 	}


### PR DESCRIPTION
Closes #732 

The address should be validated first before the amount is set 
Within the constructTx() function, unsignedTx is required to calculate the tx fee which will be deducted from the total number of coins 
One of the arguments of unsignedTx.addSenddestination is destination address 

In the light of this, this PR

- Adds toast notification "Set destination address" if max button is clicked and amount is not set 
- Fixes rhe bug that keeps the max button active when amount input is highlighted and cleared 