### PR TITLE
Ensure that amount is revalidated when source account is changed

### DIFF
--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -25,10 +25,12 @@ type AccountSelector struct {
 
 	openSelectorDialog *decredmaterial.Clickable
 
-	wallets            []*dcrlibwallet.Wallet
-	selectedAccount    *dcrlibwallet.Account
-	selectedWalletName string
-	totalBalance       string
+	wallets               []*dcrlibwallet.Wallet
+	selectedAccount       *dcrlibwallet.Account
+	selectedWalletName    string
+	totalBalance          string
+	defaultAcccountNumber int32
+	isDefaultSet          bool
 }
 
 func NewAccountSelector(l *load.Load) *AccountSelector {
@@ -39,7 +41,8 @@ func NewAccountSelector(l *load.Load) *AccountSelector {
 		accountIsValid:     func(*dcrlibwallet.Account) bool { return true },
 		openSelectorDialog: l.Theme.NewClickable(true),
 
-		wallets: l.WL.SortedWalletList(),
+		wallets:      l.WL.SortedWalletList(),
+		isDefaultSet: false,
 	}
 }
 
@@ -58,7 +61,22 @@ func (as *AccountSelector) AccountSelected(callback func(*dcrlibwallet.Account))
 	return as
 }
 
+func (as *AccountSelector) Changed() bool {
+	if as.defaultAcccountNumber != as.selectedAccount.Number {
+		as.defaultAcccountNumber = as.selectedAccount.Number
+		return true
+	}
+
+	return false
+}
+
 func (as *AccountSelector) Handle() {
+	if !as.isDefaultSet {
+		as.defaultAcccountNumber = as.selectedAccount.Number
+		as.isDefaultSet = true
+	}
+	as.Changed()
+
 	for as.openSelectorDialog.Clicked() {
 		newAccountSelectorModal(as.Load, as.selectedAccount, as.wallets).
 			title(as.dialogTitle).

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -434,6 +434,11 @@ func (pg *Page) Handle() {
 		pg.amount.validateDCRAmount()
 		pg.validateAndConstructTx()
 	}
+
+	if pg.sendDestination.sendToAddress && pg.amount.SendMax && len(pg.sendDestination.destinationAddressEditor.Editor.Text()) == 0 {
+		pg.amount.dcrAmountEditor.Editor.SetText("")
+		pg.amount.SendMax = false
+	}
 }
 
 func (pg *Page) OnClose() {

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -52,11 +52,9 @@ type Page struct {
 
 	moreOptionIsOpen bool
 
-	exchangeRate          float64
-	usdExchangeSet        bool
-	exchangeError         string
-	defaultAcccountNumber int32
-	currentAccountNumber  int32
+	exchangeRate   float64
+	usdExchangeSet bool
+	exchangeError  string
 
 	*authoredTxData
 }
@@ -155,7 +153,6 @@ func (pg *Page) OnResume() {
 		pg.usdExchangeSet = false
 	}
 	pg.Load.EnableKeyEvent = true
-	pg.defaultAcccountNumber = pg.sourceAccountSelector.SelectedAccount().Number
 }
 
 func (pg *Page) fetchExchangeValue() {
@@ -432,9 +429,7 @@ func (pg *Page) Handle() {
 
 	}
 
-	pg.currentAccountNumber = pg.sourceAccountSelector.SelectedAccount().Number
-	if pg.currentAccountNumber != pg.defaultAcccountNumber {
-		pg.defaultAcccountNumber = pg.currentAccountNumber
+	if pg.sourceAccountSelector.Changed() {
 		pg.amount.validateDCRAmount()
 	}
 }

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -386,7 +386,6 @@ func (pg *Page) Handle() {
 	// if destination switch is equal to Address
 	if pg.sendDestination.sendToAddress {
 		if pg.sendDestination.validate() {
-			fmt.Println("Validated")
 			// Enable max amount if max button is clicked
 			if pg.amount.IsMaxClicked() {
 				pg.amount.setError("")

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -430,6 +430,11 @@ func (pg *Page) Handle() {
 			pg.amount.amountChanged()
 		}
 	}
+
+	if len(pg.amount.dcrAmountEditor.Editor.Text()) > 0 && pg.sourceAccountSelector.Changed() {
+		pg.amount.validateDCRAmount()
+		pg.validateAndConstructTx()
+	}
 }
 
 func (pg *Page) OnClose() {

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -383,54 +383,52 @@ func (pg *Page) Handle() {
 		}
 	}
 
-	validAddress := pg.sendDestination.validate()
+	// if destination switch is equal to Address
 	if pg.sendDestination.sendToAddress {
-		addEditor := pg.sendDestination.destinationAddressEditor
-		if validAddress {
+		if pg.sendDestination.validate() {
+			fmt.Println("Validated")
+			// Enable max amount if max button is clicked
 			if pg.amount.IsMaxClicked() {
 				pg.amount.setError("")
 				pg.amount.SendMax = true
 				pg.amount.amountChanged()
 			}
 
-			editorsAreEmpty := len(pg.amount.dcrAmountEditor.Editor.Text()) < 1 || len(pg.amount.usdAmountEditor.Editor.Text()) < 1
-			if editorsAreEmpty {
-				pg.amount.dcrAmountEditor.Editor.SetText("")
-				pg.amount.usdAmountEditor.Editor.SetText("")
-				pg.amount.SendMax = false
-			}
-		} else if len(addEditor.Editor.Text()) < 1 {
-			if len(pg.amount.dcrAmountEditor.Editor.Text()) < 1 || len(pg.amount.usdAmountEditor.Editor.Text()) < 1 {
-				pg.amount.SendMax = false
-			}
-			if pg.amount.IsMaxClicked() {
-				if pg.amount.amountIsValid() {
-					pg.amount.setError("")
-				} else {
-					pg.Toast.NotifyError("Set destination address")
+			if currencyValue != values.USDExchangeValue {
+				if len(pg.amount.dcrAmountEditor.Editor.Text()) == 0 {
+					pg.amount.SendMax = false
+				}
+			} else {
+				if len(pg.amount.dcrAmountEditor.Editor.Text()) == 0 {
+					pg.amount.usdAmountEditor.Editor.SetText("")
+					pg.amount.SendMax = false
 				}
 			}
 		}
 
-	} else {
-		if validAddress {
+		if len(pg.sendDestination.destinationAddressEditor.Editor.Text()) == 0 {
 			if pg.amount.IsMaxClicked() {
-				pg.amount.setError("")
-				pg.amount.SendMax = true
-				pg.amount.amountChanged()
+				pg.Toast.NotifyError("Set destination address")
+				pg.amount.SendMax = false
+			}
+		}
+	} else {
+		if currencyValue != values.USDExchangeValue {
+			if len(pg.amount.dcrAmountEditor.Editor.Text()) == 0 {
+				pg.amount.SendMax = false
+			}
+		} else {
+			if len(pg.amount.dcrAmountEditor.Editor.Text()) == 0 {
+				pg.amount.usdAmountEditor.Editor.SetText("")
+				pg.amount.SendMax = false
 			}
 		}
 
-		if len(pg.amount.dcrAmountEditor.Editor.Text()) < 1 || len(pg.amount.usdAmountEditor.Editor.Text()) < 1 {
-			pg.amount.dcrAmountEditor.Editor.SetText("")
-			pg.amount.usdAmountEditor.Editor.SetText("")
-			pg.amount.SendMax = false
+		if pg.amount.IsMaxClicked() {
+			pg.amount.setError("")
+			pg.amount.SendMax = true
+			pg.amount.amountChanged()
 		}
-
-	}
-
-	if pg.sourceAccountSelector.Changed() {
-		pg.amount.validateDCRAmount()
 	}
 }
 

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -52,9 +52,11 @@ type Page struct {
 
 	moreOptionIsOpen bool
 
-	exchangeRate   float64
-	usdExchangeSet bool
-	exchangeError  string
+	exchangeRate          float64
+	usdExchangeSet        bool
+	exchangeError         string
+	defaultAcccountNumber int32
+	currentAccountNumber  int32
 
 	*authoredTxData
 }
@@ -153,6 +155,7 @@ func (pg *Page) OnResume() {
 		pg.usdExchangeSet = false
 	}
 	pg.Load.EnableKeyEvent = true
+	pg.defaultAcccountNumber = pg.sourceAccountSelector.SelectedAccount().Number
 }
 
 func (pg *Page) fetchExchangeValue() {
@@ -437,6 +440,13 @@ func (pg *Page) Handle() {
 		} else {
 			pg.amount.dcrAmountEditor.Editor.SetText("")
 		}
+	}
+
+	pg.currentAccountNumber = pg.sourceAccountSelector.SelectedAccount().Number
+	if pg.currentAccountNumber != pg.defaultAcccountNumber {
+		pg.defaultAcccountNumber = pg.currentAccountNumber
+		pg.amount.validateDCRAmount()
+		pg.amount.validateUSDAmount()
 	}
 }
 

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -431,16 +431,6 @@ func (pg *Page) Handle() {
 
 	}
 
-	if pg.sendDestination.accountSwitch.Changed() {
-		pg.amount.setError("")
-		if currencyValue == values.USDExchangeValue {
-			pg.amount.dcrAmountEditor.Editor.SetText("")
-			pg.amount.usdAmountEditor.Editor.SetText("")
-		} else {
-			pg.amount.dcrAmountEditor.Editor.SetText("")
-		}
-	}
-
 	pg.currentAccountNumber = pg.sourceAccountSelector.SelectedAccount().Number
 	if pg.currentAccountNumber != pg.defaultAcccountNumber {
 		pg.defaultAcccountNumber = pg.currentAccountNumber

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -190,7 +190,6 @@ func (pg *Page) validateAndConstructTx() {
 }
 
 func (pg *Page) validate() bool {
-
 	amountIsValid := pg.amount.amountIsValid()
 	addressIsValid := pg.sendDestination.validate()
 
@@ -447,6 +446,12 @@ func (pg *Page) Handle() {
 		pg.defaultAcccountNumber = pg.currentAccountNumber
 		pg.amount.validateDCRAmount()
 		pg.amount.validateUSDAmount()
+	}
+
+	if pg.validate() {
+		fmt.Println("Validated")
+	} else {
+		fmt.Println("Not validated")
 	}
 }
 

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -194,7 +194,6 @@ func (pg *Page) validate() bool {
 	addressIsValid := pg.sendDestination.validate()
 
 	validForSending := amountIsValid && addressIsValid
-	pg.nextButton.SetEnabled(validForSending)
 
 	return validForSending
 }
@@ -301,6 +300,8 @@ func (pg *Page) resetFields() {
 }
 
 func (pg *Page) Handle() {
+	pg.nextButton.SetEnabled(pg.validate())
+
 	pg.sendDestination.handle()
 	pg.amount.handle()
 

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -446,12 +446,6 @@ func (pg *Page) Handle() {
 		pg.defaultAcccountNumber = pg.currentAccountNumber
 		pg.amount.validateDCRAmount()
 	}
-
-	if pg.validate() {
-		fmt.Println("Validated")
-	} else {
-		fmt.Println("Not validated")
-	}
 }
 
 func (pg *Page) OnClose() {

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -445,7 +445,6 @@ func (pg *Page) Handle() {
 	if pg.currentAccountNumber != pg.defaultAcccountNumber {
 		pg.defaultAcccountNumber = pg.currentAccountNumber
 		pg.amount.validateDCRAmount()
-		pg.amount.validateUSDAmount()
 	}
 
 	if pg.validate() {

--- a/ui/page/send/send_amount.go
+++ b/ui/page/send/send_amount.go
@@ -126,6 +126,7 @@ func (sa *sendAmount) validateDCRAmount() {
 
 // validateUSDAmount is called when usd text changes
 func (sa *sendAmount) validateUSDAmount() bool {
+
 	sa.amountErrorText = ""
 	if sa.inputsNotEmpty(sa.usdAmountEditor.Editor) {
 		usdAmount, err := strconv.ParseFloat(sa.usdAmountEditor.Editor.Text(), 64)

--- a/ui/page/send/send_amount.go
+++ b/ui/page/send/send_amount.go
@@ -83,7 +83,8 @@ func (sa *sendAmount) setAmount(amount int64) {
 
 func (sa *sendAmount) amountIsValid() bool {
 	_, err := strconv.ParseFloat(sa.dcrAmountEditor.Editor.Text(), 64)
-	return err == nil || sa.SendMax
+	amountEditorErrors := sa.amountErrorText == ""
+	return err == nil && amountEditorErrors || sa.SendMax
 }
 
 func (sa *sendAmount) validAmount() (int64, bool, error) {


### PR DESCRIPTION
Closes #743 
This PR:

- Ensures that send amount is revalidated when source account is changed 
- Keep the send button grey until amount is succesfully validated
- Fixes bug that prevents input on amount editors on send page 