### PR TITLE
implement manual cspp mixer setup

### DIFF
--- a/ui/modal/info_modal_layouts.go
+++ b/ui/modal/info_modal_layouts.go
@@ -87,7 +87,7 @@ func privacyInfo(l *load.Load) []layout.Widget {
 
 func setupMixerInfo(th *decredmaterial.Theme) []layout.Widget {
 	text := `<span style="text-color: grayText2">
-				Two dedicated accounts (“mixed” & “unmixed”) will be created in order to use the mixer.
+				Two dedicated accounts ("mixed" & "unmixed") will be created in order to use the mixer. <br></br>
 				<b>This action cannot be undone.</b>
 			</span>`
 

--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -123,6 +123,9 @@ func (as *AccountSelector) SetSelectedAccount(account *dcrlibwallet.Account) {
 
 	as.selectedAccount = account
 	as.selectedWalletName = wal.Name
+	if as.selectedWallet != nil {
+		as.selectedWalletName = as.selectedWallet.Name
+	}
 	as.totalBalance = dcrutil.Amount(account.TotalBalance).String()
 }
 
@@ -466,7 +469,6 @@ func (asm *AccountSelectorModal) Layout(gtx layout.Context) layout.Dimensions {
 							})
 						})
 					})
-
 				}),
 				layout.Stacked(func(gtx C) D {
 					if false { //TODO

--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -92,9 +92,9 @@ func (as *AccountSelector) Handle() {
 	}
 }
 
-// SelectFirstWalletValidAccount selects the first valid account from the first wallet in the
-// SortedWalletList. If selectedWallet is not nil, the first account for the selectWallet
-// is selected.
+// SelectFirstWalletValidAccount selects the first valid account from the
+// first wallet in the SortedWalletList. If selectedWallet is not nil,
+// the first account for the selectWallet is selected.
 func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibwallet.Wallet) error {
 	if as.selectedAccount != nil && as.accountIsValid(as.selectedAccount) {
 		as.UpdateSelectedAccountBalance()

--- a/ui/page/dexclient/create_wallet_modal.go
+++ b/ui/page/dexclient/create_wallet_modal.go
@@ -97,7 +97,7 @@ func (md *createWalletModal) OnResume() {
 	md.ctx, md.ctxCancel = context.WithCancel(context.TODO())
 	md.sourceAccountSelector.ListenForTxNotifications(md.ctx)
 
-	err := md.sourceAccountSelector.SelectFirstWalletValidAccount()
+	err := md.sourceAccountSelector.SelectFirstWalletValidAccount(nil)
 	if err != nil {
 		md.Toast.NotifyError(err.Error())
 	}

--- a/ui/page/dexclient/create_wallet_modal.go
+++ b/ui/page/dexclient/create_wallet_modal.go
@@ -61,7 +61,7 @@ func newCreateWalletModal(l *load.Load, wallInfo *walletInfoWidget, walletCreate
 	md.appPassword.Editor.SingleLine = true
 	md.appPassword.Editor.SetText("")
 
-	md.sourceAccountSelector = components.NewAccountSelector(md.Load).
+	md.sourceAccountSelector = components.NewAccountSelector(md.Load, nil).
 		Title("Select DCR account to use with DEX").
 		AccountSelected(func(selectedAccount *dcrlibwallet.Account) {}).
 		AccountValidator(func(account *dcrlibwallet.Account) bool {

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -531,6 +531,7 @@ func (mp *MainPage) popToFragment(pageID string) {
 	if len(mp.pageBackStack) > 0 {
 		// set curent page to `pageID`
 		mp.currentPage = mp.pageBackStack[len(mp.pageBackStack)-1]
+		mp.currentPage.OnNavigatedTo()
 		// remove current page from backstack history
 		mp.pageBackStack = mp.pageBackStack[:len(mp.pageBackStack)-1]
 	} else {

--- a/ui/page/overview/overview_layout.go
+++ b/ui/page/overview/overview_layout.go
@@ -18,6 +18,7 @@ import (
 	"github.com/planetdecred/godcr/ui/modal"
 	"github.com/planetdecred/godcr/ui/page/components"
 	gPage "github.com/planetdecred/godcr/ui/page/governance"
+	"github.com/planetdecred/godcr/ui/page/privacy"
 	tPage "github.com/planetdecred/godcr/ui/page/transaction"
 	wPage "github.com/planetdecred/godcr/ui/page/wallets"
 	"github.com/planetdecred/godcr/ui/values"
@@ -257,7 +258,7 @@ func (pg *AppOverviewPage) HandleUserInteractions() {
 
 	if pg.toMixer.Button.Clicked() {
 		if len(pg.mixerWallets) == 1 {
-			pg.ChangeFragment(wPage.NewPrivacyPage(pg.Load, pg.mixerWallets[0]))
+			pg.ChangeFragment(privacy.NewAccountMixerPage(pg.Load, pg.mixerWallets[0]))
 		}
 		pg.ChangeFragment(wPage.NewWalletPage(pg.Load))
 	}

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -187,7 +187,6 @@ func (pg *AccountMixerPage) mixerSettingsLayout(gtx layout.Context) layout.Dimen
 			layout.Rigid(func(gtx C) D {
 				return layout.UniformInset(values.MarginPadding15).Layout(gtx, pg.Theme.Body2("Mixer Settings").Layout)
 			}),
-
 			layout.Rigid(func(gtx C) D { return row("Mixed account", mixedAccountName) }),
 			layout.Rigid(pg.Theme.Separator().Layout),
 			layout.Rigid(func(gtx C) D { return row("Change account", unmixedAccountName) }),

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -290,6 +290,9 @@ func (pg *AccountMixerPage) HandleUserInteractions() {
 		}
 	}
 
+	if pg.backButton.Button.Clicked() {
+		pg.PopToFragment(components.WalletsPageID)
+	}
 }
 
 func (pg *AccountMixerPage) showModalPasswordStartAccountMixer() {

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -166,6 +166,8 @@ func (pg *AccountMixerPage) Layout(gtx layout.Context) layout.Dimensions {
 func (pg *AccountMixerPage) mixerSettingsLayout(gtx layout.Context) layout.Dimensions {
 	return pg.Theme.Card().Layout(gtx, func(gtx C) D {
 		gtx.Constraints.Min.X = gtx.Constraints.Max.X
+		mixedAccountName, _ := pg.wallet.AccountName(pg.wallet.MixedAccountNumber())
+		unmixedAccountName, _ := pg.wallet.AccountName(pg.wallet.UnmixedAccountNumber())
 
 		row := func(txt1, txt2 string) D {
 			return layout.Inset{
@@ -185,9 +187,10 @@ func (pg *AccountMixerPage) mixerSettingsLayout(gtx layout.Context) layout.Dimen
 			layout.Rigid(func(gtx C) D {
 				return layout.UniformInset(values.MarginPadding15).Layout(gtx, pg.Theme.Body2("Mixer Settings").Layout)
 			}),
-			layout.Rigid(func(gtx C) D { return row("Mixed account", "mixed") }),
+
+			layout.Rigid(func(gtx C) D { return row("Mixed account", mixedAccountName) }),
 			layout.Rigid(pg.Theme.Separator().Layout),
-			layout.Rigid(func(gtx C) D { return row("Change account", "unmixed") }),
+			layout.Rigid(func(gtx C) D { return row("Change account", unmixedAccountName) }),
 			layout.Rigid(pg.Theme.Separator().Layout),
 			layout.Rigid(func(gtx C) D { return row("Account branch", fmt.Sprintf("%d", dcrlibwallet.MixedAccountBranch)) }),
 			layout.Rigid(pg.Theme.Separator().Layout),

--- a/ui/page/privacy/log.go
+++ b/ui/page/privacy/log.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2017, The dcrdata developers
+// See LICENSE for details.
+
+package privacy
+
+import "github.com/decred/slog"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log = slog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	log = slog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/ui/page/privacy/manual_mixer_setup_page..go
+++ b/ui/page/privacy/manual_mixer_setup_page..go
@@ -29,8 +29,6 @@ type ManualMixerSetupPage struct {
 	backButton     decredmaterial.IconButton
 	infoButton     decredmaterial.IconButton
 	toPrivacySetup decredmaterial.Button
-
-	autoSetupIcon *decredmaterial.Icon
 }
 
 func NewManualMixerSetupPage(l *load.Load, wallet *dcrlibwallet.Wallet) *ManualMixerSetupPage {
@@ -67,9 +65,6 @@ func NewManualMixerSetupPage(l *load.Load, wallet *dcrlibwallet.Wallet) *ManualM
 		})
 
 	pg.backButton, pg.infoButton = components.SubpageHeaderButtons(l)
-
-	pg.autoSetupIcon = decredmaterial.NewIcon(pg.Icons.ActionCheckCircle)
-	pg.autoSetupIcon.Color = pg.Theme.Color.Success
 
 	return pg
 }
@@ -112,15 +107,11 @@ func (pg *ManualMixerSetupPage) Layout(gtx layout.Context) layout.Dimensions {
 						layout.Flexed(1, func(gtx C) D {
 							return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
 								layout.Rigid(func(gtx C) D {
-									return pg.mixerAccountSections(gtx, "Mixed account", func(gtx C) D {
-										return pg.mixedAccountSelector.Layout(gtx)
-									})
+									return pg.mixerAccountSections(gtx, "Mixed account", pg.mixedAccountSelector.Layout)
 								}),
 								layout.Rigid(func(gtx C) D {
 									return layout.Inset{Top: values.MarginPaddingMinus15}.Layout(gtx, func(gtx C) D {
-										return pg.mixerAccountSections(gtx, "Unmixed account", func(gtx C) D {
-											return pg.unmixedAccountSelector.Layout(gtx)
-										})
+										return pg.mixerAccountSections(gtx, "Unmixed account", pg.unmixedAccountSelector.Layout)
 									})
 								}),
 								layout.Rigid(func(gtx C) D {
@@ -139,9 +130,7 @@ func (pg *ManualMixerSetupPage) Layout(gtx layout.Context) layout.Dimensions {
 										</span>`
 												return layout.Inset{
 													Left: values.MarginPadding8,
-												}.Layout(gtx, func(gtx C) D {
-													return renderers.RenderHTML(txt, pg.Theme).Layout(gtx)
-												})
+												}.Layout(gtx, renderers.RenderHTML(txt, pg.Theme).Layout)
 											}),
 										)
 									})
@@ -183,11 +172,6 @@ func (pg *ManualMixerSetupPage) mixerAccountSections(gtx layout.Context, title s
 }
 
 func (pg *ManualMixerSetupPage) showModalSetupMixerAcct() {
-	if pg.mixedAccountSelector.SelectedAccount().WalletID != pg.unmixedAccountSelector.SelectedAccount().WalletID {
-		pg.Toast.NotifyError("Selected accounts do not belong to the same wallet")
-		return
-	}
-
 	if pg.mixedAccountSelector.SelectedAccount().Number == pg.unmixedAccountSelector.SelectedAccount().Number {
 		pg.Toast.NotifyError("Cannot use same account for mixed & unmixed")
 		return

--- a/ui/page/privacy/manual_mixer_setup_page..go
+++ b/ui/page/privacy/manual_mixer_setup_page..go
@@ -170,16 +170,6 @@ func (pg *ManualMixerSetupPage) showModalSetupMixerAcct() {
 		return
 	}
 
-	if pg.mixedAccountSelector.SelectedAccount().Name == "mixed" || pg.mixedAccountSelector.SelectedAccount().Name == "unmixed" {
-		pg.Toast.NotifyError("The selected mixed account already has privacy enabled")
-		return
-	}
-
-	if pg.unmixedAccountSelector.SelectedAccount().Name == "mixed" || pg.unmixedAccountSelector.SelectedAccount().Name == "unmixed" {
-		pg.Toast.NotifyError("The selected unmixed account already has privacy enabled")
-		return
-	}
-
 	modal.NewPasswordModal(pg.Load).
 		Title("Confirm to set mixer accounts").
 		NegativeButton("Cancel", func() {}).

--- a/ui/page/privacy/manual_mixer_setup_page..go
+++ b/ui/page/privacy/manual_mixer_setup_page..go
@@ -117,8 +117,10 @@ func (pg *ManualMixerSetupPage) Layout(gtx layout.Context) layout.Dimensions {
 									})
 								}),
 								layout.Rigid(func(gtx C) D {
-									return pg.mixerAccountSections(gtx, "Unmixed account", func(gtx C) D {
-										return pg.unmixedAccountSelector.Layout(gtx)
+									return layout.Inset{Top: values.MarginPaddingMinus15}.Layout(gtx, func(gtx C) D {
+										return pg.mixerAccountSections(gtx, "Unmixed account", func(gtx C) D {
+											return pg.unmixedAccountSelector.Layout(gtx)
+										})
 									})
 								}),
 								layout.Rigid(func(gtx C) D {
@@ -168,7 +170,7 @@ func (pg *ManualMixerSetupPage) mixerAccountSections(gtx layout.Context, title s
 					return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 						layout.Rigid(func(gtx C) D {
 							inset := layout.Inset{
-								Bottom: values.MarginPadding16,
+								Bottom: values.MarginPadding8,
 							}
 							return inset.Layout(gtx, pg.Theme.Body1(title).Layout)
 						}),

--- a/ui/page/privacy/manual_mixer_setup_page..go
+++ b/ui/page/privacy/manual_mixer_setup_page..go
@@ -83,8 +83,8 @@ func (pg *ManualMixerSetupPage) ID() string {
 func (pg *ManualMixerSetupPage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 
-	pg.mixedAccountSelector.SelectFirstWalletValidAccount()
-	pg.unmixedAccountSelector.SelectFirstWalletValidAccount()
+	pg.mixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet)
+	pg.unmixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet)
 }
 
 // Layout draws the page UI components into the provided layout context

--- a/ui/page/privacy/manual_mixer_setup_page..go
+++ b/ui/page/privacy/manual_mixer_setup_page..go
@@ -200,6 +200,8 @@ func (pg *ManualMixerSetupPage) showModalSetupMixerAcct() {
 				}
 				pg.WL.MultiWallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
 				pm.Dismiss()
+
+				pg.ChangeFragment(NewAccountMixerPage(pg.Load, pg.wallet))
 			}()
 
 			return false

--- a/ui/page/privacy/manual_mixer_setup_page..go
+++ b/ui/page/privacy/manual_mixer_setup_page..go
@@ -41,7 +41,7 @@ func NewManualMixerSetupPage(l *load.Load, wallet *dcrlibwallet.Wallet) *ManualM
 	}
 
 	// Mixed account picker
-	pg.mixedAccountSelector = components.NewAccountSelector(l).
+	pg.mixedAccountSelector = components.NewAccountSelector(l, wallet).
 		Title("Mixed account").
 		AccountSelected(func(selectedAccount *dcrlibwallet.Account) {}).
 		AccountValidator(func(account *dcrlibwallet.Account) bool {
@@ -54,7 +54,7 @@ func NewManualMixerSetupPage(l *load.Load, wallet *dcrlibwallet.Wallet) *ManualM
 		})
 
 	// Unmixed account picker
-	pg.unmixedAccountSelector = components.NewAccountSelector(l).
+	pg.unmixedAccountSelector = components.NewAccountSelector(l, wallet).
 		Title("Unmixed account").
 		AccountSelected(func(selectedAccount *dcrlibwallet.Account) {}).
 		AccountValidator(func(account *dcrlibwallet.Account) bool {
@@ -181,6 +181,11 @@ func (pg *ManualMixerSetupPage) mixerAccountSections(gtx layout.Context, title s
 }
 
 func (pg *ManualMixerSetupPage) showModalSetupMixerAcct() {
+	if pg.mixedAccountSelector.SelectedAccount().WalletID != pg.unmixedAccountSelector.SelectedAccount().WalletID {
+		pg.Toast.NotifyError("Selected accounts do not belong to the same wallet")
+		return
+	}
+
 	if pg.mixedAccountSelector.SelectedAccount().Number == pg.unmixedAccountSelector.SelectedAccount().Number {
 		pg.Toast.NotifyError("Cannot use same account for mixed & unmixed")
 		return

--- a/ui/page/privacy/manual_mixer_setup_page..go
+++ b/ui/page/privacy/manual_mixer_setup_page..go
@@ -4,13 +4,13 @@ import (
 	"context"
 
 	"gioui.org/layout"
-	"github.com/planetdecred/godcr/ui/renderers"
 
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
 	"github.com/planetdecred/godcr/ui/modal"
 	"github.com/planetdecred/godcr/ui/page/components"
+	"github.com/planetdecred/godcr/ui/renderers"
 	"github.com/planetdecred/godcr/ui/values"
 )
 
@@ -116,13 +116,11 @@ func (pg *ManualMixerSetupPage) Layout(gtx layout.Context) layout.Dimensions {
 								}),
 								layout.Rigid(func(gtx C) D {
 									return layout.Inset{Top: values.MarginPadding10, Left: values.MarginPadding16, Right: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
-										return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+										return layout.Flex{
+											Axis: layout.Horizontal,
+										}.Layout(gtx,
 											layout.Rigid(func(gtx C) D {
-												return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-													layout.Rigid(func(gtx C) D {
-														return pg.Icons.ActionInfo.Layout(gtx, pg.Theme.Color.Gray1)
-													}),
-												)
+												return pg.Icons.ActionInfo.Layout(gtx, pg.Theme.Color.Gray1)
 											}),
 											layout.Rigid(func(gtx C) D {
 												txt := `<span style="text-color: grayText2">
@@ -156,14 +154,9 @@ func (pg *ManualMixerSetupPage) mixerAccountSections(gtx layout.Context, title s
 		return layout.UniformInset(values.MarginPadding16).Layout(gtx, func(gtx C) D {
 			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
-						layout.Rigid(func(gtx C) D {
-							inset := layout.Inset{
-								Bottom: values.MarginPadding8,
-							}
-							return inset.Layout(gtx, pg.Theme.Body1(title).Layout)
-						}),
-					)
+					return layout.Inset{
+						Bottom: values.MarginPadding8,
+					}.Layout(gtx, pg.Theme.Body1(title).Layout)
 				}),
 				layout.Rigid(body),
 			)

--- a/ui/page/privacy/manual_mixer_setup_page..go
+++ b/ui/page/privacy/manual_mixer_setup_page..go
@@ -1,0 +1,238 @@
+package privacy
+
+import (
+	"context"
+
+	"gioui.org/layout"
+	"github.com/planetdecred/godcr/ui/renderers"
+
+	"github.com/planetdecred/dcrlibwallet"
+	"github.com/planetdecred/godcr/ui/decredmaterial"
+	"github.com/planetdecred/godcr/ui/load"
+	"github.com/planetdecred/godcr/ui/modal"
+	"github.com/planetdecred/godcr/ui/page/components"
+	"github.com/planetdecred/godcr/ui/values"
+)
+
+const ManualMixerSetupPageID = "ManualMixerSetup"
+
+type ManualMixerSetupPage struct {
+	*load.Load
+
+	ctx       context.Context // page context
+	ctxCancel context.CancelFunc
+
+	wallet                 *dcrlibwallet.Wallet
+	mixedAccountSelector   *components.AccountSelector
+	unmixedAccountSelector *components.AccountSelector
+
+	backButton     decredmaterial.IconButton
+	infoButton     decredmaterial.IconButton
+	toPrivacySetup decredmaterial.Button
+
+	autoSetupIcon *decredmaterial.Icon
+}
+
+func NewManualMixerSetupPage(l *load.Load, wallet *dcrlibwallet.Wallet) *ManualMixerSetupPage {
+	pg := &ManualMixerSetupPage{
+		Load:           l,
+		wallet:         wallet,
+		toPrivacySetup: l.Theme.Button("Set up"),
+	}
+
+	// Mixed account picker
+	pg.mixedAccountSelector = components.NewAccountSelector(l).
+		Title("Mixed account").
+		AccountSelected(func(selectedAccount *dcrlibwallet.Account) {}).
+		AccountValidator(func(account *dcrlibwallet.Account) bool {
+			wal := pg.Load.WL.MultiWallet.WalletWithID(account.WalletID)
+
+			// Imported and watch only wallet accounts are invalid to use as a mixed account
+			accountIsValid := account.Number != load.MaxInt32 && !wal.IsWatchingOnlyWallet()
+
+			return accountIsValid
+		})
+
+	// Unmixed account picker
+	pg.unmixedAccountSelector = components.NewAccountSelector(l).
+		Title("Unmixed account").
+		AccountSelected(func(selectedAccount *dcrlibwallet.Account) {}).
+		AccountValidator(func(account *dcrlibwallet.Account) bool {
+			wal := pg.Load.WL.MultiWallet.WalletWithID(account.WalletID)
+
+			// Imported and watch only wallet accounts are invalid to use as an unmixed account
+			accountIsValid := account.Number != load.MaxInt32 && !wal.IsWatchingOnlyWallet()
+
+			return accountIsValid
+		})
+
+	pg.backButton, pg.infoButton = components.SubpageHeaderButtons(l)
+
+	pg.autoSetupIcon = decredmaterial.NewIcon(pg.Icons.ActionCheckCircle)
+	pg.autoSetupIcon.Color = pg.Theme.Color.Success
+
+	return pg
+}
+
+// ID is a unique string that identifies the page and may be used
+// to differentiate this page from other pages.
+// Part of the load.Page interface.
+func (pg *ManualMixerSetupPage) ID() string {
+	return ManualMixerSetupPageID
+}
+
+// OnNavigatedTo is called when the page is about to be displayed and
+// may be used to initialize page features that are only relevant when
+// the page is displayed.
+// Part of the load.Page interface.
+func (pg *ManualMixerSetupPage) OnNavigatedTo() {
+	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
+
+	pg.mixedAccountSelector.SelectFirstWalletValidAccount()
+	pg.unmixedAccountSelector.SelectFirstWalletValidAccount()
+}
+
+// Layout draws the page UI components into the provided layout context
+// to be eventually drawn on screen.
+// Part of the load.Page interface.
+func (pg *ManualMixerSetupPage) Layout(gtx layout.Context) layout.Dimensions {
+	body := func(gtx C) D {
+		page := components.SubPage{
+			Load:       pg.Load,
+			Title:      "Manual setup",
+			WalletName: pg.wallet.Name,
+			BackButton: pg.backButton,
+			Back: func() {
+				pg.PopFragment()
+			},
+			Body: func(gtx C) D {
+				return pg.Theme.Card().Layout(gtx, func(gtx C) D {
+					gtx.Constraints.Min.X = gtx.Constraints.Max.X
+					return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
+						layout.Flexed(1, func(gtx C) D {
+							return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
+								layout.Rigid(func(gtx C) D {
+									return pg.mixerAccountSections(gtx, "Mixed account", func(gtx C) D {
+										return pg.mixedAccountSelector.Layout(gtx)
+									})
+								}),
+								layout.Rigid(func(gtx C) D {
+									return pg.mixerAccountSections(gtx, "Unmixed account", func(gtx C) D {
+										return pg.unmixedAccountSelector.Layout(gtx)
+									})
+								}),
+								layout.Rigid(func(gtx C) D {
+									return layout.Inset{Top: values.MarginPadding10, Left: values.MarginPadding16, Right: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
+										return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+											layout.Rigid(func(gtx C) D {
+												return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+													layout.Rigid(func(gtx C) D {
+														return pg.Icons.ActionInfo.Layout(gtx, pg.Theme.Color.Gray1)
+													}),
+												)
+											}),
+											layout.Rigid(func(gtx C) D {
+												txt := `<span style="text-color: grayText2">
+											<b>Make sure to select the corresponding accounts to the previous setup. </b> Failing to do so could damage wallet privacy.
+										</span>`
+												return layout.Inset{
+													Left: values.MarginPadding8,
+												}.Layout(gtx, func(gtx C) D {
+													return renderers.RenderHTML(txt, pg.Theme).Layout(gtx)
+												})
+											}),
+										)
+									})
+								}),
+							)
+						}),
+						layout.Rigid(func(gtx C) D {
+							gtx.Constraints.Min.X = gtx.Constraints.Max.X
+							return layout.UniformInset(values.MarginPadding15).Layout(gtx, pg.toPrivacySetup.Layout)
+						}),
+					)
+				})
+			},
+		}
+		return page.Layout(gtx)
+	}
+
+	return components.UniformPadding(gtx, body)
+}
+
+func (pg *ManualMixerSetupPage) mixerAccountSections(gtx layout.Context, title string, body layout.Widget) layout.Dimensions {
+	return pg.Theme.Card().Layout(gtx, func(gtx C) D {
+		return layout.UniformInset(values.MarginPadding16).Layout(gtx, func(gtx C) D {
+			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							inset := layout.Inset{
+								Bottom: values.MarginPadding16,
+							}
+							return inset.Layout(gtx, pg.Theme.Body1(title).Layout)
+						}),
+					)
+				}),
+				layout.Rigid(body),
+			)
+		})
+	})
+}
+
+func (pg *ManualMixerSetupPage) showModalSetupMixerAcct() {
+	if pg.mixedAccountSelector.SelectedAccount().Number == pg.unmixedAccountSelector.SelectedAccount().Number {
+		pg.Toast.NotifyError("Cannot use same account for mixed & unmixed")
+		return
+	}
+
+	if pg.mixedAccountSelector.SelectedAccount().Name == "mixed" || pg.mixedAccountSelector.SelectedAccount().Name == "unmixed" {
+		pg.Toast.NotifyError("The selected mixed account already has privacy enabled")
+		return
+	}
+
+	if pg.unmixedAccountSelector.SelectedAccount().Name == "mixed" || pg.unmixedAccountSelector.SelectedAccount().Name == "unmixed" {
+		pg.Toast.NotifyError("The selected unmixed account already has privacy enabled")
+		return
+	}
+
+	modal.NewPasswordModal(pg.Load).
+		Title("Confirm to set mixer accounts").
+		NegativeButton("Cancel", func() {}).
+		PositiveButton("Confirm", func(password string, pm *modal.PasswordModal) bool {
+			go func() {
+				err := pg.wallet.SetAccountMixerConfig(pg.mixedAccountSelector.SelectedAccount().Number, pg.unmixedAccountSelector.SelectedAccount().Number, password)
+				if err != nil {
+					pm.SetError(err.Error())
+					pm.SetLoading(false)
+					return
+				}
+				pg.WL.MultiWallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
+				pm.Dismiss()
+			}()
+
+			return false
+		}).Show()
+}
+
+// HandleUserInteractions is called just before Layout() to determine
+// if any user interaction recently occurred on the page and may be
+// used to update the page's UI components shortly before they are
+// displayed.
+// Part of the load.Page interface.
+func (pg *ManualMixerSetupPage) HandleUserInteractions() {
+	if pg.toPrivacySetup.Clicked() {
+		go pg.showModalSetupMixerAcct()
+	}
+}
+
+// OnNavigatedFrom is called when the page is about to be removed from
+// the displayed window. This method should ideally be used to disable
+// features that are irrelevant when the page is NOT displayed.
+// NOTE: The page may be re-displayed on the app's window, in which case
+// OnNavigatedTo() will be called again. This method should not destroy UI
+// components unless they'll be recreated in the OnNavigatedTo() method.
+// Part of the load.Page interface.
+func (pg *ManualMixerSetupPage) OnNavigatedFrom() {
+	pg.ctxCancel()
+}

--- a/ui/page/privacy/setup_mixer_accounts_page.go
+++ b/ui/page/privacy/setup_mixer_accounts_page.go
@@ -161,41 +161,33 @@ func (pg *SetupMixerAccountsPage) Layout(gtx layout.Context) layout.Dimensions {
 func (pg *SetupMixerAccountsPage) autoSetupLayout(gtx C) D {
 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
 	return layout.UniformInset(values.MarginPadding16).Layout(gtx, func(gtx C) D {
-		return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
+		return layout.Flex{Spacing: layout.SpaceBetween}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
-				return layout.Flex{Spacing: layout.SpaceBetween}.Layout(gtx,
+				return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
 					layout.Rigid(func(gtx C) D {
-						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								return pg.autoSetupIcon.Layout(gtx, values.MarginPadding20)
-							}),
-							layout.Rigid(func(gtx C) D {
-								autoSetupText := pg.Theme.H6("Auto setup")
-								txt := pg.Theme.Body2("Create and set up the needed accounts for you.")
-								return layout.Inset{
-									Left: values.MarginPadding16,
-								}.Layout(gtx, func(gtx C) D {
-									return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-										layout.Rigid(autoSetupText.Layout),
-										layout.Rigid(txt.Layout),
-									)
-								})
-							}),
-						)
+						return pg.autoSetupIcon.Layout(gtx, values.MarginPadding20)
 					}),
 					layout.Rigid(func(gtx C) D {
-						return layout.Flex{}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								return layout.Inset{
-									Right: values.MarginPadding4,
-									Top:   values.MarginPadding10,
-								}.Layout(gtx, func(gtx C) D {
-									return pg.nextIcon.Layout(gtx, values.MarginPadding20)
-								})
-							}),
-						)
+						autoSetupText := pg.Theme.H6("Auto setup")
+						txt := pg.Theme.Body2("Create and setup the needed accounts for you.")
+						return layout.Inset{
+							Left: values.MarginPadding16,
+						}.Layout(gtx, func(gtx C) D {
+							return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+								layout.Rigid(autoSetupText.Layout),
+								layout.Rigid(txt.Layout),
+							)
+						})
 					}),
 				)
+			}),
+			layout.Rigid(func(gtx C) D {
+				return layout.Inset{
+					Right: values.MarginPadding4,
+					Top:   values.MarginPadding10,
+				}.Layout(gtx, func(gtx C) D {
+					return pg.nextIcon.Layout(gtx, values.MarginPadding20)
+				})
 			}),
 		)
 	})
@@ -204,43 +196,31 @@ func (pg *SetupMixerAccountsPage) autoSetupLayout(gtx C) D {
 func (pg *SetupMixerAccountsPage) manualSetupLayout(gtx C) D {
 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
 	return layout.UniformInset(values.MarginPadding16).Layout(gtx, func(gtx C) D {
-		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+		return layout.Flex{Spacing: layout.SpaceBetween}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
-				return layout.Flex{Spacing: layout.SpaceBetween}.Layout(gtx,
+				return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+					layout.Rigid(pg.Icons.EditIcon.Layout24dp),
 					layout.Rigid(func(gtx C) D {
-						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-							layout.Rigid(pg.Icons.EditIcon.Layout24dp),
-							layout.Rigid(func(gtx C) D {
-								autoSetupText := pg.Theme.H6("Manual setup")
-								txt := pg.Theme.Body2("For wallets that have enabled privacy before.")
-								return layout.Inset{
-									Left: values.MarginPadding16,
-								}.Layout(gtx, func(gtx C) D {
-									return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-										layout.Rigid(autoSetupText.Layout),
-										layout.Rigid(txt.Layout),
-									)
-								})
-							}),
-						)
-					}),
-					layout.Rigid(func(gtx C) D {
-						return layout.Flex{}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								return layout.Flex{}.Layout(gtx,
-									layout.Rigid(func(gtx C) D {
-										return layout.Inset{
-											Right: values.MarginPadding4,
-											Top:   values.MarginPadding10,
-										}.Layout(gtx, func(gtx C) D {
-											return pg.nextIcon.Layout(gtx, values.MarginPadding20)
-										})
-									}),
-								)
-							}),
-						)
+						autoSetupText := pg.Theme.H6("Manual setup")
+						txt := pg.Theme.Body2("For wallets that have enabled privacy before.")
+						return layout.Inset{
+							Left: values.MarginPadding16,
+						}.Layout(gtx, func(gtx C) D {
+							return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+								layout.Rigid(autoSetupText.Layout),
+								layout.Rigid(txt.Layout),
+							)
+						})
 					}),
 				)
+			}),
+			layout.Rigid(func(gtx C) D {
+				return layout.Inset{
+					Right: values.MarginPadding4,
+					Top:   values.MarginPadding10,
+				}.Layout(gtx, func(gtx C) D {
+					return pg.nextIcon.Layout(gtx, values.MarginPadding20)
+				})
 			}),
 		)
 	})
@@ -259,6 +239,7 @@ func (pg *SetupMixerAccountsPage) showModalSetupMixerInfo() {
 
 func (pg *SetupMixerAccountsPage) showModalSetupMixerAcct() {
 	accounts, _ := pg.wallet.GetAccountsRaw()
+	txt := "There are existing accounts named mixed or unmixed. Please change the name to something else for now. You can change them back after the setup."
 	for _, acct := range accounts.Acc {
 		if acct.Name == "mixed" || acct.Name == "unmixed" {
 			alert := decredmaterial.NewIcon(decredmaterial.MustIcon(widget.NewIcon(icons.AlertError)))
@@ -266,7 +247,7 @@ func (pg *SetupMixerAccountsPage) showModalSetupMixerAcct() {
 			info := modal.NewInfoModal(pg.Load).
 				Icon(alert).
 				Title("Account name is taken").
-				Body("There are existing accounts named mixed or unmixed. Please change the name to something else for now. You can change them back after the setup.").
+				Body(txt).
 				PositiveButton("Go back & rename", func() {
 					pg.PopFragment()
 				})

--- a/ui/page/privacy/setup_mixer_accounts_page.go
+++ b/ui/page/privacy/setup_mixer_accounts_page.go
@@ -286,7 +286,10 @@ func (pg *SetupMixerAccountsPage) showModalSetupMixerAcct() {
 					pm.SetLoading(false)
 					return
 				}
+				pg.WL.MultiWallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
 				pm.Dismiss()
+
+				pg.ChangeFragment(NewAccountMixerPage(pg.Load, pg.wallet))
 			}()
 
 			return false

--- a/ui/page/privacy/setup_mixer_accounts_page.go
+++ b/ui/page/privacy/setup_mixer_accounts_page.go
@@ -1,0 +1,325 @@
+package privacy
+
+import (
+	"context"
+
+	"gioui.org/layout"
+	"gioui.org/text"
+	"gioui.org/widget"
+	"github.com/planetdecred/godcr/ui/renderers"
+
+	"github.com/planetdecred/dcrlibwallet"
+	"github.com/planetdecred/godcr/ui/decredmaterial"
+	"github.com/planetdecred/godcr/ui/load"
+	"github.com/planetdecred/godcr/ui/modal"
+	"github.com/planetdecred/godcr/ui/page/components"
+	"github.com/planetdecred/godcr/ui/values"
+	"golang.org/x/exp/shiny/materialdesign/icons"
+)
+
+const SetupMixerAccountsPageID = "SetupMixerAccounts"
+
+type SetupMixerAccountsPage struct {
+	*load.Load
+
+	ctx       context.Context // page context
+	ctxCancel context.CancelFunc
+
+	wallet *dcrlibwallet.Wallet
+
+	backButton              decredmaterial.IconButton
+	infoButton              decredmaterial.IconButton
+	autoSetupClickable      *decredmaterial.Clickable
+	manualSetupClickable    *decredmaterial.Clickable
+	autoSetupIcon, nextIcon *decredmaterial.Icon
+}
+
+func NewSetupMixerAccountsPage(l *load.Load, wallet *dcrlibwallet.Wallet) *SetupMixerAccountsPage {
+	pg := &SetupMixerAccountsPage{
+		Load:   l,
+		wallet: wallet,
+	}
+	pg.backButton, pg.infoButton = components.SubpageHeaderButtons(l)
+
+	pg.autoSetupIcon = decredmaterial.NewIcon(pg.Icons.ActionCheckCircle)
+	pg.autoSetupIcon.Color = pg.Theme.Color.Success
+
+	pg.nextIcon = decredmaterial.NewIcon(pg.Icons.NavigationArrowForward)
+	pg.nextIcon.Color = pg.Theme.Color.Gray1
+
+	pg.autoSetupClickable = pg.Theme.NewClickable(true)
+
+	pg.manualSetupClickable = pg.Theme.NewClickable(true)
+
+	return pg
+}
+
+// ID is a unique string that identifies the page and may be used
+// to differentiate this page from other pages.
+// Part of the load.Page interface.
+func (pg *SetupMixerAccountsPage) ID() string {
+	return SetupMixerAccountsPageID
+}
+
+// OnNavigatedTo is called when the page is about to be displayed and
+// may be used to initialize page features that are only relevant when
+// the page is displayed.
+// Part of the load.Page interface.
+func (pg *SetupMixerAccountsPage) OnNavigatedTo() {
+	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
+}
+
+// Layout draws the page UI components into the provided layout context
+// to be eventually drawn on screen.
+// Part of the load.Page interface.
+func (pg *SetupMixerAccountsPage) Layout(gtx layout.Context) layout.Dimensions {
+	body := func(gtx C) D {
+		page := components.SubPage{
+			Load:       pg.Load,
+			Title:      "Set up needed accounts",
+			WalletName: pg.wallet.Name,
+			BackButton: pg.backButton,
+			Back: func() {
+				pg.PopFragment()
+			},
+			Body: func(gtx C) D {
+				return pg.Theme.Card().Layout(gtx, func(gtx C) D {
+					gtx.Constraints.Min.X = gtx.Constraints.Max.X
+					return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
+						layout.Flexed(1, func(gtx C) D {
+							return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
+								layout.Rigid(func(gtx C) D {
+									txt := pg.Theme.Body1("Two dedicated accounts will be set up to use the mixer:")
+									txt.Alignment = text.Start
+									ic := decredmaterial.NewIcon(pg.Icons.ImageBrightness1)
+									ic.Color = pg.Theme.Color.Gray1
+									return layout.Inset{Top: values.MarginPadding16, Left: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
+										return layout.Flex{Axis: layout.Vertical, Alignment: layout.Start}.Layout(gtx,
+											layout.Rigid(txt.Layout),
+											layout.Rigid(func(gtx C) D {
+												return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
+													return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+														layout.Rigid(func(gtx C) D {
+															return layout.Inset{Bottom: values.MarginPadding12}.Layout(gtx, func(gtx C) D {
+																return ic.Layout(gtx, values.MarginPadding8)
+															})
+														}),
+														layout.Rigid(func(gtx C) D {
+															txt2 := `<span style="text-color: grayText2">
+														<b>Mixed </b> account will be the outbounding spending account.
+													</span>`
+
+															return layout.Inset{Left: values.MarginPadding8}.Layout(gtx, func(gtx C) D {
+																return renderers.RenderHTML(txt2, pg.Theme).Layout(gtx)
+															})
+														}),
+													)
+												})
+											}),
+											layout.Rigid(func(gtx C) D {
+												return layout.Inset{Top: values.MarginPadding16}.Layout(gtx, func(gtx C) D {
+													return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+														layout.Rigid(func(gtx C) D {
+															return layout.Inset{Bottom: values.MarginPadding12}.Layout(gtx, func(gtx C) D {
+																return ic.Layout(gtx, values.MarginPadding8)
+															})
+														}),
+														layout.Rigid(func(gtx C) D {
+															txt3 := `<span style="text-color: grayText2">
+													<b>Unmixed </b> account will be the change handling account.
+												</span>`
+
+															return layout.Inset{Left: values.MarginPadding8}.Layout(gtx, func(gtx C) D {
+																return renderers.RenderHTML(txt3, pg.Theme).Layout(gtx)
+															})
+														}),
+													)
+												})
+											}),
+										)
+									})
+								}),
+							)
+						}),
+						layout.Rigid(func(gtx C) D {
+							gtx.Constraints.Min.X = gtx.Constraints.Max.X
+							return pg.autoSetupClickable.Layout(gtx, func(gtx C) D {
+								return pg.autoSetupLayout(gtx)
+							})
+						}),
+						layout.Rigid(func(gtx C) D {
+							gtx.Constraints.Min.X = gtx.Constraints.Max.X
+							return pg.manualSetupClickable.Layout(gtx, func(gtx C) D {
+								return pg.manualSetupLayout(gtx)
+							})
+						}),
+					)
+				})
+			},
+		}
+		return page.Layout(gtx)
+	}
+
+	return components.UniformPadding(gtx, body)
+}
+
+func (pg *SetupMixerAccountsPage) autoSetupLayout(gtx C) D {
+	gtx.Constraints.Min.X = gtx.Constraints.Max.X
+	return layout.UniformInset(values.MarginPadding16).Layout(gtx, func(gtx C) D {
+		return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				return layout.Flex{Spacing: layout.SpaceBetween}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								return pg.autoSetupIcon.Layout(gtx, values.MarginPadding20)
+							}),
+							layout.Rigid(func(gtx C) D {
+								autoSetupText := pg.Theme.H6("Auto setup")
+								txt := pg.Theme.Body2("Create and set up the needed accounts for you.")
+								return layout.Inset{
+									Left: values.MarginPadding16,
+								}.Layout(gtx, func(gtx C) D {
+									return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+										layout.Rigid(autoSetupText.Layout),
+										layout.Rigid(txt.Layout),
+									)
+								})
+							}),
+						)
+					}),
+					layout.Rigid(func(gtx C) D {
+						return layout.Flex{}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								return layout.Inset{
+									Right: values.MarginPadding4,
+									Top:   values.MarginPadding10,
+								}.Layout(gtx, func(gtx C) D {
+									return pg.nextIcon.Layout(gtx, values.MarginPadding20)
+								})
+							}),
+						)
+					}),
+				)
+			}),
+		)
+	})
+}
+
+func (pg *SetupMixerAccountsPage) manualSetupLayout(gtx C) D {
+	gtx.Constraints.Min.X = gtx.Constraints.Max.X
+	return layout.UniformInset(values.MarginPadding16).Layout(gtx, func(gtx C) D {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				return layout.Flex{Spacing: layout.SpaceBetween}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+							layout.Rigid(pg.Icons.EditIcon.Layout24dp),
+							layout.Rigid(func(gtx C) D {
+								autoSetupText := pg.Theme.H6("Manual setup")
+								txt := pg.Theme.Body2("For wallets that have enabled privacy before.")
+								return layout.Inset{
+									Left: values.MarginPadding16,
+								}.Layout(gtx, func(gtx C) D {
+									return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+										layout.Rigid(autoSetupText.Layout),
+										layout.Rigid(txt.Layout),
+									)
+								})
+							}),
+						)
+					}),
+					layout.Rigid(func(gtx C) D {
+						return layout.Flex{}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								return layout.Flex{}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										return layout.Inset{
+											Right: values.MarginPadding4,
+											Top:   values.MarginPadding10,
+										}.Layout(gtx, func(gtx C) D {
+											return pg.nextIcon.Layout(gtx, values.MarginPadding20)
+										})
+									}),
+								)
+							}),
+						)
+					}),
+				)
+			}),
+		)
+	})
+}
+
+func (pg *SetupMixerAccountsPage) showModalSetupMixerInfo() {
+	info := modal.NewInfoModal(pg.Load).
+		Title("Set up mixer by creating two needed accounts").
+		Body("Two dedicated accounts (\"mixed\" & \"unmixed\") will be created in order to use the mixer. \n\n <b>This action cannot be undone.</b>").
+		NegativeButton(values.String(values.StrCancel), func() {}).
+		PositiveButton("Begin setup", func() {
+			pg.showModalSetupMixerAcct()
+		})
+	pg.ShowModal(info)
+}
+
+func (pg *SetupMixerAccountsPage) showModalSetupMixerAcct() {
+	accounts, _ := pg.wallet.GetAccountsRaw()
+	for _, acct := range accounts.Acc {
+		if acct.Name == "mixed" || acct.Name == "unmixed" {
+			alert := decredmaterial.NewIcon(decredmaterial.MustIcon(widget.NewIcon(icons.AlertError)))
+			alert.Color = pg.Theme.Color.DeepBlue
+			info := modal.NewInfoModal(pg.Load).
+				Icon(alert).
+				Title("Account name is taken").
+				Body("There are existing accounts named mixed or unmixed. Please change the name to something else for now. You can change them back after the setup.").
+				PositiveButton("Go back & rename", func() {
+					pg.PopFragment()
+				})
+			pg.ShowModal(info)
+			return
+		}
+	}
+
+	modal.NewPasswordModal(pg.Load).
+		Title("Confirm to create needed accounts").
+		NegativeButton("Cancel", func() {}).
+		PositiveButton("Confirm", func(password string, pm *modal.PasswordModal) bool {
+			go func() {
+				err := pg.wallet.CreateMixerAccounts("mixed", "unmixed", password)
+				if err != nil {
+					pm.SetError(err.Error())
+					pm.SetLoading(false)
+					return
+				}
+				pm.Dismiss()
+			}()
+
+			return false
+		}).Show()
+}
+
+// HandleUserInteractions is called just before Layout() to determine
+// if any user interaction recently occurred on the page and may be
+// used to update the page's UI components shortly before they are
+// displayed.
+// Part of the load.Page interface.
+func (pg *SetupMixerAccountsPage) HandleUserInteractions() {
+	if pg.autoSetupClickable.Clicked() {
+		go pg.showModalSetupMixerInfo()
+	}
+
+	if pg.manualSetupClickable.Clicked() {
+		pg.ChangeFragment(NewManualMixerSetupPage(pg.Load, pg.wallet))
+	}
+}
+
+// OnNavigatedFrom is called when the page is about to be removed from
+// the displayed window. This method should ideally be used to disable
+// features that are irrelevant when the page is NOT displayed.
+// NOTE: The page may be re-displayed on the app's window, in which case
+// OnNavigatedTo() will be called again. This method should not destroy UI
+// components unless they'll be recreated in the OnNavigatedTo() method.
+// Part of the load.Page interface.
+func (pg *SetupMixerAccountsPage) OnNavigatedFrom() {
+	pg.ctxCancel()
+}

--- a/ui/page/privacy/setup_mixer_accounts_page.go
+++ b/ui/page/privacy/setup_mixer_accounts_page.go
@@ -254,7 +254,7 @@ func (pg *SetupMixerAccountsPage) manualSetupLayout(gtx C) D {
 func (pg *SetupMixerAccountsPage) showModalSetupMixerInfo() {
 	info := modal.NewInfoModal(pg.Load).
 		Title("Set up mixer by creating two needed accounts").
-		Body("Two dedicated accounts (\"mixed\" & \"unmixed\") will be created in order to use the mixer. \n\n <b>This action cannot be undone.</b>").
+		SetupWithTemplate(modal.SetupMixerInfoTemplate).
 		NegativeButton(values.String(values.StrCancel), func() {}).
 		PositiveButton("Begin setup", func() {
 			pg.showModalSetupMixerAcct()

--- a/ui/page/privacy/setup_mixer_accounts_page.go
+++ b/ui/page/privacy/setup_mixer_accounts_page.go
@@ -6,13 +6,13 @@ import (
 	"gioui.org/layout"
 	"gioui.org/text"
 	"gioui.org/widget"
-	"github.com/planetdecred/godcr/ui/renderers"
 
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
 	"github.com/planetdecred/godcr/ui/modal"
 	"github.com/planetdecred/godcr/ui/page/components"
+	"github.com/planetdecred/godcr/ui/renderers"
 	"github.com/planetdecred/godcr/ui/values"
 	"golang.org/x/exp/shiny/materialdesign/icons"
 )

--- a/ui/page/privacy/setup_mixer_accounts_page.go
+++ b/ui/page/privacy/setup_mixer_accounts_page.go
@@ -48,7 +48,6 @@ func NewSetupMixerAccountsPage(l *load.Load, wallet *dcrlibwallet.Wallet) *Setup
 	pg.nextIcon.Color = pg.Theme.Color.Gray1
 
 	pg.autoSetupClickable = pg.Theme.NewClickable(true)
-
 	pg.manualSetupClickable = pg.Theme.NewClickable(true)
 
 	return pg
@@ -109,9 +108,9 @@ func (pg *SetupMixerAccountsPage) Layout(gtx layout.Context) layout.Dimensions {
 														<b>Mixed </b> account will be the outbounding spending account.
 													</span>`
 
-															return layout.Inset{Left: values.MarginPadding8}.Layout(gtx, func(gtx C) D {
-																return renderers.RenderHTML(txt2, pg.Theme).Layout(gtx)
-															})
+															return layout.Inset{
+																Left: values.MarginPadding8,
+															}.Layout(gtx, renderers.RenderHTML(txt2, pg.Theme).Layout)
 														}),
 													)
 												})
@@ -129,9 +128,9 @@ func (pg *SetupMixerAccountsPage) Layout(gtx layout.Context) layout.Dimensions {
 													<b>Unmixed </b> account will be the change handling account.
 												</span>`
 
-															return layout.Inset{Left: values.MarginPadding8}.Layout(gtx, func(gtx C) D {
-																return renderers.RenderHTML(txt3, pg.Theme).Layout(gtx)
-															})
+															return layout.Inset{
+																Left: values.MarginPadding8,
+															}.Layout(gtx, renderers.RenderHTML(txt3, pg.Theme).Layout)
 														}),
 													)
 												})
@@ -143,15 +142,11 @@ func (pg *SetupMixerAccountsPage) Layout(gtx layout.Context) layout.Dimensions {
 						}),
 						layout.Rigid(func(gtx C) D {
 							gtx.Constraints.Min.X = gtx.Constraints.Max.X
-							return pg.autoSetupClickable.Layout(gtx, func(gtx C) D {
-								return pg.autoSetupLayout(gtx)
-							})
+							return pg.autoSetupClickable.Layout(gtx, pg.autoSetupLayout)
 						}),
 						layout.Rigid(func(gtx C) D {
 							gtx.Constraints.Min.X = gtx.Constraints.Max.X
-							return pg.manualSetupClickable.Layout(gtx, func(gtx C) D {
-								return pg.manualSetupLayout(gtx)
-							})
+							return pg.manualSetupClickable.Layout(gtx, pg.manualSetupLayout)
 						}),
 					)
 				})

--- a/ui/page/privacy/setup_privacy_page.go
+++ b/ui/page/privacy/setup_privacy_page.go
@@ -44,10 +44,6 @@ func NewSetupPrivacyPage(l *load.Load, wallet *dcrlibwallet.Wallet) *SetupPrivac
 	}
 	pg.backButton, pg.infoButton = components.SubpageHeaderButtons(l)
 
-	if pg.wallet.MixedAccountNumber() > 0 && pg.wallet.UnmixedAccountNumber() > 0 {
-		pg.ChangeFragment(NewAccountMixerPage(pg.Load, wallet))
-	}
-
 	return pg
 
 }
@@ -65,6 +61,10 @@ func (pg *SetupPrivacyPage) ID() string {
 // Part of the load.Page interface.
 func (pg *SetupPrivacyPage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
+
+	if pg.wallet.MixedAccountNumber() > 0 && pg.wallet.UnmixedAccountNumber() > 0 {
+		go pg.ChangeFragment(NewAccountMixerPage(pg.Load, pg.wallet))
+	}
 }
 
 // Layout draws the page UI components into the provided layout context

--- a/ui/page/privacy/setup_privacy_page.go
+++ b/ui/page/privacy/setup_privacy_page.go
@@ -1,0 +1,157 @@
+package privacy
+
+import (
+	"context"
+
+	"gioui.org/layout"
+	"gioui.org/text"
+
+	"github.com/planetdecred/dcrlibwallet"
+	"github.com/planetdecred/godcr/ui/decredmaterial"
+	"github.com/planetdecred/godcr/ui/load"
+	"github.com/planetdecred/godcr/ui/modal"
+	"github.com/planetdecred/godcr/ui/page/components"
+	"github.com/planetdecred/godcr/ui/values"
+)
+
+const SetupPrivacyPageID = "SetupPrivacy"
+
+type (
+	C = layout.Context
+	D = layout.Dimensions
+)
+
+type SetupPrivacyPage struct {
+	*load.Load
+
+	ctx       context.Context // page context
+	ctxCancel context.CancelFunc
+
+	wallet         *dcrlibwallet.Wallet
+	pageContainer  layout.List
+	toPrivacySetup decredmaterial.Button
+
+	backButton decredmaterial.IconButton
+	infoButton decredmaterial.IconButton
+}
+
+func NewSetupPrivacyPage(l *load.Load, wallet *dcrlibwallet.Wallet) *SetupPrivacyPage {
+	pg := &SetupPrivacyPage{
+		Load:           l,
+		wallet:         wallet,
+		pageContainer:  layout.List{Axis: layout.Vertical},
+		toPrivacySetup: l.Theme.Button("Set up mixer for this wallet"),
+	}
+	pg.backButton, pg.infoButton = components.SubpageHeaderButtons(l)
+
+	if pg.wallet.MixedAccountNumber() > 0 && pg.wallet.UnmixedAccountNumber() > 0 {
+		pg.ChangeFragment(NewAccountMixerPage(pg.Load, wallet))
+	}
+
+	return pg
+
+}
+
+// ID is a unique string that identifies the page and may be used
+// to differentiate this page from other pages.
+// Part of the load.Page interface.
+func (pg *SetupPrivacyPage) ID() string {
+	return SetupPrivacyPageID
+}
+
+// OnNavigatedTo is called when the page is about to be displayed and
+// may be used to initialize page features that are only relevant when
+// the page is displayed.
+// Part of the load.Page interface.
+func (pg *SetupPrivacyPage) OnNavigatedTo() {
+	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
+}
+
+// Layout draws the page UI components into the provided layout context
+// to be eventually drawn on screen.
+// Part of the load.Page interface.
+func (pg *SetupPrivacyPage) Layout(gtx layout.Context) layout.Dimensions {
+	d := func(gtx C) D {
+		sp := components.SubPage{
+			Load:       pg.Load,
+			Title:      "StakeShuffle",
+			WalletName: pg.wallet.Name,
+			BackButton: pg.backButton,
+			InfoButton: pg.infoButton,
+			Back: func() {
+				pg.PopFragment()
+			},
+			InfoTemplate: modal.PrivacyInfoTemplate,
+			Body: func(gtx layout.Context) layout.Dimensions {
+				return pg.privacyIntroLayout(gtx)
+			},
+		}
+		return sp.Layout(gtx)
+	}
+	return components.UniformPadding(gtx, d)
+}
+
+func (pg *SetupPrivacyPage) privacyIntroLayout(gtx layout.Context) layout.Dimensions {
+	return pg.Theme.Card().Layout(gtx, func(gtx C) D {
+		gtx.Constraints.Min.X = gtx.Constraints.Max.X
+		return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
+			layout.Flexed(1, func(gtx C) D {
+				return layout.Center.Layout(gtx, func(gtx C) D {
+					return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							return layout.Inset{
+								Bottom: values.MarginPadding24,
+							}.Layout(gtx, func(gtx C) D {
+								return pg.Icons.PrivacySetup.LayoutSize(gtx, values.MarginPadding280)
+							})
+						}),
+						layout.Rigid(func(gtx C) D {
+							txt := pg.Theme.H6("How does StakeShuffle++ mixer enhance your privacy?")
+							txt2 := pg.Theme.Body1("Shuffle++ mixer can mix your DCRs through CoinJoin transactions.")
+							txt3 := pg.Theme.Body1("Using mixed DCRs protects you from exposing your financial activities to")
+							txt4 := pg.Theme.Body1("the public (e.g. how much you own, who pays you).")
+							txt.Alignment, txt2.Alignment, txt3.Alignment, txt4.Alignment = text.Middle, text.Middle, text.Middle, text.Middle
+
+							return layout.Flex{Axis: layout.Vertical, Alignment: layout.Middle}.Layout(gtx,
+								layout.Rigid(txt.Layout),
+								layout.Rigid(func(gtx C) D {
+									return layout.Inset{Top: values.MarginPadding10}.Layout(gtx, txt2.Layout)
+								}),
+								layout.Rigid(func(gtx C) D {
+									return layout.Inset{Top: values.MarginPadding10}.Layout(gtx, txt3.Layout)
+								}),
+								layout.Rigid(txt4.Layout),
+							)
+						}),
+					)
+				})
+			}),
+			layout.Rigid(func(gtx C) D {
+				gtx.Constraints.Min.X = gtx.Constraints.Max.X
+				return layout.UniformInset(values.MarginPadding15).Layout(gtx, pg.toPrivacySetup.Layout)
+			}),
+		)
+	})
+}
+
+// HandleUserInteractions is called just before Layout() to determine
+// if any user interaction recently occurred on the page and may be
+// used to update the page's UI components shortly before they are
+// displayed.
+// Part of the load.Page interface.
+func (pg *SetupPrivacyPage) HandleUserInteractions() {
+	if pg.toPrivacySetup.Clicked() {
+		pg.ChangeFragment(NewSetupMixerAccountsPage(pg.Load, pg.wallet))
+	}
+}
+
+// OnNavigatedFrom is called when the page is about to be removed from
+// the displayed window. This method should ideally be used to disable
+// features that are irrelevant when the page is NOT displayed.
+// NOTE: The page may be re-displayed on the app's window, in which case
+// OnNavigatedTo() will be called again. This method should not destroy UI
+// components unless they'll be recreated in the OnNavigatedTo() method.
+// Part of the load.Page interface.
+func (pg *SetupPrivacyPage) OnNavigatedFrom() {
+	pg.ctxCancel()
+}

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -136,7 +136,7 @@ func (pg *ReceivePage) ID() string {
 func (pg *ReceivePage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 	pg.selector.ListenForTxNotifications(pg.ctx)
-	pg.selector.SelectFirstWalletValidAccount() // Want to reset the user's selection everytime this page appears?
+	pg.selector.SelectFirstWalletValidAccount(nil) // Want to reset the user's selection everytime this page appears?
 	// might be better to track the last selection in a variable and reselect it.
 }
 

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -95,7 +95,7 @@ func NewReceivePage(l *load.Load) *ReceivePage {
 	pg.backButton, pg.infoButton = components.SubpageHeaderButtons(l)
 	pg.backButton.Icon = pg.Icons.ContentClear
 
-	pg.selector = components.NewAccountSelector(pg.Load).
+	pg.selector = components.NewAccountSelector(pg.Load, nil).
 		Title("Receiving account").
 		AccountSelected(func(selectedAccount *dcrlibwallet.Account) {
 			selectedWallet := pg.multiWallet.WalletWithID(selectedAccount.WalletID)

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -98,7 +98,7 @@ func NewSendPage(l *load.Load) *Page {
 	}
 
 	// Source account picker
-	pg.sourceAccountSelector = components.NewAccountSelector(l).
+	pg.sourceAccountSelector = components.NewAccountSelector(l, nil).
 		Title("Sending account").
 		AccountSelected(func(selectedAccount *dcrlibwallet.Account) {
 			pg.validateAndConstructTx()

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -128,7 +128,7 @@ func NewSendPage(l *load.Load) *Page {
 
 	pg.sendDestination.destinationAccountSelector.AccountSelected(func(selectedAccount *dcrlibwallet.Account) {
 		pg.validateAndConstructTx()
-		pg.sourceAccountSelector.SelectFirstWalletValidAccount() // refresh source account
+		pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil) // refresh source account
 	})
 
 	pg.sendDestination.addressChanged = func() {
@@ -159,8 +159,8 @@ func (pg *Page) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 	pg.sourceAccountSelector.ListenForTxNotifications(pg.ctx)
 
-	pg.sendDestination.destinationAccountSelector.SelectFirstWalletValidAccount()
-	pg.sourceAccountSelector.SelectFirstWalletValidAccount()
+	pg.sendDestination.destinationAccountSelector.SelectFirstWalletValidAccount(nil)
+	pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil)
 	pg.sendDestination.destinationAddressEditor.Editor.Focus()
 
 	currencyExchangeValue := pg.WL.MultiWallet.ReadStringConfigValueForKey(dcrlibwallet.CurrencyConversionConfigKey)

--- a/ui/page/send/send_destination.go
+++ b/ui/page/send/send_destination.go
@@ -34,7 +34,7 @@ func newSendDestination(l *load.Load) *destination {
 	dst.accountSwitch = l.Theme.SwitchButtonText([]decredmaterial.SwitchItem{{Text: "Address"}, {Text: "My account"}})
 
 	// Destination account picker
-	dst.destinationAccountSelector = components.NewAccountSelector(dst.Load).
+	dst.destinationAccountSelector = components.NewAccountSelector(dst.Load, nil).
 		Title("Receiving account").
 		AccountValidator(func(account *dcrlibwallet.Account) bool {
 

--- a/ui/page/staking/auto_ticket_modal.go
+++ b/ui/page/staking/auto_ticket_modal.go
@@ -175,7 +175,7 @@ func (tb *ticketBuyerModal) Dismiss() {
 }
 
 func (tb *ticketBuyerModal) initializeAccountSelector() {
-	tb.accountSelector = components.NewAccountSelector(tb.Load).
+	tb.accountSelector = components.NewAccountSelector(tb.Load, nil).
 		Title("Purchasing account").
 		AccountSelected(func(selectedAccount *dcrlibwallet.Account) {}).
 		AccountValidator(func(account *dcrlibwallet.Account) bool {

--- a/ui/page/staking/auto_ticket_modal.go
+++ b/ui/page/staking/auto_ticket_modal.go
@@ -95,7 +95,7 @@ func (tb *ticketBuyerModal) OnResume() {
 	}
 
 	if tb.accountSelector.SelectedAccount() == nil {
-		err := tb.accountSelector.SelectFirstWalletValidAccount()
+		err := tb.accountSelector.SelectFirstWalletValidAccount(nil)
 		if err != nil {
 			tb.Toast.NotifyError(err.Error())
 		}

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -302,7 +302,7 @@ func (tp *stakingModal) Show() {
 }
 
 func (tp *stakingModal) initializeAccountSelector() {
-	tp.accountSelector = components.NewAccountSelector(tp.Load).
+	tp.accountSelector = components.NewAccountSelector(tp.Load, nil).
 		Title("Purchasing account").
 		AccountSelected(func(selectedAccount *dcrlibwallet.Account) {}).
 		AccountValidator(func(account *dcrlibwallet.Account) bool {

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -90,7 +90,7 @@ func (tp *stakingModal) OnResume() {
 
 	tp.accountSelector.ListenForTxNotifications(tp.ctx)
 
-	err := tp.accountSelector.SelectFirstWalletValidAccount()
+	err := tp.accountSelector.SelectFirstWalletValidAccount(nil)
 	if err != nil {
 		tp.Toast.NotifyError(err.Error())
 	}

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -17,6 +17,7 @@ import (
 	"github.com/planetdecred/godcr/ui/load"
 	"github.com/planetdecred/godcr/ui/modal"
 	"github.com/planetdecred/godcr/ui/page/components"
+	"github.com/planetdecred/godcr/ui/page/privacy"
 	"github.com/planetdecred/godcr/ui/page/seedbackup"
 	"github.com/planetdecred/godcr/ui/values"
 )
@@ -273,7 +274,7 @@ func (pg *WalletPage) getWalletMenu(wal *dcrlibwallet.Wallet) []menuItem {
 			text:     values.String(values.StrStakeShuffle),
 			button:   pg.Theme.NewClickable(true),
 			separate: true,
-			id:       PrivacyPageID,
+			id:       privacy.SetupPrivacyPageID,
 		},
 		{
 			text:   values.String(values.StrRename),
@@ -1036,8 +1037,8 @@ func (pg *WalletPage) HandleUserInteractions() {
 				switch menu.id {
 				case SignMessagePageID:
 					pg.ChangeFragment(NewSignMessagePage(pg.Load, listItem.wal))
-				case PrivacyPageID:
-					pg.ChangeFragment(NewPrivacyPage(pg.Load, listItem.wal))
+				case privacy.SetupPrivacyPageID:
+					pg.ChangeFragment(privacy.NewSetupPrivacyPage(pg.Load, listItem.wal))
 				case WalletSettingsPageID:
 					pg.ChangeFragment(NewWalletSettingsPage(pg.Load, listItem.wal))
 				default:

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -564,7 +564,7 @@ func (pg *WalletPage) walletSection(gtx layout.Context) layout.Dimensions {
 								return blankLine.Layout(gtx)
 							}),
 							layout.Rigid(func(gtx C) D {
-								pg.card.Color = pg.Theme.Color.White
+								pg.card.Color = pg.Theme.Color.Surface
 								pg.card.Radius = decredmaterial.CornerRadius{BottomLeft: 10, BottomRight: 10}
 								return pg.card.Layout(gtx, func(gtx C) D {
 									return pg.checkMixerSection(gtx, listItem)

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -761,19 +761,38 @@ func (pg *WalletPage) layoutCollapsibleHeader(gtx layout.Context, listItem *wall
 					return pg.Theme.Body1(listItem.wal.Name).Layout(gtx)
 				}),
 				layout.Rigid(func(gtx C) D {
-					var txt decredmaterial.Label
-					if len(listItem.wal.EncryptedSeed) > 0 {
-						txt = pg.Theme.Caption(values.String(values.StrNotBackedUp))
-						txt.Color = pg.Theme.Color.Danger
-					}
-					if listItem.wal.IsAccountMixerActive() {
-						txt = pg.Theme.Caption("Mixing...")
-						txt.Color = pg.Theme.Color.GrayText2
-					}
-					if (txt != decredmaterial.Label{}) {
-						return txt.Layout(gtx)
-					}
-					return D{}
+					return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							var txt decredmaterial.Label
+							if len(listItem.wal.EncryptedSeed) > 0 {
+								txt = pg.Theme.Caption(values.String(values.StrNotBackedUp))
+								txt.Color = pg.Theme.Color.Danger
+								return txt.Layout(gtx)
+							}
+							return D{}
+						}),
+						layout.Rigid(func(gtx C) D {
+							if listItem.wal.IsAccountMixerActive() {
+								return layout.Inset{
+									Left: values.MarginPadding4,
+								}.Layout(gtx, func(gtx C) D {
+									return decredmaterial.Card{
+										Color: pg.Theme.Color.Gray4,
+									}.Layout(gtx, func(gtx C) D {
+										return layout.Inset{
+											Left:  values.MarginPadding4,
+											Right: values.MarginPadding4,
+										}.Layout(gtx, func(gtx C) D {
+											name := pg.Theme.Label(values.TextSize12, "Mixing...")
+											name.Color = pg.Theme.Color.GrayText2
+											return name.Layout(gtx)
+										})
+									})
+								})
+							}
+							return D{}
+						}),
+					)
 				}),
 			)
 		}),

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -952,7 +952,10 @@ func (pg *WalletPage) checkMixerSection(gtx layout.Context, listItem *walletList
 									return layout.Flex{}.Layout(gtx,
 										layout.Rigid(txt.Layout),
 										layout.Rigid(func(gtx C) D {
-											return layout.Inset{Top: values.MarginPadding2, Left: values.MarginPadding8}.Layout(gtx, func(gtx C) D {
+											return layout.Inset{
+												Top:  values.MarginPadding2,
+												Left: values.MarginPadding8,
+											}.Layout(gtx, func(gtx C) D {
 												return pg.nextIcon.Layout(gtx, values.MarginPadding16)
 											})
 										}),

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -557,20 +557,11 @@ func (pg *WalletPage) walletSection(gtx layout.Context) layout.Dimensions {
 			if listItem.wal.IsAccountMixerActive() {
 				children = append(children, layout.Rigid(func(gtx C) D {
 					return layout.Inset{Top: unit.Dp(-8)}.Layout(gtx, func(gtx C) D {
-						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								blankLine := pg.Theme.Line(10, gtx.Constraints.Max.X)
-								blankLine.Color = pg.Theme.Color.Surface
-								return blankLine.Layout(gtx)
-							}),
-							layout.Rigid(func(gtx C) D {
-								pg.card.Color = pg.Theme.Color.Surface
-								pg.card.Radius = decredmaterial.CornerRadius{BottomLeft: 10, BottomRight: 10}
-								return pg.card.Layout(gtx, func(gtx C) D {
-									return pg.checkMixerSection(gtx, listItem)
-								})
-							}),
-						)
+						pg.card.Color = pg.Theme.Color.Surface
+						pg.card.Radius = decredmaterial.CornerRadius{BottomLeft: 10, BottomRight: 10}
+						return pg.card.Layout(gtx, func(gtx C) D {
+							return pg.checkMixerSection(gtx, listItem)
+						})
 					})
 				}))
 			}

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -18,6 +18,7 @@ var (
 	MarginPadding6        = unit.Dp(6)
 	MarginPadding7        = unit.Dp(7)
 	MarginPadding8        = unit.Dp(8)
+	MarginPaddingMinus8   = unit.Dp(-8)
 	MarginPadding9        = unit.Dp(9)
 	MarginPadding10       = unit.Dp(10)
 	MarginPaddingMinus10  = unit.Dp(-10)


### PR DESCRIPTION
Resolves #780, #796

- [x] Move all mixer related files to "privacy" package
- [x] Allow re-map of mixed/unmixed account in privacy setup for restored wallets
- [x] Show mixer card for the wallet currently mixing

![Screenshot from 2022-03-19 17-15-52](https://user-images.githubusercontent.com/25265396/159129511-51851a93-5893-4768-920a-5529fd5555be.png)
![Screenshot from 2022-03-19 17-16-04](https://user-images.githubusercontent.com/25265396/159129510-b1d835a7-b72d-4b2f-9f9c-301c328f86c3.png)
![Screenshot from 2022-03-19 17-16-22](https://user-images.githubusercontent.com/25265396/159129508-ca1324d9-88fa-4b0a-b330-f625cdb3c67f.png)
![Screenshot from 2022-03-20 16-31-59](https://user-images.githubusercontent.com/25265396/159170072-88fb9deb-d306-4eb4-be2f-1f86d98c65a3.png)
