### PR TITLE
Unusable state after wallet restore

### DIFF
--- a/ui/load/load.go
+++ b/ui/load/load.go
@@ -32,6 +32,7 @@ type Receiver struct {
 	KeyEvents           chan *key.Event
 	AcctMixerStatus     chan *wallet.AccountMixer
 	SyncedProposal      chan *wallet.Proposal
+	WalletRestored      chan struct{} // Wallet restored channel.
 }
 
 type Icons struct {

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -458,7 +458,7 @@ func (pg *Restore) Handle() {
 						pg.PopWindowPage()
 					} else {
 						pg.WL.Wallet.SetupListeners()
-						pg.ChangeWindowPage(NewWalletPage(pg.Load), false)
+						pg.Load.Receiver.WalletRestored <- struct{}{}
 					}
 
 				}()

--- a/ui/window.go
+++ b/ui/window.go
@@ -379,7 +379,7 @@ func (win *Window) Loop(w *app.Window, shutdown chan int) {
 			default:
 				log.Tracef("Unhandled window event %+v\n", e)
 			}
-		case <- win.load.Receiver.WalletRestored:
+		case <-win.load.Receiver.WalletRestored:
 			win.changePage(page.NewMainPage(win.load), false)
 		}
 	}

--- a/ui/window.go
+++ b/ui/window.go
@@ -138,6 +138,7 @@ func (win *Window) NewLoad() (*load.Load, error) {
 		InternalLog:         win.internalLog,
 		SyncedProposal:      win.proposal,
 		NotificationsUpdate: make(chan interface{}, 10),
+		WalletRestored:      make(chan struct{}),
 	}
 
 	l.SelectedWallet = &win.selected
@@ -378,6 +379,8 @@ func (win *Window) Loop(w *app.Window, shutdown chan int) {
 			default:
 				log.Tracef("Unhandled window event %+v\n", e)
 			}
+		case <- win.load.Receiver.WalletRestored:
+			win.changePage(page.NewMainPage(win.load), false)
 		}
 	}
 }


### PR DESCRIPTION
This PR fix #735.
After wallet restore the App navigates to unusable interface. The is PR fixed that bug.