### PR TITLE
fix a bug where navigating to the staking overview page caused the app to crash

### DIFF
--- a/ui/page/staking/overview.go
+++ b/ui/page/staking/overview.go
@@ -138,7 +138,9 @@ func (pg *Page) loadPageData() {
 	go func() {
 		if len(pg.WL.MultiWallet.KnownVSPs()) == 0 {
 			// TODO: Does this page need this list?
-			pg.WL.MultiWallet.ReloadVSPList(pg.ctx)
+			if pg.ctx != nil {
+				pg.WL.MultiWallet.ReloadVSPList(pg.ctx)
+			}
 		}
 
 		totalRewards, err := pg.WL.MultiWallet.TotalStakingRewards()


### PR DESCRIPTION
Resolves #814 

This PR fixes a bug where sometimes a nil context was being passed to the `pg.WL.MultiWallet.ReloadVSPList(pg.ctx)` function which caused a panic.

This fix implemented here was to ensure that the page context wasn't nil before passing it to the `ReloadVSPList()` method