### PR TITLE
Fix USD balance display bug

### DIFF
--- a/ui/page/listeners.go
+++ b/ui/page/listeners.go
@@ -16,6 +16,7 @@ import (
 
 func (mp *MainPage) OnTransaction(transaction string) {
 	transactionNotification := mp.WL.Wallet.ReadBoolConfigValueForKey(load.TransactionNotificationConfigKey)
+	load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
 	mp.UpdateBalance()
 
 	var tx dcrlibwallet.Transaction
@@ -41,6 +42,7 @@ func (mp *MainPage) OnBlockAttached(walletID int, blockHeight int32) {
 		}
 	}
 
+	load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
 	mp.UpdateBalance()
 	mp.UpdateNotification(wallet.SyncStatusUpdate{
 		Stage: wallet.BlockAttached,
@@ -48,6 +50,7 @@ func (mp *MainPage) OnBlockAttached(walletID int, blockHeight int32) {
 }
 
 func (mp *MainPage) OnTransactionConfirmed(walletID int, hash string, blockHeight int32) {
+	load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
 	mp.UpdateBalance()
 }
 
@@ -148,6 +151,7 @@ func (mp *MainPage) OnHeadersRescanProgress(headersRescanProgress *dcrlibwallet.
 	})
 }
 func (mp *MainPage) OnSyncCompleted() {
+	load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
 	mp.UpdateBalance()
 	mp.UpdateNotification(wallet.SyncStatusUpdate{
 		Stage: wallet.SyncCompleted,

--- a/ui/page/listeners.go
+++ b/ui/page/listeners.go
@@ -16,8 +16,7 @@ import (
 
 func (mp *MainPage) OnTransaction(transaction string) {
 	transactionNotification := mp.WL.Wallet.ReadBoolConfigValueForKey(load.TransactionNotificationConfigKey)
-	load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
-	mp.UpdateBalance()
+	mp.UpdateBalance(true)
 
 	var tx dcrlibwallet.Transaction
 	err := json.Unmarshal([]byte(transaction), &tx)
@@ -42,16 +41,14 @@ func (mp *MainPage) OnBlockAttached(walletID int, blockHeight int32) {
 		}
 	}
 
-	load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
-	mp.UpdateBalance()
+	mp.UpdateBalance(true)
 	mp.UpdateNotification(wallet.SyncStatusUpdate{
 		Stage: wallet.BlockAttached,
 	})
 }
 
 func (mp *MainPage) OnTransactionConfirmed(walletID int, hash string, blockHeight int32) {
-	load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
-	mp.UpdateBalance()
+	mp.UpdateBalance(true)
 }
 
 // Account mixer
@@ -151,8 +148,7 @@ func (mp *MainPage) OnHeadersRescanProgress(headersRescanProgress *dcrlibwallet.
 	})
 }
 func (mp *MainPage) OnSyncCompleted() {
-	load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
-	mp.UpdateBalance()
+	mp.UpdateBalance(true)
 	mp.UpdateNotification(wallet.SyncStatusUpdate{
 		Stage: wallet.SyncCompleted,
 	})

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -555,7 +555,7 @@ func (mp *MainPage) LayoutUSDBalance(gtx layout.Context) layout.Dimensions {
 	mp.UpdateBalance()
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 		layout.Rigid(func(gtx C) D {
-			if mp.usdExchangeSet && mp.dcrUsdtBittrex.LastTradeRate != "" {
+			if mp.usdExchangeSet && mp.dcrUsdtBittrex.LastTradeRate != "" && len(mp.totalBalanceUSD) > 0 {
 				inset := layout.Inset{
 					Top:  values.MarginPadding3,
 					Left: values.MarginPadding8,

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -218,8 +218,6 @@ func (mp *MainPage) OnNavigatedTo() {
 			go mp.WL.MultiWallet.Politeia.Sync()
 		}
 	}
-
-	load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
 }
 
 func (mp *MainPage) setLanguageSetting() {
@@ -228,6 +226,7 @@ func (mp *MainPage) setLanguageSetting() {
 }
 
 func (mp *MainPage) UpdateBalance() {
+	go load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
 	currencyExchangeValue := mp.WL.Wallet.ReadStringConfigValueForKey(dcrlibwallet.CurrencyConversionConfigKey)
 	mp.usdExchangeSet = currencyExchangeValue == values.USDExchangeValue
 

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -497,6 +497,7 @@ func (mp *MainPage) popToFragment(pageID string) {
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
+	mp.UpdateBalance()
 	return layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
 			return decredmaterial.LinearLayout{
@@ -553,7 +554,6 @@ func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
 }
 
 func (mp *MainPage) LayoutUSDBalance(gtx layout.Context) layout.Dimensions {
-	mp.UpdateBalance()
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 		layout.Rigid(func(gtx C) D {
 			if mp.usdExchangeSet && mp.dcrUsdtBittrex.LastTradeRate != "" && len(mp.totalBalanceUSD) > 0 {

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -199,7 +199,6 @@ func (mp *MainPage) OnNavigatedTo() {
 	mp.WL.MultiWallet.SetBlocksRescanProgressListener(mp)
 
 	mp.setLanguageSetting()
-	mp.UpdateBalance()
 
 	if mp.currentPage == nil {
 		mp.currentPage = overview.NewOverviewPage(mp.Load)
@@ -553,6 +552,7 @@ func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
 }
 
 func (mp *MainPage) LayoutUSDBalance(gtx layout.Context) layout.Dimensions {
+	mp.UpdateBalance()
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 		layout.Rigid(func(gtx C) D {
 			if mp.usdExchangeSet && mp.dcrUsdtBittrex.LastTradeRate != "" {

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -226,7 +226,9 @@ func (mp *MainPage) setLanguageSetting() {
 }
 
 func (mp *MainPage) UpdateBalance() {
-	go load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
+	if len(mp.totalBalanceUSD) == 0 {
+		load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
+	}
 	currencyExchangeValue := mp.WL.Wallet.ReadStringConfigValueForKey(dcrlibwallet.CurrencyConversionConfigKey)
 	mp.usdExchangeSet = currencyExchangeValue == values.USDExchangeValue
 

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -225,8 +225,8 @@ func (mp *MainPage) setLanguageSetting() {
 	values.SetUserLanguage(langPre)
 }
 
-func (mp *MainPage) UpdateBalance() {
-	if len(mp.totalBalanceUSD) == 0 {
+func (mp *MainPage) UpdateBalance(fetchExch bool) {
+	if len(mp.totalBalanceUSD) == 0 || fetchExch {
 		load.GetUSDExchangeValue(&mp.dcrUsdtBittrex)
 	}
 	currencyExchangeValue := mp.WL.Wallet.ReadStringConfigValueForKey(dcrlibwallet.CurrencyConversionConfigKey)
@@ -497,7 +497,7 @@ func (mp *MainPage) popToFragment(pageID string) {
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
-	mp.UpdateBalance()
+	mp.UpdateBalance(false)
 	return layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
 			return decredmaterial.LinearLayout{


### PR DESCRIPTION
This PR closes #783.
This PR ensures that the USD balance container is not displayed when the USD balance has not been calculated. 
The USD container along with the balance is only shown if the USD balance has been calculated.

Also, it ensures that the USD exchange rate is fetched on every block and transaction  added, before updating the USD balance.