### PR TITLE
Disable actions on modals when a process is running.

### DIFF
--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -48,9 +48,6 @@ type Editor struct {
 	// isEditorButtonClickable passes a clickable icon button if true and regular icon if false
 	isEditorButtonClickable bool
 
-	// disabled sets the state of the editor to either enabled state or disbled state
-	IsDisabled bool
-
 	requiredErrorText string
 
 	editorIcon       *Icon
@@ -234,14 +231,7 @@ func (e Editor) editor(gtx layout.Context) layout.Dimensions {
 						Top:    e.m5,
 						Bottom: e.m5,
 					}
-					return inset.Layout(gtx, func(gtx C) D {
-						editorGtx := gtx
-						if e.IsDisabled {
-							editorGtx = gtx.Disabled()
-						}
-
-						return e.EditorStyle.Layout(editorGtx)
-					})
+					return inset.Layout(gtx, e.EditorStyle.Layout)
 				}),
 			)
 		}),

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -48,6 +48,9 @@ type Editor struct {
 	// isEditorButtonClickable passes a clickable icon button if true and regular icon if false
 	isEditorButtonClickable bool
 
+	// disabled sets the state of the editor to either enabled state or disbled state
+	Disabled bool
+
 	requiredErrorText string
 
 	editorIcon       *Icon
@@ -232,7 +235,12 @@ func (e Editor) editor(gtx layout.Context) layout.Dimensions {
 						Bottom: e.m5,
 					}
 					return inset.Layout(gtx, func(gtx C) D {
-						return e.EditorStyle.Layout(gtx)
+						editorGtx := gtx
+						if e.Disabled {
+							editorGtx = gtx.Disabled()
+						}
+
+						return e.EditorStyle.Layout(editorGtx)
 					})
 				}),
 			)

--- a/ui/decredmaterial/editor.go
+++ b/ui/decredmaterial/editor.go
@@ -49,7 +49,7 @@ type Editor struct {
 	isEditorButtonClickable bool
 
 	// disabled sets the state of the editor to either enabled state or disbled state
-	Disabled bool
+	IsDisabled bool
 
 	requiredErrorText string
 
@@ -236,7 +236,7 @@ func (e Editor) editor(gtx layout.Context) layout.Dimensions {
 					}
 					return inset.Layout(gtx, func(gtx C) D {
 						editorGtx := gtx
-						if e.Disabled {
+						if e.IsDisabled {
 							editorGtx = gtx.Disabled()
 						}
 

--- a/ui/decredmaterial/modal.go
+++ b/ui/decredmaterial/modal.go
@@ -9,15 +9,17 @@ import (
 )
 
 type Modal struct {
-	overlayColor  color.NRGBA
-	background    color.NRGBA
-	list          *widget.List
-	button        *widget.Clickable
-	card          Card
-	scroll        ListStyle
+	overlayColor color.NRGBA
+	background   color.NRGBA
+	list         *widget.List
+	button       *widget.Clickable
+	card         Card
+	scroll       ListStyle
+	padding      unit.Value
+
 	isFloatTitle  bool
+	isDisabled    bool
 	showScrollBar bool
-	padding       unit.Value
 }
 
 func (t *Theme) ModalFloatTitle() *Modal {
@@ -49,7 +51,11 @@ func (t *Theme) Modal() *Modal {
 // Layout renders the modal widget to screen. The modal assumes the size of
 // its content plus padding.
 func (m *Modal) Layout(gtx layout.Context, widgets []layout.Widget) layout.Dimensions {
-	dims := layout.Stack{Alignment: layout.Center}.Layout(gtx,
+	mGtx := gtx
+	if m.isDisabled {
+		mGtx = gtx.Disabled()
+	}
+	dims := layout.Stack{Alignment: layout.Center}.Layout(mGtx,
 		layout.Expanded(func(gtx C) D {
 			gtx.Constraints.Min.X = gtx.Constraints.Max.X
 			fillMax(gtx, m.overlayColor, CornerRadius{})
@@ -146,4 +152,8 @@ func (m *Modal) SetPadding(padding unit.Value) {
 
 func (m *Modal) ShowScrollbar(showScrollBar bool) {
 	m.showScrollBar = showScrollBar
+}
+
+func (m *Modal) SetDisabled(disabled bool) {
+	m.isDisabled = disabled
 }

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -173,6 +173,7 @@ func (cm *CreatePasswordModal) SetParent(parent load.Page) *CreatePasswordModal 
 }
 
 func (cm *CreatePasswordModal) Handle() {
+	cm.disableEditors()
 
 	if editorsNotEmpty(cm.passwordEditor.Editor) || editorsNotEmpty(cm.walletName.Editor) ||
 		editorsNotEmpty(cm.confirmPasswordEditor.Editor) {
@@ -218,6 +219,7 @@ func (cm *CreatePasswordModal) Handle() {
 				cm.Dismiss()
 			}
 		}
+
 	}
 
 	cm.btnNegative.SetEnabled(!cm.isLoading)
@@ -259,6 +261,12 @@ func (cm *CreatePasswordModal) passwordsMatch(editors ...*widget.Editor) bool {
 
 	cm.confirmPasswordEditor.SetError("")
 	return true
+}
+
+func (cm *CreatePasswordModal) disableEditors() {
+	cm.walletName.Disabled = cm.isLoading
+	cm.confirmPasswordEditor.Disabled = cm.isLoading
+	cm.passwordEditor.Disabled = cm.isLoading
 }
 
 func (cm *CreatePasswordModal) titleLayout() layout.Widget {

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -173,8 +173,6 @@ func (cm *CreatePasswordModal) SetParent(parent load.Page) *CreatePasswordModal 
 }
 
 func (cm *CreatePasswordModal) Handle() {
-	cm.disableEditors()
-
 	if editorsNotEmpty(cm.passwordEditor.Editor) || editorsNotEmpty(cm.walletName.Editor) ||
 		editorsNotEmpty(cm.confirmPasswordEditor.Editor) {
 		cm.btnPositve.Background = cm.Theme.Color.Primary
@@ -219,7 +217,6 @@ func (cm *CreatePasswordModal) Handle() {
 				cm.Dismiss()
 			}
 		}
-
 	}
 
 	cm.btnNegative.SetEnabled(!cm.isLoading)
@@ -231,6 +228,8 @@ func (cm *CreatePasswordModal) Handle() {
 			cm.Dismiss()
 		}
 	}
+
+	cm.modal.SetDisabled(cm.isLoading)
 
 	if cm.modal.BackdropClicked(cm.isCancelable) {
 		if !cm.isLoading {
@@ -261,12 +260,6 @@ func (cm *CreatePasswordModal) passwordsMatch(editors ...*widget.Editor) bool {
 
 	cm.confirmPasswordEditor.SetError("")
 	return true
-}
-
-func (cm *CreatePasswordModal) disableEditors() {
-	cm.walletName.Disabled = cm.isLoading
-	cm.confirmPasswordEditor.Disabled = cm.isLoading
-	cm.passwordEditor.Disabled = cm.isLoading
 }
 
 func (cm *CreatePasswordModal) titleLayout() layout.Widget {

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -140,6 +140,7 @@ func (cm *CreatePasswordModal) PasswordCreated(callback func(walletName, passwor
 
 func (cm *CreatePasswordModal) SetLoading(loading bool) {
 	cm.isLoading = loading
+	cm.modal.SetDisabled(loading)
 }
 
 func (cm *CreatePasswordModal) SetCancelable(min bool) *CreatePasswordModal {
@@ -228,8 +229,6 @@ func (cm *CreatePasswordModal) Handle() {
 			cm.Dismiss()
 		}
 	}
-
-	cm.modal.SetDisabled(cm.isLoading)
 
 	if cm.modal.BackdropClicked(cm.isCancelable) {
 		if !cm.isLoading {

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -90,6 +90,7 @@ func (cm *CreateWatchOnlyModal) Dismiss() {
 
 func (cm *CreateWatchOnlyModal) SetLoading(loading bool) {
 	cm.isLoading = loading
+	cm.modal.SetDisabled(loading)
 }
 
 func (cm *CreateWatchOnlyModal) SetCancelable(min bool) *CreateWatchOnlyModal {
@@ -107,8 +108,6 @@ func (cm *CreateWatchOnlyModal) WatchOnlyCreated(callback func(walletName, extPu
 }
 
 func (cm *CreateWatchOnlyModal) Handle() {
-	cm.modal.SetDisabled(cm.isLoading)
-
 	if editorsNotEmpty(cm.walletName.Editor) ||
 		editorsNotEmpty(cm.extendedPubKey.Editor) {
 		cm.btnPositve.Background = cm.Theme.Color.Primary

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -107,7 +107,8 @@ func (cm *CreateWatchOnlyModal) WatchOnlyCreated(callback func(walletName, extPu
 }
 
 func (cm *CreateWatchOnlyModal) Handle() {
-	cm.disableEditors()
+	cm.modal.SetDisabled(cm.isLoading)
+
 	if editorsNotEmpty(cm.walletName.Editor) ||
 		editorsNotEmpty(cm.extendedPubKey.Editor) {
 		cm.btnPositve.Background = cm.Theme.Color.Primary
@@ -191,9 +192,4 @@ func (cm *CreateWatchOnlyModal) Layout(gtx layout.Context) D {
 	}
 
 	return cm.modal.Layout(gtx, w)
-}
-
-func (cm *CreateWatchOnlyModal) disableEditors() {
-	cm.walletName.Disabled = cm.isLoading
-	cm.extendedPubKey.Disabled = cm.isLoading
 }

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -107,6 +107,7 @@ func (cm *CreateWatchOnlyModal) WatchOnlyCreated(callback func(walletName, extPu
 }
 
 func (cm *CreateWatchOnlyModal) Handle() {
+	cm.disableEditors()
 	if editorsNotEmpty(cm.walletName.Editor) ||
 		editorsNotEmpty(cm.extendedPubKey.Editor) {
 		cm.btnPositve.Background = cm.Theme.Color.Primary
@@ -190,4 +191,9 @@ func (cm *CreateWatchOnlyModal) Layout(gtx layout.Context) D {
 	}
 
 	return cm.modal.Layout(gtx, w)
+}
+
+func (cm *CreateWatchOnlyModal) disableEditors() {
+	cm.walletName.Disabled = cm.isLoading
+	cm.extendedPubKey.Disabled = cm.isLoading
 }

--- a/ui/modal/password_modal.go
+++ b/ui/modal/password_modal.go
@@ -135,6 +135,8 @@ func (pm *PasswordModal) SetError(err string) {
 }
 
 func (pm *PasswordModal) Handle() {
+	pm.password.Disabled = pm.isLoading
+
 	isSubmit, isChanged := decredmaterial.HandleEditorEvents(pm.password.Editor)
 	if isChanged {
 		pm.password.SetError("")

--- a/ui/modal/password_modal.go
+++ b/ui/modal/password_modal.go
@@ -119,6 +119,7 @@ func (pm *PasswordModal) NegativeButton(text string, clicked func()) *PasswordMo
 
 func (pm *PasswordModal) SetLoading(loading bool) {
 	pm.isLoading = loading
+	pm.modal.SetDisabled(loading)
 }
 
 func (pm *PasswordModal) SetCancelable(min bool) *PasswordModal {
@@ -135,8 +136,6 @@ func (pm *PasswordModal) SetError(err string) {
 }
 
 func (pm *PasswordModal) Handle() {
-	pm.modal.SetDisabled(pm.isLoading)
-
 	isSubmit, isChanged := decredmaterial.HandleEditorEvents(pm.password.Editor)
 	if isChanged {
 		pm.password.SetError("")

--- a/ui/modal/password_modal.go
+++ b/ui/modal/password_modal.go
@@ -135,7 +135,7 @@ func (pm *PasswordModal) SetError(err string) {
 }
 
 func (pm *PasswordModal) Handle() {
-	pm.password.Disabled = pm.isLoading
+	pm.modal.SetDisabled(pm.isLoading)
 
 	isSubmit, isChanged := decredmaterial.HandleEditorEvents(pm.password.Editor)
 	if isChanged {

--- a/ui/modal/text_input_modal.go
+++ b/ui/modal/text_input_modal.go
@@ -99,7 +99,7 @@ func (tm *TextInputModal) SetTextWithTemplate(template string) *TextInputModal {
 }
 
 func (tm *TextInputModal) Handle() {
-	tm.textInput.Disabled = tm.isEnabled
+	tm.modal.SetDisabled(tm.IsLoading)
 
 	if editorsNotEmpty(tm.textInput.Editor) {
 		tm.btnPositve.Background = tm.positiveButtonColor

--- a/ui/modal/text_input_modal.go
+++ b/ui/modal/text_input_modal.go
@@ -18,7 +18,7 @@ const TextInput = "text_input_modal"
 type TextInputModal struct {
 	*InfoModal
 
-	IsLoading           bool
+	isLoading           bool
 	showAccountWarnInfo bool
 	isCancelable        bool
 	isEnabled           bool
@@ -61,6 +61,11 @@ func (tm *TextInputModal) Hint(hint string) *TextInputModal {
 	return tm
 }
 
+func (tm *TextInputModal) SetLoading(loading bool) {
+	tm.isLoading = loading
+	tm.modal.SetDisabled(loading)
+}
+
 func (tm *TextInputModal) ShowAccountInfoTip(show bool) *TextInputModal {
 	tm.showAccountWarnInfo = show
 	return tm
@@ -99,7 +104,6 @@ func (tm *TextInputModal) SetTextWithTemplate(template string) *TextInputModal {
 }
 
 func (tm *TextInputModal) Handle() {
-	tm.modal.SetDisabled(tm.IsLoading)
 
 	if editorsNotEmpty(tm.textInput.Editor) {
 		tm.btnPositve.Background = tm.positiveButtonColor
@@ -115,11 +119,11 @@ func (tm *TextInputModal) Handle() {
 	}
 
 	if (tm.btnPositve.Clicked() || isSubmit) && tm.isEnabled {
-		if tm.IsLoading {
+		if tm.isLoading {
 			return
 		}
 
-		tm.IsLoading = true
+		tm.SetLoading(true)
 		tm.SetError("")
 		if tm.callback(tm.textInput.Editor.Text(), tm) {
 			tm.Dismiss()
@@ -127,14 +131,14 @@ func (tm *TextInputModal) Handle() {
 	}
 
 	for tm.btnNegative.Clicked() {
-		if !tm.IsLoading {
+		if !tm.isLoading {
 			tm.Dismiss()
 			tm.negativeButtonClicked()
 		}
 	}
 
 	if tm.modal.BackdropClicked(tm.isCancelable) {
-		if !tm.IsLoading {
+		if !tm.isLoading {
 			tm.Dismiss()
 		}
 	}

--- a/ui/modal/text_input_modal.go
+++ b/ui/modal/text_input_modal.go
@@ -99,6 +99,8 @@ func (tm *TextInputModal) SetTextWithTemplate(template string) *TextInputModal {
 }
 
 func (tm *TextInputModal) Handle() {
+	tm.textInput.Disabled = tm.isEnabled
+
 	if editorsNotEmpty(tm.textInput.Editor) {
 		tm.btnPositve.Background = tm.positiveButtonColor
 		tm.isEnabled = true

--- a/ui/page/dexclient/add_dex_modal.go
+++ b/ui/page/dexclient/add_dex_modal.go
@@ -74,6 +74,8 @@ func (md *addDexModal) OnResume() {
 }
 
 func (md *addDexModal) Handle() {
+	md.modal.SetDisabled(md.isSending)
+
 	if md.cancel.Button.Clicked() && !md.isSending {
 		md.Dismiss()
 	}

--- a/ui/page/dexclient/add_dex_modal.go
+++ b/ui/page/dexclient/add_dex_modal.go
@@ -74,8 +74,6 @@ func (md *addDexModal) OnResume() {
 }
 
 func (md *addDexModal) Handle() {
-	md.modal.SetDisabled(md.isSending)
-
 	if md.cancel.Button.Clicked() && !md.isSending {
 		md.Dismiss()
 	}
@@ -86,10 +84,13 @@ func (md *addDexModal) Handle() {
 		}
 
 		md.isSending = true
+		md.modal.SetDisabled(true)
 		go func() {
 			cert := []byte(md.cert.Editor.Text())
 			dex, err := md.Dexc().DEXServerInfo(md.dexServerAddress.Editor.Text(), cert)
 			md.isSending = false
+			md.modal.SetDisabled(false)
+
 			if err != nil {
 				md.Toast.NotifyError(err.Error())
 				return

--- a/ui/page/dexclient/create_wallet_modal.go
+++ b/ui/page/dexclient/create_wallet_modal.go
@@ -94,6 +94,8 @@ func (md *createWalletModal) OnResume() {
 }
 
 func (md *createWalletModal) Handle() {
+	md.modal.SetDisabled(md.isSending)
+
 	if md.cancel.Button.Clicked() && !md.isSending {
 		md.Dismiss()
 	}

--- a/ui/page/dexclient/create_wallet_modal.go
+++ b/ui/page/dexclient/create_wallet_modal.go
@@ -94,8 +94,6 @@ func (md *createWalletModal) OnResume() {
 }
 
 func (md *createWalletModal) Handle() {
-	md.modal.SetDisabled(md.isSending)
-
 	if md.cancel.Button.Clicked() && !md.isSending {
 		md.Dismiss()
 	}
@@ -106,9 +104,12 @@ func (md *createWalletModal) Handle() {
 		}
 
 		md.isSending = true
+		md.modal.SetDisabled(true)
+
 		go func() {
 			defer func() {
 				md.isSending = false
+				md.modal.SetDisabled(false)
 			}()
 
 			coinID := md.walletInfoWidget.coinID

--- a/ui/page/dexclient/markets.go
+++ b/ui/page/dexclient/markets.go
@@ -113,7 +113,9 @@ func (pg *Page) welcomeLayout(gtx C, button decredmaterial.Button) D {
 		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
 				description := "Trade crypto peer-to-peer."
-				return layout.Center.Layout(gtx, pg.Theme.H5(description).Layout)
+				return layout.Inset{Bottom: values.MarginPadding24}.Layout(gtx, func(gtx C) D {
+					return layout.Center.Layout(gtx, pg.Theme.H5(description).Layout)
+				})
 			}),
 			layout.Rigid(button.Layout),
 		)

--- a/ui/page/send/send_confirm_modal.go
+++ b/ui/page/send/send_confirm_modal.go
@@ -115,7 +115,7 @@ func (scm *sendConfirmModal) broadcastTransaction() {
 }
 
 func (scm *sendConfirmModal) Handle() {
-	scm.passwordEditor.Disabled = scm.isSending
+	scm.modal.SetDisabled(scm.isSending)
 
 	for _, evt := range scm.passwordEditor.Editor.Events() {
 		if scm.passwordEditor.Editor.Focused() {

--- a/ui/page/send/send_confirm_modal.go
+++ b/ui/page/send/send_confirm_modal.go
@@ -115,6 +115,8 @@ func (scm *sendConfirmModal) broadcastTransaction() {
 }
 
 func (scm *sendConfirmModal) Handle() {
+	scm.passwordEditor.Disabled = scm.isSending
+
 	for _, evt := range scm.passwordEditor.Editor.Events() {
 		if scm.passwordEditor.Editor.Focused() {
 			switch evt.(type) {

--- a/ui/page/send/send_confirm_modal.go
+++ b/ui/page/send/send_confirm_modal.go
@@ -100,9 +100,11 @@ func (scm *sendConfirmModal) broadcastTransaction() {
 	}
 
 	scm.isSending = true
+	scm.modal.SetDisabled(true)
 	go func() {
 		_, err := scm.authoredTxData.txAuthor.Broadcast([]byte(password))
 		scm.isSending = false
+		scm.modal.SetDisabled(false)
 		if err != nil {
 			scm.Toast.NotifyError(err.Error())
 			return
@@ -115,8 +117,6 @@ func (scm *sendConfirmModal) broadcastTransaction() {
 }
 
 func (scm *sendConfirmModal) Handle() {
-	scm.modal.SetDisabled(scm.isSending)
-
 	for _, evt := range scm.passwordEditor.Editor.Events() {
 		if scm.passwordEditor.Editor.Focused() {
 			switch evt.(type) {

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -339,6 +339,8 @@ func (tp *stakingModal) calculateTotals() {
 }
 
 func (tp *stakingModal) Handle() {
+	tp.modal.SetDisabled(tp.isLoading)
+
 	tp.stakeBtn.SetEnabled(tp.canPurchase())
 
 	if tp.vspSelector.Changed() {

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -339,8 +339,6 @@ func (tp *stakingModal) calculateTotals() {
 }
 
 func (tp *stakingModal) Handle() {
-	tp.modal.SetDisabled(tp.isLoading)
-
 	tp.stakeBtn.SetEnabled(tp.canPurchase())
 
 	if tp.vspSelector.Changed() {
@@ -410,6 +408,7 @@ func (tp *stakingModal) purchaseTickets() {
 	}
 
 	tp.isLoading = true
+	tp.modal.SetDisabled(true)
 	go func() {
 		password := []byte(tp.spendingPassword.Editor.Text())
 
@@ -420,6 +419,7 @@ func (tp *stakingModal) purchaseTickets() {
 
 		defer func() {
 			tp.isLoading = false
+			tp.modal.SetDisabled(false)
 		}()
 
 		vspHost, vspPubKey := selectedVSP.Host, selectedVSP.PubKey

--- a/ui/page/wallets/account_details_page.go
+++ b/ui/page/wallets/account_details_page.go
@@ -296,7 +296,7 @@ func (pg *AcctDetailsPage) HandleUserInteractions() {
 				err := pg.wallet.RenameAccount(pg.account.Number, newName)
 				if err != nil {
 					tim.SetError(err.Error())
-					tim.IsLoading = false
+					tim.SetLoading(false)
 					return false
 				}
 				pg.account.Name = newName

--- a/ui/page/wallets/privacy_page.go
+++ b/ui/page/wallets/privacy_page.go
@@ -318,12 +318,12 @@ func (pg *PrivacyPage) HandleUserInteractions() {
 				PositiveButton("Confirm", func(textInput string, tim *modal.TextInputModal) bool {
 					if textInput != "I understand the risks" {
 						tim.SetError("confirmation text is incorrect")
-						tim.IsLoading = false
+						tim.SetLoading(false)
 					} else {
 						pg.wallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, false)
 						tim.Dismiss()
 					}
-					return tim.IsLoading
+					return false
 				})
 
 			textModal.Title("Confirm to allow spending from unmixed accounts").


### PR DESCRIPTION
* Currently, when the send/confirm button is selected, the editors and other actionable widgets on the modals are still active. 
This PR aims to disable the modals while the action is in progress.

also Fix #774 