### PR TITLE
Enable mainnet support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ Follow the [installation](https://gioui.org/doc/install) instructions for gio.
 
 Then `go build`.
 
+## Running godcr
+### General usage
+By default, **godcr** runs on Mainnet network type. However, godcr can run on testnet by issuing commands on the terminal in the format:
+```bash
+godcr [options]
+```
+- Run `./godcr --network=testnet` to run godcr on the testnet network.
+- Run `godcr -h` or `godcr help` to get general information of commands and options that can be issued on the cli.
+- Use `godcr <command> -h` or   `godcr help <command>` to get detailed information about a command.
+
 ## Profiling 
 Godcr uses [pprof](https://github.com/google/pprof) for profiling. It creates a web server which you can use to save your profiles. To setup a profiling web server, run godcr with the --profile flag and pass a server port to it as an argument.
 

--- a/main.go
+++ b/main.go
@@ -49,8 +49,16 @@ func main() {
 		buildDate = time.Now()
 	}
 
+	var net string
+	switch cfg.Network {
+	case "testnet":
+		net = "testnet3"
+	default:
+		net = cfg.Network
+	}
+
 	logFile := filepath.Join(cfg.LogDir, defaultLogFilename)
-	wal, err := wallet.NewWallet(cfg.HomeDir, cfg.Network, Version, logFile, buildDate, make(chan wallet.Response, 3))
+	wal, err := wallet.NewWallet(cfg.HomeDir, net, Version, logFile, buildDate, make(chan wallet.Response, 3))
 	if err != nil {
 		log.Error(err)
 		return

--- a/ui/decredmaterial/dropdown.go
+++ b/ui/decredmaterial/dropdown.go
@@ -154,7 +154,7 @@ func (d *DropDown) layoutActiveIcon(gtx layout.Context, index int) D {
 func (d *DropDown) layoutOption(gtx layout.Context, itemIndex int) D {
 	item := d.items[itemIndex]
 
-	width := gtx.Px(values.MarginPadding174)
+	width := gtx.Px(values.MarginPadding180)
 	if d.revs {
 		width = gtx.Px(values.MarginPadding140)
 	}
@@ -166,11 +166,15 @@ func (d *DropDown) layoutOption(gtx layout.Context, itemIndex int) D {
 		clickable = d.clickable
 	}
 
+	padding := values.MarginPadding10
+	if item.Icon != nil {
+		padding = values.MarginPadding8
+	}
 	return LinearLayout{
 		Width:     width,
 		Height:    WrapContent,
 		Clickable: clickable,
-		Padding:   layout.UniformInset(values.MarginPadding10),
+		Padding:   layout.UniformInset(padding),
 		Border:    Border{Radius: radius},
 	}.Layout(gtx,
 		layout.Rigid(func(gtx C) D {

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -143,7 +143,7 @@ func (in *InfoModal) SetupWithTemplate(template string) *InfoModal {
 		customTemplate = verifyMessageInfo(in.Theme)
 	case PrivacyInfoTemplate:
 		title = "How to use the mixer?"
-		customTemplate = privacyInfo(in.Theme)
+		customTemplate = privacyInfo(in.Load)
 	case SetupMixerInfoTemplate:
 		customTemplate = setupMixerInfo(in.Theme)
 	case WalletBackupInfoTemplate:

--- a/ui/modal/info_modal_layouts.go
+++ b/ui/modal/info_modal_layouts.go
@@ -3,13 +3,11 @@ package modal
 import (
 	"gioui.org/layout"
 	"gioui.org/text"
-	"gioui.org/unit"
-	"gioui.org/widget"
 
 	"github.com/planetdecred/godcr/ui/decredmaterial"
+	"github.com/planetdecred/godcr/ui/load"
 	"github.com/planetdecred/godcr/ui/renderers"
 	"github.com/planetdecred/godcr/ui/values"
-	"golang.org/x/exp/shiny/materialdesign/icons"
 )
 
 const (
@@ -48,37 +46,35 @@ func signMessageInfo(th *decredmaterial.Theme) []layout.Widget {
 	}
 }
 
-func privacyInfo(th *decredmaterial.Theme) []layout.Widget {
+func privacyInfo(l *load.Load) []layout.Widget {
+	ic := decredmaterial.NewIcon(l.Icons.ImageBrightness1)
+	ic.Color = l.Theme.Color.Gray1
 	return []layout.Widget{
 		func(gtx C) D {
 			return layout.Flex{Alignment: layout.Baseline}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					ic := decredmaterial.NewIcon(decredmaterial.MustIcon(widget.NewIcon(icons.ImageLens)))
-					ic.Color = th.Color.Gray1
 					return ic.Layout(gtx, values.MarginPadding8)
 				}),
 				layout.Rigid(func(gtx C) D {
-					text := th.Body1("When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.")
-					text.Color = th.Color.GrayText2
+					text := l.Theme.Body1("When you turn on the mixer, your unmixed DCRs in this wallet (unmixed balance) will be gradually mixed.")
+					text.Color = l.Theme.Color.GrayText2
 					return layout.Inset{Left: values.MarginPadding10}.Layout(gtx, text.Layout)
 				}),
 			)
 		},
 		func(gtx C) D {
-			txt := th.Body1("Important: keep this app opened while mixer is running.")
-			txt.Font.Weight = text.Bold
+			txt := l.Theme.Body1("Important: keep this app opened while mixer is running.")
+			txt.Font.Weight = text.SemiBold
 			return txt.Layout(gtx)
 		},
 		func(gtx C) D {
 			return layout.Flex{Alignment: layout.Baseline}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					ic := decredmaterial.NewIcon(decredmaterial.MustIcon(widget.NewIcon(icons.ImageLens)))
-					ic.Color = th.Color.Gray1
 					return ic.Layout(gtx, values.MarginPadding8)
 				}),
 				layout.Rigid(func(gtx C) D {
-					text := th.Body1("Mixer will automatically stop when unmixed balance are fully mixed.")
-					text.Color = th.Color.GrayText2
+					text := l.Theme.Body1("Mixer will automatically stop when unmixed balance are fully mixed.")
+					text.Color = l.Theme.Color.GrayText2
 					return layout.Inset{Left: values.MarginPadding10}.Layout(gtx, text.Layout)
 				}),
 			)
@@ -124,31 +120,30 @@ func backupInfo(th *decredmaterial.Theme) []layout.Widget {
 	}
 }
 
-func allowUnspendUnmixedAcct(th *decredmaterial.Theme) []layout.Widget {
+func allowUnspendUnmixedAcct(l *load.Load) []layout.Widget {
 	return []layout.Widget{
 		func(gtx C) D {
 			return layout.Flex{}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					ic := decredmaterial.NewIcon(decredmaterial.MustIcon(widget.NewIcon(icons.ActionInfo)))
-					ic.Color = th.Color.GrayText1
+					ic := decredmaterial.NewIcon(l.Icons.ActionInfo)
+					ic.Color = l.Theme.Color.GrayText1
 					return layout.Inset{Top: values.MarginPadding4}.Layout(gtx, func(gtx C) D {
-						return ic.Layout(gtx, unit.Dp(18))
+						return ic.Layout(gtx, values.MarginPadding18)
 					})
 				}),
 				layout.Rigid(func(gtx C) D {
-					text := th.Body1("Spendings from unmixed accounts could potentially be traced back to you")
-					text.Color = th.Color.GrayText1
+					text := l.Theme.Body1("Spendings from unmixed accounts could potentially be traced back to you")
+					text.Color = l.Theme.Color.GrayText1
 					return layout.Inset{Left: values.MarginPadding5}.Layout(gtx, text.Layout)
 				}),
 			)
 		},
-
 		func(gtx C) D {
 			text := `<span style="text-color: grayText1">
 					Please type "<span style="font-weight: bold">I understand the risks</span>
 					" to allow spending from unmixed accounts.
 			</span>`
-			return renderers.RenderHTML(text, th).Layout(gtx)
+			return renderers.RenderHTML(text, l.Theme).Layout(gtx)
 		},
 	}
 }

--- a/ui/modal/text_input_modal.go
+++ b/ui/modal/text_input_modal.go
@@ -93,7 +93,7 @@ func (tm *TextInputModal) SetCancelable(min bool) *TextInputModal {
 func (tm *TextInputModal) SetTextWithTemplate(template string) *TextInputModal {
 	switch template {
 	case AllowUnmixedSpendingTemplate:
-		tm.textCustomTemplate = allowUnspendUnmixedAcct(tm.Theme)
+		tm.textCustomTemplate = allowUnspendUnmixedAcct(tm.Load)
 	}
 	return tm
 }

--- a/ui/page/components/proposal_list.go
+++ b/ui/page/components/proposal_list.go
@@ -193,6 +193,7 @@ func LayoutNoProposalsFound(gtx C, l *load.Load, syncing bool, category int32) D
 
 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
 	text := l.Theme.Body1(fmt.Sprintf("No %s proposals yet ", selectedCategory))
+	text.Color = l.Theme.Color.GrayText3
 	if syncing {
 		text = l.Theme.Body1("Fetching proposals...")
 	}

--- a/ui/page/overview/recent_proposals.go
+++ b/ui/page/overview/recent_proposals.go
@@ -53,6 +53,9 @@ func (pg *AppOverviewPage) recentProposalsSection(gtx C) D {
 								return title.Layout(gtx)
 							}),
 							layout.Flexed(1, func(gtx C) D {
+								if len(proposalItems) == 0 {
+									return D{}
+								}
 								return layout.E.Layout(gtx, pg.toProposals.Layout)
 							}),
 						)

--- a/ui/page/overview/recent_transaction.go
+++ b/ui/page/overview/recent_transaction.go
@@ -64,11 +64,13 @@ func (pg *AppOverviewPage) recentTransactionsSection(gtx layout.Context) layout.
 					if len(pg.transactions) == 0 {
 						message := pg.Theme.Body1(values.String(values.StrNoTransactionsYet))
 						message.Color = pg.Theme.Color.GrayText3
-						return components.Container{Padding: layout.Inset{
-							Left:   values.MarginPadding18,
-							Bottom: values.MarginPadding16,
-							Top:    values.MarginPadding18,
-						}}.Layout(gtx, message.Layout)
+						gtx.Constraints.Min.X = gtx.Constraints.Max.X
+						return layout.Center.Layout(gtx, func(gtx C) D {
+							return layout.Inset{
+								Top:    values.MarginPadding10,
+								Bottom: values.MarginPadding10,
+							}.Layout(gtx, message.Layout)
+						})
 					}
 
 					return pg.transactionsList.Layout(gtx, len(pg.transactions), func(gtx C, i int) D {

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -128,6 +128,7 @@ func (pg *TransactionsPage) Layout(gtx layout.Context) layout.Dimensions {
 									padding := values.MarginPadding16
 									txt := pg.Theme.Body1(values.String(values.StrNoTransactionsYet))
 									txt.Color = pg.Theme.Color.GrayText3
+									gtx.Constraints.Min.X = gtx.Constraints.Max.X
 									return layout.Center.Layout(gtx, func(gtx C) D {
 										return layout.Inset{Top: padding, Bottom: padding}.Layout(gtx, txt.Layout)
 									})

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -63,7 +63,7 @@ var (
 	MarginPadding140      = unit.Dp(140)
 	MarginPadding150      = unit.Dp(150)
 	MarginPadding168      = unit.Dp(168)
-	MarginPadding174      = unit.Dp(174)
+	MarginPadding180      = unit.Dp(180)
 	MarginPadding195      = unit.Dp(195)
 	MarginPaddingMinus195 = unit.Dp(-195)
 	MarginPadding200      = unit.Dp(200)


### PR DESCRIPTION
Fix #708 

This PR makes Godcr run on the mainnet network type by default.

Using the terminal command prompt, by running `./godcr --network=testnet` (macOS) godcr runs on the testnet network type.

It also
- Centralize no txn label on tx page.
- Allow no txn label card to extend entire page width
- Update overview page no proposal color
- Clean up info modal template
- Hide see all proposal ban when no proposals are available.
- Fix issues with wallet modal expand/collapse icon size.
- Fix issues with modal size when wallet icon is displayed.