### PR TITLE
Send page password/Key event Bug

### DIFF
--- a/ui/load/load.go
+++ b/ui/load/load.go
@@ -76,21 +76,21 @@ type Load struct {
 
 	Toast *notification.Toast
 
-	SelectedWallet            *int
-	SelectedAccount           *int
-	SelectedUTXO              map[int]map[int32]map[string]*wallet.UnspentOutput
+	SelectedWallet  *int
+	SelectedAccount *int
+	SelectedUTXO    map[int]map[int32]map[string]*wallet.UnspentOutput
 
-	ToggleSync       func()
-	RefreshWindow    func()
-	ShowModal        func(Modal)
-	DismissModal     func(Modal)
-	ChangeWindowPage func(page Page, keepBackStack bool)
-	PopWindowPage    func() bool
-	ChangeFragment   func(page Page)
-	PopFragment      func()
-	PopToFragment    func(pageID string)
-	SubscribeKeyEvent      func(eventChan chan *key.Event, pageID string) // Widgets call this function to recieve key events.
-	UnsubscribeKeyEvent    func(pageID string) error
+	ToggleSync          func()
+	RefreshWindow       func()
+	ShowModal           func(Modal)
+	DismissModal        func(Modal)
+	ChangeWindowPage    func(page Page, keepBackStack bool)
+	PopWindowPage       func() bool
+	ChangeFragment      func(page Page)
+	PopFragment         func()
+	PopToFragment       func(pageID string)
+	SubscribeKeyEvent   func(eventChan chan *key.Event, pageID string) // Widgets call this function to recieve key events.
+	UnsubscribeKeyEvent func(pageID string) error
 }
 
 func NewLoad() (*Load, error) {
@@ -127,7 +127,7 @@ func NewLoad() (*Load, error) {
 		Receiver: r,
 		Toast:    notification.NewToast(th),
 
-		Printer:                   message.NewPrinter(language.English),
+		Printer: message.NewPrinter(language.English),
 	}
 
 	return l, nil

--- a/ui/load/load.go
+++ b/ui/load/load.go
@@ -29,7 +29,7 @@ type DCRUSDTBittrex struct {
 type Receiver struct {
 	InternalLog         chan string
 	NotificationsUpdate chan interface{}
-	KeyEvents           chan *key.Event
+	KeyEvents           map[string]chan *key.Event
 	AcctMixerStatus     chan *wallet.AccountMixer
 	SyncedProposal      chan *wallet.Proposal
 	WalletRestored      chan struct{} // Wallet restored channel.
@@ -79,8 +79,6 @@ type Load struct {
 	SelectedWallet            *int
 	SelectedAccount           *int
 	SelectedUTXO              map[int]map[int32]map[string]*wallet.UnspentOutput
-	EnableKeyEvent            bool
-	EnableKeyEventOnInfoModal bool
 
 	ToggleSync       func()
 	RefreshWindow    func()
@@ -91,6 +89,8 @@ type Load struct {
 	ChangeFragment   func(page Page)
 	PopFragment      func()
 	PopToFragment    func(pageID string)
+	SubscribeKeyEvent      func(eventChan chan *key.Event, pageID string) // Widgets call this function to recieve key events.
+	UnsubscribeKeyEvent    func(pageID string) error
 }
 
 func NewLoad() (*Load, error) {
@@ -128,8 +128,6 @@ func NewLoad() (*Load, error) {
 		Toast:    notification.NewToast(th),
 
 		Printer:                   message.NewPrinter(language.English),
-		EnableKeyEvent:            false,
-		EnableKeyEventOnInfoModal: false,
 	}
 
 	return l, nil

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -58,7 +58,7 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 		btnPositve:       l.Theme.Button("Confirm"),
 		btnNegative:      l.Theme.OutlineButton("Cancel"),
 		isCancelable:     true,
-		keyEvent:         l.Receiver.KeyEvents,
+		keyEvent:         make(chan *key.Event),
 	}
 
 	cm.btnPositve.Font.Weight = text.Medium
@@ -78,7 +78,7 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 	th := material.NewTheme(gofont.Collection())
 	cm.materialLoader = material.Loader(th)
 
-	cm.Load.EnableKeyEventOnInfoModal = true
+	l.SubscribeKeyEvent(cm.keyEvent, cm.randomID)
 
 	return cm
 }
@@ -96,7 +96,7 @@ func (cm *CreatePasswordModal) OnResume() {
 }
 
 func (cm *CreatePasswordModal) OnDismiss() {
-	cm.Load.EnableKeyEventOnInfoModal = false
+	cm.Load.UnsubscribeKeyEvent(cm.randomID)
 }
 
 func (cm *CreatePasswordModal) Show() {

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -47,7 +47,7 @@ func NewCreateWatchOnlyModal(l *load.Load) *CreateWatchOnlyModal {
 		btnPositve:   l.Theme.Button(values.String(values.StrImport)),
 		btnNegative:  l.Theme.OutlineButton(values.String(values.StrCancel)),
 		isCancelable: true,
-		keyEvent:     l.Receiver.KeyEvents,
+		keyEvent:     make(chan *key.Event),
 	}
 
 	cm.btnPositve.Font.Weight = text.Medium
@@ -73,11 +73,11 @@ func (cm *CreateWatchOnlyModal) ModalID() string {
 
 func (cm *CreateWatchOnlyModal) OnResume() {
 	cm.walletName.Editor.Focus()
-	cm.Load.EnableKeyEvent = true
+	cm.Load.SubscribeKeyEvent(cm.keyEvent, cm.randomID)
 }
 
 func (cm *CreateWatchOnlyModal) OnDismiss() {
-	cm.Load.EnableKeyEvent = false
+	cm.Load.UnsubscribeKeyEvent(cm.randomID)
 }
 
 func (cm *CreateWatchOnlyModal) Show() {

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -49,7 +49,7 @@ func NewInfoModal(l *load.Load) *InfoModal {
 		modal:        *l.Theme.ModalFloatTitle(),
 		btnPositve:   l.Theme.OutlineButton("Yes"),
 		btnNegative:  l.Theme.OutlineButton("No"),
-		keyEvent:     l.Receiver.KeyEvents,
+		keyEvent:     make(chan *key.Event),
 		isCancelable: true,
 		btnAlignment: layout.E,
 	}
@@ -73,11 +73,11 @@ func (in *InfoModal) Dismiss() {
 }
 
 func (in *InfoModal) OnResume() {
-	in.Load.EnableKeyEventOnInfoModal = true
+	in.Load.SubscribeKeyEvent(in.keyEvent, in.randomID)
 }
 
 func (in *InfoModal) OnDismiss() {
-	in.Load.EnableKeyEventOnInfoModal = false
+	in.Load.UnsubscribeKeyEvent(in.randomID)
 }
 
 func (in *InfoModal) SetCancelable(min bool) *InfoModal {

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -325,7 +325,7 @@ func (pg *Page) Handle() {
 
 	for pg.nextButton.Clicked() {
 		if pg.txAuthor != nil {
-			pg.confirmTxModal = newSendConfirmModal(pg.Load, pg.authoredTxData)
+			pg.confirmTxModal = newSendConfirmModal(pg.Load, pg.authoredTxData).SetParent(pg)
 			pg.confirmTxModal.exchangeRateSet = pg.exchangeRate != -1 && pg.usdExchangeSet
 
 			pg.confirmTxModal.txSent = func() {
@@ -333,6 +333,7 @@ func (pg *Page) Handle() {
 				pg.clearEstimates()
 			}
 
+			pg.Load.UnsubscribeKeyEvent(pg.ID())
 			pg.confirmTxModal.Show()
 		}
 	}

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -357,6 +357,7 @@ func (pg *Page) Handle() {
 			if !pg.amount.dcrAmountEditor.Editor.Focused() && !modalShown {
 				pg.amount.dcrAmountEditor.Editor.Focus()
 			}
+			decredmaterial.SwitchEditors(pg.keyEvent, pg.amount.dcrAmountEditor.Editor)
 		default:
 			if pg.sendDestination.accountSwitch.Changed() {
 				if !pg.sendDestination.validate() {

--- a/ui/page/send/send_confirm_modal.go
+++ b/ui/page/send/send_confirm_modal.go
@@ -30,6 +30,7 @@ type sendConfirmModal struct {
 
 	*authoredTxData
 	exchangeRateSet bool
+	isShown         bool
 }
 
 func newSendConfirmModal(l *load.Load, data *authoredTxData) *sendConfirmModal {
@@ -60,10 +61,12 @@ func (scm *sendConfirmModal) ModalID() string {
 }
 
 func (scm *sendConfirmModal) Show() {
+	scm.isShown = true
 	scm.ShowModal(scm)
 }
 
 func (scm *sendConfirmModal) Dismiss() {
+	scm.isShown = false
 	scm.DismissModal(scm)
 }
 
@@ -73,6 +76,10 @@ func (scm *sendConfirmModal) OnResume() {
 
 func (scm *sendConfirmModal) OnDismiss() {
 
+}
+
+func (scm *sendConfirmModal) IsShown() bool {
+	return scm.isShown
 }
 
 func (scm *sendConfirmModal) broadcastTransaction() {

--- a/ui/page/send/send_confirm_modal.go
+++ b/ui/page/send/send_confirm_modal.go
@@ -31,6 +31,7 @@ type sendConfirmModal struct {
 	*authoredTxData
 	exchangeRateSet bool
 	isShown         bool
+	parent          load.Page // Reference to the page that this modal is shown on.
 }
 
 func newSendConfirmModal(l *load.Load, data *authoredTxData) *sendConfirmModal {
@@ -67,6 +68,10 @@ func (scm *sendConfirmModal) Show() {
 
 func (scm *sendConfirmModal) Dismiss() {
 	scm.isShown = false
+	// Call Parent's onResume to resubscribe parent for key events.
+	if scm.parent != nil {
+		scm.parent.OnResume()
+	}
 	scm.DismissModal(scm)
 }
 
@@ -80,6 +85,12 @@ func (scm *sendConfirmModal) OnDismiss() {
 
 func (scm *sendConfirmModal) IsShown() bool {
 	return scm.isShown
+}
+
+// SetParent sets the page that created sendConfirmModal as it's parent.
+func (scm *sendConfirmModal) SetParent(parent load.Page) *sendConfirmModal {
+	scm.parent = parent
+	return scm
 }
 
 func (scm *sendConfirmModal) broadcastTransaction() {

--- a/ui/page/verify_message_page.go
+++ b/ui/page/verify_message_page.go
@@ -37,7 +37,7 @@ func NewVerifyMessagePage(l *load.Load) *VerifyMessagePage {
 	pg := &VerifyMessagePage{
 		Load:               l,
 		verifyMessage:      l.Theme.Body1(""),
-		keyEvent:           l.Receiver.KeyEvents,
+		keyEvent:           make(chan *key.Event),
 		EnableEditorSwitch: false,
 	}
 
@@ -69,7 +69,7 @@ func (pg *VerifyMessagePage) ID() string {
 
 func (pg *VerifyMessagePage) OnResume() {
 	pg.addressEditor.Editor.Focus()
-	pg.Load.EnableKeyEvent = true
+	pg.Load.SubscribeKeyEvent(pg.keyEvent, pg.ID())
 }
 
 func (pg *VerifyMessagePage) Layout(gtx layout.Context) layout.Dimensions {
@@ -245,5 +245,5 @@ func (pg *VerifyMessagePage) validateAddress() bool {
 }
 
 func (pg *VerifyMessagePage) OnClose() {
-	pg.Load.EnableKeyEvent = false
+	pg.Load.UnsubscribeKeyEvent(pg.ID())
 }

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -70,7 +70,7 @@ func NewRestorePage(l *load.Load) *Restore {
 
 		seedList: &layout.List{Axis: layout.Vertical},
 
-		keyEvent: l.Receiver.KeyEvents,
+		keyEvent: make(chan *key.Event),
 
 		suggestionLimit: 3,
 		openPopupIndex:  -1,
@@ -101,7 +101,7 @@ func NewRestorePage(l *load.Load) *Restore {
 
 	// set suggestions
 	pg.allSuggestions = dcrlibwallet.PGPWordList()
-	pg.Load.EnableKeyEvent = true
+	l.SubscribeKeyEvent(pg.keyEvent, pg.ID())
 
 	return pg
 }
@@ -111,8 +111,7 @@ func (pg *Restore) ID() string {
 }
 
 func (pg *Restore) OnResume() {
-	pg.Load.EnableKeyEvent = true
-	pg.keyEvent = pg.Receiver.KeyEvents
+	pg.Load.SubscribeKeyEvent(pg.keyEvent, pg.ID())
 
 }
 
@@ -439,8 +438,7 @@ func (pg *Restore) Handle() {
 			return
 		}
 
-		pg.Load.EnableKeyEvent = false
-		pg.keyEvent = nil
+		pg.Load.UnsubscribeKeyEvent(pg.ID())
 
 		modal.NewCreatePasswordModal(pg.Load).
 			Title("Enter wallet details").
@@ -519,5 +517,5 @@ func (pg *Restore) Handle() {
 }
 
 func (pg *Restore) OnClose() {
-	pg.Load.EnableKeyEvent = false
+	pg.Load.UnsubscribeKeyEvent(pg.ID())
 }

--- a/ui/page/wallets/sign_message_page.go
+++ b/ui/page/wallets/sign_message_page.go
@@ -72,7 +72,7 @@ func NewSignMessagePage(l *load.Load, wallet *dcrlibwallet.Wallet) *SignMessageP
 		copyButton:         l.Theme.Button("Copy"),
 		copySignature:      l.Theme.NewClickable(false),
 		copyIcon:           copyIcon,
-		keyEvent:           l.Receiver.KeyEvents,
+		keyEvent:           make(chan *key.Event),
 	}
 
 	pg.signedMessageLabel.Color = l.Theme.Color.GrayText2
@@ -87,7 +87,7 @@ func (pg *SignMessagePage) ID() string {
 
 func (pg *SignMessagePage) OnResume() {
 	pg.addressEditor.Editor.Focus()
-	pg.Load.EnableKeyEvent = true
+	pg.Load.SubscribeKeyEvent(pg.keyEvent, pg.ID())
 }
 
 func (pg *SignMessagePage) Layout(gtx layout.Context) layout.Dimensions {
@@ -336,5 +336,5 @@ func (pg *SignMessagePage) clearForm() {
 }
 
 func (pg *SignMessagePage) OnClose() {
-	pg.Load.EnableKeyEvent = false
+	pg.Load.UnsubscribeKeyEvent(pg.ID())
 }

--- a/ui/window.go
+++ b/ui/window.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"sync"
 	"time"
+	"errors"
 
 	"gioui.org/app"
 	"gioui.org/io/key"
@@ -267,17 +268,17 @@ func (win *Window) layoutPage(gtx C, page load.Page) {
 
 // SubscribeKeyEvent subscribes pages for key events.
 func (win *Window) SubscribeKeyEvent(eventChan chan *key.Event, pageID string) {
-	keyEvents[pageID] = eventChan
+	win.keyEvents[pageID] = eventChan
 }
 
 // UnsubscribeKeyEvent unsubscribe a page with {pageID} from receiving key events.
 func (win *Window) UnsubscribeKeyEvent(pageID string) error {
-	if _, ok := keyEvents[pageID]; ok {
-		delete(keyEvents, pageID)
+	if _, ok := win.keyEvents[pageID]; ok {
+		delete(win.keyEvents, pageID)
 		return nil
 	}
 
-	return errors.new("Page not subscribed for key events.")
+	return errors.New("Page not subscribed for key events.")
 }
 
 // Loop runs main event handling and page rendering loop
@@ -384,7 +385,7 @@ func (win *Window) Loop(w *app.Window, shutdown chan int) {
 				evt.Frame(gtx.Ops)
 			case key.Event:
 				go func() {
-					for _, c := range keyEvents {
+					for _, c := range win.keyEvents {
 						c <- &evt
 					}
 				}()

--- a/ui/window.go
+++ b/ui/window.go
@@ -278,7 +278,7 @@ func (win *Window) UnsubscribeKeyEvent(pageID string) error {
 		return nil
 	}
 
-	return errors.New("Page not subscribed for key events.")
+	return errors.New("Page not subscribed for key events")
 }
 
 // Loop runs main event handling and page rendering loop

--- a/ui/window.go
+++ b/ui/window.go
@@ -1,9 +1,9 @@
 package ui
 
 import (
+	"errors"
 	"sync"
 	"time"
-	"errors"
 
 	"gioui.org/app"
 	"gioui.org/io/key"


### PR DESCRIPTION
This PR restructures how Key events are delivered to the modals and Pages, fixes the bug where pages and modals listen to key events on the same channel and try to handle the same events simultaneously. It also fixes #739  where the password confirmation editor goes out of focus when sending DCR to accounts. 