### PR TITLE
Fix hover fill on add wallet menu

### DIFF
--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -1024,12 +1024,10 @@ func (pg *WalletPage) layoutAddWalletMenu(gtx layout.Context) layout.Dimensions 
 				return (&layout.List{Axis: layout.Vertical}).Layout(gtx, len(pg.addWalletMenu), func(gtx C, i int) D {
 					card := pg.Theme.Card()
 					card.Radius = decredmaterial.Radius(0)
-					return card.HoverableLayout(gtx, pg.addWalletMenu[i].button, func(gtx C) D {
-						return pg.addWalletMenu[i].button.Layout(gtx, func(gtx C) D {
-							return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
-								gtx.Constraints.Min.X = gtx.Constraints.Max.X
-								return pg.Theme.Body2(pg.addWalletMenu[i].text).Layout(gtx)
-							})
+					return pg.addWalletMenu[i].button.Layout(gtx, func(gtx C) D {
+						return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
+							gtx.Constraints.Min.X = gtx.Constraints.Max.X
+							return pg.Theme.Body2(pg.addWalletMenu[i].text).Layout(gtx)
 						})
 					})
 				})

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -1012,8 +1012,7 @@ func (pg *WalletPage) checkMixerSection(gtx layout.Context, listItem *walletList
 }
 
 func (pg *WalletPage) layoutAddWalletMenu(gtx layout.Context) layout.Dimensions {
-	width := unit.Value{U: unit.UnitDp, V: 55}
-	gtx.Constraints.Max.X = gtx.Px(width)
+	gtx.Constraints.Max.X = gtx.Px(values.MarginPadding56)
 	inset := layout.Inset{
 		Top:  unit.Dp(-100),
 		Left: unit.Dp(-130),
@@ -1023,21 +1022,16 @@ func (pg *WalletPage) layoutAddWalletMenu(gtx layout.Context) layout.Dimensions 
 		return pg.Theme.Shadow().Layout(gtx, func(gtx C) D {
 			return pg.optionsMenuCard.Layout(gtx, func(gtx C) D {
 				return (&layout.List{Axis: layout.Vertical}).Layout(gtx, len(pg.addWalletMenu), func(gtx C, i int) D {
-					return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-						layout.Rigid(func(gtx C) D {
-							card := pg.Theme.Card()
-							card.Radius = decredmaterial.Radius(0)
-							return card.HoverableLayout(gtx, pg.addWalletMenu[i].button, func(gtx C) D {
-								return pg.addWalletMenu[i].button.Layout(gtx, func(gtx C) D {
-									return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
-										gtx.Constraints.Min.X = gtx.Constraints.Max.X
-										return pg.Theme.Body2(pg.addWalletMenu[i].text).Layout(gtx)
-									})
-								})
+					card := pg.Theme.Card()
+					card.Radius = decredmaterial.Radius(0)
+					return card.HoverableLayout(gtx, pg.addWalletMenu[i].button, func(gtx C) D {
+						return pg.addWalletMenu[i].button.Layout(gtx, func(gtx C) D {
+							return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
+								gtx.Constraints.Min.X = gtx.Constraints.Max.X
+								return pg.Theme.Body2(pg.addWalletMenu[i].text).Layout(gtx)
 							})
-						}),
-					)
-
+						})
+					})
 				})
 			})
 		})

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -1022,8 +1022,6 @@ func (pg *WalletPage) layoutAddWalletMenu(gtx layout.Context) layout.Dimensions 
 		return pg.Theme.Shadow().Layout(gtx, func(gtx C) D {
 			return pg.optionsMenuCard.Layout(gtx, func(gtx C) D {
 				return (&layout.List{Axis: layout.Vertical}).Layout(gtx, len(pg.addWalletMenu), func(gtx C, i int) D {
-					card := pg.Theme.Card()
-					card.Radius = decredmaterial.Radius(0)
 					return pg.addWalletMenu[i].button.Layout(gtx, func(gtx C) D {
 						return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
 							gtx.Constraints.Min.X = gtx.Constraints.Max.X

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -1012,6 +1012,8 @@ func (pg *WalletPage) checkMixerSection(gtx layout.Context, listItem *walletList
 }
 
 func (pg *WalletPage) layoutAddWalletMenu(gtx layout.Context) layout.Dimensions {
+	width := unit.Value{U: unit.UnitDp, V: 55}
+	gtx.Constraints.Max.X = gtx.Px(width)
 	inset := layout.Inset{
 		Top:  unit.Dp(-100),
 		Left: unit.Dp(-130),
@@ -1021,9 +1023,21 @@ func (pg *WalletPage) layoutAddWalletMenu(gtx layout.Context) layout.Dimensions 
 		return pg.Theme.Shadow().Layout(gtx, func(gtx C) D {
 			return pg.optionsMenuCard.Layout(gtx, func(gtx C) D {
 				return (&layout.List{Axis: layout.Vertical}).Layout(gtx, len(pg.addWalletMenu), func(gtx C, i int) D {
-					return pg.addWalletMenu[i].button.Layout(gtx, func(gtx C) D {
-						return layout.UniformInset(unit.Dp(10)).Layout(gtx, pg.Theme.Body2(pg.addWalletMenu[i].text).Layout)
-					})
+					return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							card := pg.Theme.Card()
+							card.Radius = decredmaterial.Radius(0)
+							return card.HoverableLayout(gtx, pg.addWalletMenu[i].button, func(gtx C) D {
+								return pg.addWalletMenu[i].button.Layout(gtx, func(gtx C) D {
+									return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
+										gtx.Constraints.Min.X = gtx.Constraints.Max.X
+										return pg.Theme.Body2(pg.addWalletMenu[i].text).Layout(gtx)
+									})
+								})
+							})
+						}),
+					)
+
 				})
 			})
 		})


### PR DESCRIPTION
On the wallets page, when the mouse cursor hovers on the add wallet menu items, the shadow does not fill the clickable row properly as seen in the video below:
https://streamable.com/v1g6st

This PR ensures that the clickable row is filled by the shadow when hovered on. See results in the video below:
https://streamable.com/xou2oe
