### PR TITLE
Wallet restore crash

### DIFF
--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -222,6 +222,9 @@ func (cm *CreatePasswordModal) Handle() {
 	cm.btnNegative.SetEnabled(!cm.isLoading)
 	if cm.btnNegative.Clicked() {
 		if !cm.isLoading {
+			if cm.parent != nil {
+				cm.parent.OnResume()
+			}
 			cm.Dismiss()
 		}
 	}

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -76,6 +76,8 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 	th := material.NewTheme(gofont.Collection())
 	cm.materialLoader = material.Loader(th)
 
+	cm.Load.EnableKeyEventOnInfoModal = true
+
 	return cm
 }
 
@@ -89,11 +91,10 @@ func (cm *CreatePasswordModal) OnResume() {
 	} else {
 		cm.passwordEditor.Editor.Focus()
 	}
-	cm.Load.EnableKeyEvent = true
 }
 
 func (cm *CreatePasswordModal) OnDismiss() {
-	cm.Load.EnableKeyEvent = false
+	cm.Load.EnableKeyEventOnInfoModal = false
 }
 
 func (cm *CreatePasswordModal) Show() {
@@ -229,7 +230,6 @@ func (cm *CreatePasswordModal) Handle() {
 	} else {
 		decredmaterial.SwitchEditors(cm.keyEvent, cm.passwordEditor.Editor, cm.confirmPasswordEditor.Editor)
 	}
-
 }
 
 func (cm *CreatePasswordModal) passwordsMatch(editors ...*widget.Editor) bool {

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -39,6 +39,8 @@ type CreatePasswordModal struct {
 	serverError string
 	description string
 
+	parent load.Page
+
 	materialLoader material.LoaderStyle
 
 	btnPositve  decredmaterial.Button
@@ -161,6 +163,12 @@ func (cm *CreatePasswordModal) validToCreate() bool {
 
 	return nameValid && editorsNotEmpty(cm.passwordEditor.Editor, cm.confirmPasswordEditor.Editor) &&
 		cm.passwordsMatch(cm.passwordEditor.Editor, cm.confirmPasswordEditor.Editor)
+}
+
+// SetParent sets the page that created PasswordModal as it's parent.
+func (cm *CreatePasswordModal) SetParent(parent load.Page) *CreatePasswordModal {
+	cm.parent = parent
+	return cm
 }
 
 func (cm *CreatePasswordModal) Handle() {

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -111,6 +111,9 @@ func (pg *Restore) ID() string {
 }
 
 func (pg *Restore) OnResume() {
+	pg.Load.EnableKeyEvent = true
+	pg.keyEvent = pg.Receiver.KeyEvents
+
 }
 
 func (pg *Restore) Layout(gtx layout.Context) layout.Dimensions {
@@ -436,10 +439,14 @@ func (pg *Restore) Handle() {
 			return
 		}
 
+		pg.Load.EnableKeyEvent = false
+		pg.keyEvent = nil
+
 		modal.NewCreatePasswordModal(pg.Load).
 			Title("Enter wallet details").
 			EnableName(true).
 			ShowWalletInfoTip(true).
+			SetParent(pg).
 			PasswordCreated(func(walletName, password string, m *modal.CreatePasswordModal) bool {
 				go func() {
 					_, err := pg.WL.MultiWallet.RestoreWallet(walletName, pg.seedPhrase, password, dcrlibwallet.PassphraseTypePass)


### PR DESCRIPTION
Resolves #734

This PR fixes issue #734 where the godcr crashes if tab is used to navigate text fields on the create password modal.