### PR TITLE
Add wallet balance to staking UI

### DIFF
--- a/ui/decredmaterial/progressbar.go
+++ b/ui/decredmaterial/progressbar.go
@@ -131,7 +131,9 @@ func (p ProgressBarStyle) Layout(gtx layout.Context) layout.Dimensions {
 // TODO: Allow more than just 2 layers and make it dynamic
 func (mp *MultiLayerProgressBar) progressBarLayout(gtx C) D {
 	r := float32(gtx.Px(values.MarginPadding0))
-	mp.Width = float32(gtx.Constraints.Max.X)
+	if mp.Width <= 0 {
+		mp.Width = float32(gtx.Constraints.Max.X)
+	}
 
 	// progressScale represent the different progress bar layers
 	progressScale := func(width float32, color color.NRGBA) layout.Dimensions {

--- a/ui/decredmaterial/progressbar.go
+++ b/ui/decredmaterial/progressbar.go
@@ -3,15 +3,19 @@
 package decredmaterial
 
 import (
+	"fmt"
 	"image"
 	"image/color"
 
 	"gioui.org/f32"
 	"gioui.org/layout"
+	// "gioui.org/widget"
 	"gioui.org/op/clip"
 	"gioui.org/op/paint"
 	"gioui.org/unit"
 	"gioui.org/widget/material"
+
+	"github.com/planetdecred/godcr/ui/values"
 )
 
 type ProgressBarStyle struct {
@@ -20,6 +24,23 @@ type ProgressBarStyle struct {
 	Width     unit.Value
 	Direction layout.Direction
 	material.ProgressBarStyle
+}
+
+type ProgressBarItem struct {
+	Value   float32
+	Color   color.NRGBA
+	SubText string
+}
+
+// VoteBar shows the range/percentage of the yes votes and no votes against the total required.
+type MultiLayerProgressBar struct {
+	t *Theme
+
+	items  []ProgressBarItem
+	Radius CornerRadius
+	Height unit.Value
+	Width  float32
+	total  float32
 }
 
 func (t *Theme) ProgressBar(progress int) ProgressBarStyle {
@@ -96,7 +117,140 @@ func (p ProgressBarStyle) Layout(gtx layout.Context) layout.Dimensions {
 	)
 }
 
-// clamp1 limits v to range [0..1].
+func (t *Theme) MultiLayerProgressBar(total float32, items []ProgressBarItem) *MultiLayerProgressBar {
+	mp := &MultiLayerProgressBar{
+		t: t,
+
+		total:  total,
+		Height: values.MarginPadding8,
+		items:  items,
+	}
+
+	return mp
+}
+
+func (mp *MultiLayerProgressBar) progressBarLayout(gtx C) D {
+	r := float32(gtx.Px(values.MarginPadding0))
+	mp.Width = float32(gtx.Constraints.Max.X)
+
+	// progressScale represent the different progress bar layers
+	progressScale := func(width float32, color color.NRGBA) layout.Dimensions {
+		d := image.Point{X: int(width), Y: gtx.Px(mp.Height)}
+
+		defer clip.RRect{
+			Rect: f32.Rectangle{Max: f32.Point{X: width, Y: float32(gtx.Px(mp.Height))}},
+			NE:   r, NW: r, SE: r, SW: r,
+		}.Push(gtx.Ops).Pop()
+
+		paint.ColorOp{Color: color}.Add(gtx.Ops)
+		paint.PaintOp{}.Add(gtx.Ops)
+
+		return layout.Dimensions{
+			Size: d,
+		}
+	}
+
+	return layout.Stack{Alignment: layout.W}.Layout(gtx,
+		// layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+		// 	return progressScale(mp.Width, mp.t.Color.Gray2)
+		// }),
+		layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+			// progressLayer := make([]layout.Widget, 0)
+			var w []layout.Widget
+
+			for _, item := range mp.items {
+				val := (item.Value / mp.total) * 100
+				width := (mp.Width / 100) * val
+				fmt.Println(val)
+				fmt.Println(width)
+				fmt.Println(item)
+				fmt.Println(mp.Width)
+
+				w = append(w, func(gtx C) D {
+					if width == 0 {
+						return D{}
+					}
+
+					// return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					// layout.Rigid(mp.t.Label(values.TextSize14, item.SubText).Layout),
+					// layout.Rigid(func(gtx C) D {
+					return progressScale(width, item.Color)
+					// })
+					// )
+				})
+
+			}
+
+			// fmt.Println(len(progressLayer))
+			// return layout.Flex{}.Layout(gtx, progressLayer...)
+			list := &layout.List{Axis: layout.Horizontal}
+			return list.Layout(gtx, len(w), func(gtx C, i int) D {
+				return w[i](gtx)
+			})
+
+		}),
+	)
+}
+
+func (mp *MultiLayerProgressBar) Layout(gtx C) D {
+	return layout.Stack{}.Layout(gtx,
+		layout.Stacked(func(gtx C) D {
+			return layout.Inset{Top: values.MarginPadding5, Bottom: values.MarginPadding5}.Layout(gtx, func(gtx C) D {
+				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					// layout.Rigid(func(gtx C) D {
+					// 	return layout.Flex{}.Layout(gtx,
+					// 		layout.Rigid(func(gtx C) D {
+					// 			yesLabel := mp.Theme.Body1("Yes: ")
+					// 			return mp.layoutIconAndText(gtx, yesLabel, mp.yesVotes, mp.yesColor)
+					// 		}),
+					// 		layout.Rigid(func(gtx C) D {
+					// 			noLabel := mp.Theme.Body1("No: ")
+					// 			return mp.layoutIconAndText(gtx, noLabel, mp.noVotes, mp.noColor)
+					// 		}),
+					// 		layout.Flexed(1, func(gtx C) D {
+					// 			return layout.E.Layout(gtx, func(gtx C) D {
+					// 				return mp.layoutInfo(gtx)
+					// 			})
+					// 		}),
+					// 	)
+					// }),
+					layout.Rigid(func(gtx C) D {
+						return layout.Inset{Top: values.MarginPadding5}.Layout(gtx, mp.progressBarLayout)
+					}),
+				)
+			})
+		}),
+	)
+}
+
+// func (v *VoteBar) layoutIconAndText(gtx C, lbl decredmaterial.Label, count float32, col color.NRGBA) D {
+// 	return layout.Inset{Right: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
+// 		return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+// 			layout.Rigid(func(gtx C) D {
+// 				return layout.Inset{Right: values.MarginPadding5, Top: values.MarginPadding5}.Layout(gtx, func(gtx C) D {
+// 					mp.legendIcon.Color = col
+// 					return mp.legendIcon.Layout(gtx, values.MarginPadding10)
+// 				})
+// 			}),
+// 			layout.Rigid(func(gtx C) D {
+// 				lbl.Font.Weight = text.SemiBold
+// 				return lbl.Layout(gtx)
+// 			}),
+// 			layout.Rigid(func(gtx C) D {
+// 				percentage := (count / mp.totalVotes) * 100
+// 				if percentage != percentage {
+// 					percentage = 0
+// 				}
+// 				percentageStr := strconv.FormatFloat(float64(percentage), 'f', 1, 64) + "%"
+// 				countStr := strconv.FormatFloat(float64(count), 'f', 0, 64)
+
+// 				return mp.Theme.Body1(fmt.Sprintf("%s (%s)", countStr, percentageStr)).Layout(gtx)
+// 			}),
+// 		)
+// 	})
+// }
+
+// clamp1 limits mp.to range [0..1].
 func clamp1(v float32) float32 {
 	if v >= 1 {
 		return 1

--- a/ui/page/components/components.go
+++ b/ui/page/components/components.go
@@ -720,3 +720,27 @@ func CoinImageBySymbol(icons *load.Icons, coinName string) *decredmaterial.Image
 	}
 	return nil
 }
+
+func CalculateTotalWalletsBalance(l *load.Load) (dcrutil.Amount, dcrutil.Amount, error) {
+	totalBalance := int64(0)
+	spandableBalance := int64(0)
+
+	wallets := l.WL.SortedWalletList()
+	if len(wallets) == 0 {
+		return 0, 0, nil
+	}
+
+	for _, wallet := range wallets {
+		accountsResult, err := wallet.GetAccountsRaw()
+		if err != nil {
+			return 0, 0, err
+		}
+
+		for _, account := range accountsResult.Acc {
+			totalBalance += account.TotalBalance
+			spandableBalance += account.Balance.Spendable
+		}
+	}
+
+	return dcrutil.Amount(totalBalance), dcrutil.Amount(spandableBalance), nil
+}

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -298,27 +298,6 @@ func (mp *MainPage) updateBalance() {
 	}
 }
 
-// func (mp *MainPage) CalculateTotalWalletsBalance() (dcrutil.Amount, error) {
-// 	totalBalance := int64(0)
-// wallets := mp.WL.SortedWalletList()
-// 	if len(wallets) == 0 {
-// 		return 0, nil
-// 	}
-
-// 	for _, wallet := range wallets {
-// 		accountsResult, err := wallet.GetAccountsRaw()
-// 		if err != nil {
-// 			return 0, err
-// 		}
-
-// 		for _, account := range accountsResult.Acc {
-// 			totalBalance += account.TotalBalance
-// 		}
-// 	}
-
-// 	return dcrutil.Amount(totalBalance), nil
-// }
-
 func (mp *MainPage) StartSyncing() {
 	for _, wal := range mp.WL.SortedWalletList() {
 		if !wal.HasDiscoveredAccounts && wal.IsLocked() {

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -284,7 +284,7 @@ func (mp *MainPage) fetchExchangeRate() {
 }
 
 func (mp *MainPage) updateBalance() {
-	totalBalance, err := mp.CalculateTotalWalletsBalance()
+	totalBalance, _, err := components.CalculateTotalWalletsBalance(mp.Load)
 	if err == nil {
 		mp.totalBalance = totalBalance
 
@@ -298,26 +298,26 @@ func (mp *MainPage) updateBalance() {
 	}
 }
 
-func (mp *MainPage) CalculateTotalWalletsBalance() (dcrutil.Amount, error) {
-	totalBalance := int64(0)
-	wallets := mp.WL.SortedWalletList()
-	if len(wallets) == 0 {
-		return 0, nil
-	}
+// func (mp *MainPage) CalculateTotalWalletsBalance() (dcrutil.Amount, error) {
+// 	totalBalance := int64(0)
+// wallets := mp.WL.SortedWalletList()
+// 	if len(wallets) == 0 {
+// 		return 0, nil
+// 	}
 
-	for _, wallet := range wallets {
-		accountsResult, err := wallet.GetAccountsRaw()
-		if err != nil {
-			return 0, err
-		}
+// 	for _, wallet := range wallets {
+// 		accountsResult, err := wallet.GetAccountsRaw()
+// 		if err != nil {
+// 			return 0, err
+// 		}
 
-		for _, account := range accountsResult.Acc {
-			totalBalance += account.TotalBalance
-		}
-	}
+// 		for _, account := range accountsResult.Acc {
+// 			totalBalance += account.TotalBalance
+// 		}
+// 	}
 
-	return dcrutil.Amount(totalBalance), nil
-}
+// 	return dcrutil.Amount(totalBalance), nil
+// }
 
 func (mp *MainPage) StartSyncing() {
 	for _, wal := range mp.WL.SortedWalletList() {

--- a/ui/page/staking/balance_layout.go
+++ b/ui/page/staking/balance_layout.go
@@ -76,7 +76,7 @@ func (pg *Page) walletBalanceLayout(gtx C) D {
 }
 
 func (pg *Page) layoutIconAndText(gtx C, title string, val string, col color.NRGBA) D {
-	return layout.Inset{Right: values.MarginPadding8}.Layout(gtx, func(gtx C) D {
+	return layout.Inset{Right: values.MarginPadding12}.Layout(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
 				return layout.Inset{Right: values.MarginPadding5, Top: values.MarginPadding5}.Layout(gtx, func(gtx C) D {
@@ -86,12 +86,12 @@ func (pg *Page) layoutIconAndText(gtx C, title string, val string, col color.NRG
 				})
 			}),
 			layout.Rigid(func(gtx C) D {
-				txt := pg.Theme.Label(values.TextSize12, title)
+				txt := pg.Theme.Label(values.TextSize14, title)
 				txt.Color = pg.Theme.Color.GrayText2
 				return txt.Layout(gtx)
 			}),
 			layout.Rigid(func(gtx C) D {
-				txt := pg.Theme.Label(values.TextSize12, val)
+				txt := pg.Theme.Label(values.TextSize14, val)
 				txt.Color = pg.Theme.Color.GrayText2
 				return txt.Layout(gtx)
 			}),

--- a/ui/page/staking/balance_layout.go
+++ b/ui/page/staking/balance_layout.go
@@ -1,0 +1,57 @@
+package staking
+
+import (
+	"gioui.org/layout"
+
+	"github.com/planetdecred/godcr/ui/decredmaterial"
+	"github.com/planetdecred/godcr/ui/page/components"
+	"github.com/planetdecred/godcr/ui/values"
+)
+
+func (pg *Page) walletBalanceLayout(gtx C) D {
+	return pg.pageSections(gtx, func(gtx C) D {
+		return layout.Flex{Spacing: layout.SpaceBetween}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				return layout.Flex{}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						txt := pg.Theme.Label(values.TextSize14, "Balance:")
+						txt.Color = pg.Theme.Color.GrayText2
+						return txt.Layout(gtx)
+					}),
+					layout.Rigid(func(gtx C) D {
+						txt := pg.Theme.Label(values.TextSize14, "")
+						txt.Color = pg.Theme.Color.GrayText2
+
+						totalBalance, _, err := components.CalculateTotalWalletsBalance(pg.Load)
+						if err == nil {
+							txt.Text = totalBalance.String()
+						} else {
+							txt.Text = err.Error()
+						}
+						return layout.Inset{
+							Left:  values.MarginPadding5,
+							Right: values.MarginPadding16,
+						}.Layout(gtx, txt.Layout)
+					}),
+				)
+			}),
+			layout.Rigid(func(gtx C) D {
+				totalBalance, spendable, _ := components.CalculateTotalWalletsBalance(pg.Load)
+				locked := totalBalance - spendable
+				items := []decredmaterial.ProgressBarItem{
+					{
+						Value:   float32(spendable.ToCoin()),
+						Color:   pg.Theme.Color.Primary,
+						SubText: "Spendable",
+					},
+					{
+						Value:   float32(locked.ToCoin()),
+						Color:   pg.Theme.Color.Danger,
+						SubText: "Locked",
+					},
+				}
+				return pg.Theme.MultiLayerProgressBar(float32(totalBalance.ToCoin()), items).Layout(gtx)
+			}),
+		)
+	})
+}

--- a/ui/page/staking/balance_layout.go
+++ b/ui/page/staking/balance_layout.go
@@ -1,6 +1,8 @@
 package staking
 
 import (
+	"image/color"
+
 	"gioui.org/layout"
 
 	"github.com/planetdecred/godcr/ui/decredmaterial"
@@ -10,30 +12,36 @@ import (
 
 func (pg *Page) walletBalanceLayout(gtx C) D {
 	return pg.pageSections(gtx, func(gtx C) D {
-		return layout.Flex{Spacing: layout.SpaceBetween}.Layout(gtx,
+		return layout.Flex{
+			Spacing:   layout.SpaceBetween,
+			Alignment: layout.End,
+			Axis:      layout.Vertical,
+		}.Layout(gtx,
 			layout.Rigid(func(gtx C) D {
-				return layout.Flex{}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
-						txt := pg.Theme.Label(values.TextSize14, "Balance:")
-						txt.Color = pg.Theme.Color.GrayText2
-						return txt.Layout(gtx)
-					}),
-					layout.Rigid(func(gtx C) D {
-						txt := pg.Theme.Label(values.TextSize14, "")
-						txt.Color = pg.Theme.Color.GrayText2
+				return layout.Inset{Bottom: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
+					return layout.Flex{}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							txt := pg.Theme.Label(values.TextSize14, "Balance:")
+							txt.Color = pg.Theme.Color.GrayText2
+							return txt.Layout(gtx)
+						}),
+						layout.Rigid(func(gtx C) D {
+							txt := pg.Theme.Label(values.TextSize14, "")
+							txt.Color = pg.Theme.Color.GrayText2
 
-						totalBalance, _, err := components.CalculateTotalWalletsBalance(pg.Load)
-						if err == nil {
-							txt.Text = totalBalance.String()
-						} else {
-							txt.Text = err.Error()
-						}
-						return layout.Inset{
-							Left:  values.MarginPadding5,
-							Right: values.MarginPadding16,
-						}.Layout(gtx, txt.Layout)
-					}),
-				)
+							totalBalance, _, err := components.CalculateTotalWalletsBalance(pg.Load)
+							if err == nil {
+								txt.Text = totalBalance.String()
+							} else {
+								txt.Text = err.Error()
+							}
+							return layout.Inset{
+								Left:  values.MarginPadding5,
+								Right: values.MarginPadding16,
+							}.Layout(gtx, txt.Layout)
+						}),
+					)
+				})
 			}),
 			layout.Rigid(func(gtx C) D {
 				totalBalance, spendable, _ := components.CalculateTotalWalletsBalance(pg.Load)
@@ -41,16 +49,51 @@ func (pg *Page) walletBalanceLayout(gtx C) D {
 				items := []decredmaterial.ProgressBarItem{
 					{
 						Value:   float32(spendable.ToCoin()),
-						Color:   pg.Theme.Color.Primary,
+						Color:   pg.Theme.Color.Turquoise300,
 						SubText: "Spendable",
 					},
 					{
 						Value:   float32(locked.ToCoin()),
-						Color:   pg.Theme.Color.Danger,
+						Color:   pg.Theme.Color.PrimaryHighlight,
 						SubText: "Locked",
 					},
 				}
-				return pg.Theme.MultiLayerProgressBar(float32(totalBalance.ToCoin()), items).Layout(gtx)
+
+				labelWdg := func(gtx C) D {
+					return layout.Flex{}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							return pg.layoutIconAndText(gtx, "Spendable: ", spendable.String(), items[0].Color)
+						}),
+						layout.Rigid(func(gtx C) D {
+							return pg.layoutIconAndText(gtx, "Locked: ", locked.String(), items[1].Color)
+						}),
+					)
+				}
+				return pg.Theme.MultiLayerProgressBar(float32(totalBalance.ToCoin()), items).Layout(gtx, labelWdg)
+			}),
+		)
+	})
+}
+
+func (pg *Page) layoutIconAndText(gtx C, title string, val string, col color.NRGBA) D {
+	return layout.Inset{Right: values.MarginPadding8}.Layout(gtx, func(gtx C) D {
+		return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				return layout.Inset{Right: values.MarginPadding5, Top: values.MarginPadding5}.Layout(gtx, func(gtx C) D {
+					ic := decredmaterial.NewIcon(pg.Icons.ImageBrightness1)
+					ic.Color = col
+					return ic.Layout(gtx, values.MarginPadding8)
+				})
+			}),
+			layout.Rigid(func(gtx C) D {
+				txt := pg.Theme.Label(values.TextSize12, title)
+				txt.Color = pg.Theme.Color.GrayText2
+				return txt.Layout(gtx)
+			}),
+			layout.Rigid(func(gtx C) D {
+				txt := pg.Theme.Label(values.TextSize12, val)
+				txt.Color = pg.Theme.Color.GrayText2
+				return txt.Layout(gtx)
 			}),
 		)
 	})

--- a/ui/page/staking/live_stake_record.go
+++ b/ui/page/staking/live_stake_record.go
@@ -1,0 +1,188 @@
+package staking
+
+import (
+	"fmt"
+	"image/color"
+
+	"gioui.org/layout"
+
+	"github.com/planetdecred/godcr/ui/decredmaterial"
+	"github.com/planetdecred/godcr/ui/load"
+	"github.com/planetdecred/godcr/ui/page/components"
+	"github.com/planetdecred/godcr/ui/values"
+)
+
+func (pg *Page) initLiveStakeWidget() *Page {
+	pg.toTickets = pg.Theme.TextAndIconButton("See All", pg.Icons.NavigationArrowForward)
+	pg.toTickets.Color = pg.Theme.Color.Primary
+	pg.toTickets.BackgroundColor = color.NRGBA{}
+
+	pg.ticketsLive = pg.Theme.NewClickableList(layout.Vertical)
+
+	return pg
+}
+
+func (pg *Page) stakeLiveSection(gtx layout.Context) layout.Dimensions {
+	return pg.pageSections(gtx, func(gtx C) D {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				return layout.Inset{Bottom: values.MarginPadding14}.Layout(gtx, func(gtx C) D {
+					title := pg.Theme.Label(values.TextSize14, "Live Tickets")
+					title.Color = pg.Theme.Color.GrayText2
+					return pg.titleRow(gtx, title.Layout, func(gtx C) D {
+						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+							pg.stakingCountIcon(pg.Icons.TicketUnminedIcon, pg.ticketOverview.Unmined),
+							pg.stakingCountIcon(pg.Icons.TicketImmatureIcon, pg.ticketOverview.Immature),
+							pg.stakingCountIcon(pg.Icons.TicketLiveIcon, pg.ticketOverview.Live),
+							layout.Rigid(func(gtx C) D {
+								if len(pg.liveTickets) > 0 {
+									return pg.toTickets.Layout(gtx)
+								}
+								return D{}
+							}),
+						)
+					})
+				})
+			}),
+			layout.Rigid(func(gtx C) D {
+				if len(pg.liveTickets) == 0 {
+					noLiveStake := pg.Theme.Label(values.TextSize16, "No live tickets yet.")
+					noLiveStake.Color = pg.Theme.Color.GrayText3
+					return noLiveStake.Layout(gtx)
+				}
+				return pg.ticketsLive.Layout(gtx, len(pg.liveTickets), func(gtx C, index int) D {
+					return ticketListLayout(gtx, pg.Load, pg.liveTickets[index], index, true)
+				})
+			}),
+		)
+	})
+}
+
+func (pg *Page) stakingCountIcon(icon *decredmaterial.Image, count int) layout.FlexChild {
+	return layout.Rigid(func(gtx C) D {
+		if count == 0 {
+			return D{}
+		}
+		return layout.Inset{Right: values.MarginPadding14}.Layout(gtx, func(gtx C) D {
+			return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					return icon.Layout16dp(gtx)
+				}),
+				layout.Rigid(func(gtx C) D {
+					return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, func(gtx C) D {
+						label := pg.Theme.Label(values.TextSize14, fmt.Sprintf("%d", count))
+						return label.Layout(gtx)
+					})
+				}),
+			)
+		})
+	})
+}
+
+func (pg *Page) stakingRecordSection(gtx C) D {
+	return pg.pageSections(gtx, func(gtx C) D {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				return layout.Inset{
+					Bottom: values.MarginPadding14,
+				}.Layout(gtx, func(gtx C) D {
+					title := pg.Theme.Label(values.TextSize14, "Ticket Record")
+					title.Color = pg.Theme.Color.GrayText2
+
+					if pg.ticketOverview.All == 0 {
+						return pg.titleRow(gtx, title.Layout, func(gtx C) D { return D{} })
+					}
+					return pg.titleRow(gtx, title.Layout, pg.toTickets.Layout)
+				})
+			}),
+			layout.Rigid(func(gtx C) D {
+				wdgs := []layout.Widget{
+					pg.ticketRecordIconCount(pg.Icons.TicketUnminedIcon, pg.ticketOverview.Unmined, "Unmined"),
+					pg.ticketRecordIconCount(pg.Icons.TicketImmatureIcon, pg.ticketOverview.Immature, "Immature"),
+					pg.ticketRecordIconCount(pg.Icons.TicketLiveIcon, pg.ticketOverview.Live, "Live"),
+					pg.ticketRecordIconCount(pg.Icons.TicketVotedIcon, pg.ticketOverview.Voted, "Voted"),
+					pg.ticketRecordIconCount(pg.Icons.TicketExpiredIcon, pg.ticketOverview.Expired, "Expired"),
+					pg.ticketRecordIconCount(pg.Icons.TicketRevokedIcon, pg.ticketOverview.Revoked, "Revoked"),
+				}
+
+				return decredmaterial.GridWrap{
+					Axis:      layout.Horizontal,
+					Alignment: layout.End,
+				}.Layout(gtx, len(wdgs), func(gtx C, i int) D {
+					return wdgs[i](gtx)
+				})
+			}),
+			layout.Rigid(func(gtx C) D {
+				return decredmaterial.LinearLayout{
+					Width:       decredmaterial.MatchParent,
+					Height:      decredmaterial.WrapContent,
+					Background:  pg.Theme.Color.Success2,
+					Padding:     layout.Inset{Top: values.MarginPadding16, Bottom: values.MarginPadding16},
+					Border:      decredmaterial.Border{Radius: decredmaterial.Radius(8)},
+					Direction:   layout.Center,
+					Alignment:   layout.Middle,
+					Orientation: layout.Vertical,
+				}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return layout.Inset{Bottom: values.MarginPadding4}.Layout(gtx, func(gtx C) D {
+							txt := pg.Theme.Label(values.TextSize14, "Rewards Earned")
+							txt.Color = pg.Theme.Color.Turquoise700
+							return txt.Layout(gtx)
+						})
+					}),
+					layout.Rigid(func(gtx C) D {
+						return layout.Flex{}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								ic := pg.Icons.StakeyIcon
+								return layout.Inset{Right: values.MarginPadding6}.Layout(gtx, ic.Layout24dp)
+							}),
+							layout.Rigid(func(gtx C) D {
+								award := pg.Theme.Color.Text
+								noAward := pg.Theme.Color.GrayText3
+								if pg.WL.MultiWallet.ReadBoolConfigValueForKey(load.DarkModeConfigKey, false) {
+									award = pg.Theme.Color.Gray3
+									noAward = pg.Theme.Color.Gray3
+								}
+
+								if pg.totalRewards == "0 DCR" {
+									txt := pg.Theme.Label(values.TextSize16, "Stakey sees no rewards")
+									txt.Color = noAward
+									return txt.Layout(gtx)
+								}
+
+								return components.LayoutBalanceColor(gtx, pg.Load, pg.totalRewards, award)
+							}),
+						)
+					}),
+				)
+			}),
+		)
+	})
+}
+
+func (pg *Page) ticketRecordIconCount(icon *decredmaterial.Image, count int, status string) layout.Widget {
+	return func(gtx C) D {
+		return layout.Inset{Bottom: values.MarginPadding16, Right: values.MarginPadding40}.Layout(gtx, func(gtx C) D {
+			return layout.Flex{}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					return icon.Layout24dp(gtx)
+				}),
+				layout.Rigid(func(gtx C) D {
+					return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, func(gtx C) D {
+						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								label := pg.Theme.Label(values.TextSize16, fmt.Sprintf("%d", count))
+								return label.Layout(gtx)
+							}),
+							layout.Rigid(func(gtx C) D {
+								txt := pg.Theme.Label(values.TextSize12, status)
+								txt.Color = pg.Theme.Color.GrayText2
+								return txt.Layout(gtx)
+							}),
+						)
+					})
+				}),
+			)
+		})
+	}
+}

--- a/ui/page/staking/overview.go
+++ b/ui/page/staking/overview.go
@@ -3,7 +3,6 @@ package staking
 import (
 	"context"
 	"fmt"
-	"image/color"
 
 	"gioui.org/layout"
 	"gioui.org/text"
@@ -34,9 +33,8 @@ type Page struct {
 	ctx       context.Context // page context
 	ctxCancel context.CancelFunc
 
-	ticketPageContainer *layout.List
-	ticketBuyerWallet   *dcrlibwallet.Wallet
-	ticketsLive         *decredmaterial.ClickableList
+	ticketBuyerWallet *dcrlibwallet.Wallet
+	ticketsLive       *decredmaterial.ClickableList
 
 	autoPurchaseSettings *decredmaterial.Clickable
 	autoPurchase         *decredmaterial.Switch
@@ -54,13 +52,6 @@ type Page struct {
 func NewStakingPage(l *load.Load) *Page {
 	pg := &Page{
 		Load: l,
-
-		ticketsLive:          l.Theme.NewClickableList(layout.Vertical),
-		ticketPageContainer:  &layout.List{Axis: layout.Vertical},
-		stakeBtn:             l.Theme.Button("Stake"),
-		autoPurchaseSettings: l.Theme.NewClickable(false),
-		autoPurchase:         l.Theme.Switch(),
-		toTickets:            l.Theme.TextAndIconButton("See All", l.Icons.NavigationArrowForward),
 	}
 
 	pg.list = &widget.List{
@@ -68,10 +59,11 @@ func NewStakingPage(l *load.Load) *Page {
 			Axis: layout.Vertical,
 		},
 	}
-	pg.toTickets.Color = l.Theme.Color.Primary
-	pg.toTickets.BackgroundColor = color.NRGBA{}
 
 	pg.ticketOverview = new(dcrlibwallet.StakingOverview)
+
+	pg.initStakePriceWidget()
+	pg.initLiveStakeWidget()
 	pg.loadPageData()
 
 	return pg
@@ -196,19 +188,13 @@ func (pg *Page) loadPageData() {
 func (pg *Page) Layout(gtx layout.Context) layout.Dimensions {
 	widgets := []layout.Widget{
 		func(ctx layout.Context) layout.Dimensions {
-			return components.UniformHorizontalPadding(gtx, func(gtx layout.Context) layout.Dimensions {
-				return pg.stakePriceSection(gtx)
-			})
+			return components.UniformHorizontalPadding(gtx, pg.stakePriceSection)
 		},
 		func(ctx layout.Context) layout.Dimensions {
-			return components.UniformHorizontalPadding(gtx, func(gtx layout.Context) layout.Dimensions {
-				return pg.stakeLiveSection(gtx)
-			})
+			return components.UniformHorizontalPadding(gtx, pg.stakeLiveSection)
 		},
 		func(ctx layout.Context) layout.Dimensions {
-			return components.UniformHorizontalPadding(gtx, func(gtx layout.Context) layout.Dimensions {
-				return pg.stakingRecordSection(gtx)
-			})
+			return components.UniformHorizontalPadding(gtx, pg.stakingRecordSection)
 		},
 	}
 
@@ -235,258 +221,6 @@ func (pg *Page) titleRow(gtx layout.Context, leftWidget, rightWidget func(C) D) 
 		layout.Rigid(leftWidget),
 		layout.Rigid(rightWidget),
 	)
-}
-
-func (pg *Page) stakePriceSection(gtx layout.Context) layout.Dimensions {
-	return pg.pageSections(gtx, func(gtx C) D {
-		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-			layout.Rigid(func(gtx C) D {
-				return layout.Inset{
-					Bottom: values.MarginPadding11,
-				}.Layout(gtx, func(gtx C) D {
-					leftWg := func(gtx C) D {
-						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								title := pg.Theme.Label(values.TextSize14, "Ticket Price")
-								title.Color = pg.Theme.Color.GrayText2
-								return title.Layout(gtx)
-							}),
-							layout.Rigid(func(gtx C) D {
-								return layout.Inset{
-									Left:  values.MarginPadding8,
-									Right: values.MarginPadding4,
-								}.Layout(gtx, func(gtx C) D {
-									ic := pg.Icons.TimerIcon
-									if pg.WL.MultiWallet.ReadBoolConfigValueForKey(load.DarkModeConfigKey, false) {
-										ic = pg.Icons.TimerDarkMode
-									}
-									return ic.Layout12dp(gtx)
-								})
-							}),
-							layout.Rigid(func(gtx C) D {
-								secs, _ := pg.WL.MultiWallet.NextTicketPriceRemaining()
-								txt := pg.Theme.Label(values.TextSize14, nextTicketRemaining(int(secs)))
-								txt.Color = pg.Theme.Color.GrayText2
-								return txt.Layout(gtx)
-							}),
-						)
-					}
-
-					rightWg := func(gtx C) D {
-						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								icon := pg.Icons.SettingsActiveIcon
-								if pg.ticketBuyerWallet.IsAutoTicketsPurchaseActive() {
-									icon = pg.Icons.SettingsInactiveIcon
-								}
-								return pg.autoPurchaseSettings.Layout(gtx, func(gtx C) D {
-									return icon.Layout24dp(gtx)
-								})
-							}),
-							layout.Rigid(func(gtx C) D {
-								title := pg.Theme.Label(values.TextSize14, "Auto Purchase")
-								title.Color = pg.Theme.Color.GrayText2
-								return layout.Inset{
-									Left:  values.MarginPadding4,
-									Right: values.MarginPadding4,
-								}.Layout(gtx, title.Layout)
-							}),
-							layout.Rigid(pg.autoPurchase.Layout),
-						)
-					}
-					return pg.titleRow(gtx, leftWg, rightWg)
-				})
-			}),
-			layout.Rigid(func(gtx C) D {
-				return layout.Inset{
-					Bottom: values.MarginPadding8,
-				}.Layout(gtx, func(gtx C) D {
-					ic := pg.Icons.NewStakeIcon
-					return layout.Center.Layout(gtx, ic.Layout48dp)
-				})
-			}),
-			layout.Rigid(func(gtx C) D {
-				return layout.Inset{
-					Bottom: values.MarginPadding16,
-				}.Layout(gtx, func(gtx C) D {
-					return layout.Center.Layout(gtx, func(gtx C) D {
-						return components.LayoutBalanceSize(gtx, pg.Load, pg.ticketPrice, values.TextSize28)
-					})
-				})
-			}),
-			layout.Rigid(func(gtx C) D {
-				return layout.Center.Layout(gtx, func(gtx C) D {
-					gtx.Constraints.Min.X = gtx.Px(values.MarginPadding150)
-					return pg.stakeBtn.Layout(gtx)
-				})
-			}),
-		)
-	})
-}
-
-func (pg *Page) stakeLiveSection(gtx layout.Context) layout.Dimensions {
-	return pg.pageSections(gtx, func(gtx C) D {
-		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-			layout.Rigid(func(gtx C) D {
-				return layout.Inset{Bottom: values.MarginPadding14}.Layout(gtx, func(gtx C) D {
-					title := pg.Theme.Label(values.TextSize14, "Live Tickets")
-					title.Color = pg.Theme.Color.GrayText2
-					return pg.titleRow(gtx, title.Layout, func(gtx C) D {
-						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-							pg.stakingCountIcon(pg.Icons.TicketUnminedIcon, pg.ticketOverview.Unmined),
-							pg.stakingCountIcon(pg.Icons.TicketImmatureIcon, pg.ticketOverview.Immature),
-							pg.stakingCountIcon(pg.Icons.TicketLiveIcon, pg.ticketOverview.Live),
-							layout.Rigid(func(gtx C) D {
-								if len(pg.liveTickets) > 0 {
-									return pg.toTickets.Layout(gtx)
-								}
-								return D{}
-							}),
-						)
-					})
-				})
-			}),
-			layout.Rigid(func(gtx C) D {
-				if len(pg.liveTickets) == 0 {
-					noLiveStake := pg.Theme.Label(values.TextSize16, "No active tickets.")
-					noLiveStake.Color = pg.Theme.Color.GrayText3
-					return noLiveStake.Layout(gtx)
-				}
-				return pg.ticketsLive.Layout(gtx, len(pg.liveTickets), func(gtx C, index int) D {
-					return ticketListLayout(gtx, pg.Load, pg.liveTickets[index], index, true)
-				})
-			}),
-		)
-	})
-}
-
-func (pg *Page) stakingCountIcon(icon *decredmaterial.Image, count int) layout.FlexChild {
-	return layout.Rigid(func(gtx C) D {
-		if count == 0 {
-			return D{}
-		}
-		return layout.Inset{Right: values.MarginPadding14}.Layout(gtx, func(gtx C) D {
-			return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
-				layout.Rigid(func(gtx C) D {
-					return icon.Layout16dp(gtx)
-				}),
-				layout.Rigid(func(gtx C) D {
-					return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, func(gtx C) D {
-						label := pg.Theme.Label(values.TextSize14, fmt.Sprintf("%d", count))
-						return label.Layout(gtx)
-					})
-				}),
-			)
-		})
-	})
-}
-
-func (pg *Page) stakingRecordSection(gtx C) D {
-	return pg.pageSections(gtx, func(gtx C) D {
-		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-			layout.Rigid(func(gtx C) D {
-				return layout.Inset{
-					Bottom: values.MarginPadding14,
-				}.Layout(gtx, func(gtx C) D {
-					title := pg.Theme.Label(values.TextSize14, "Ticket Record")
-					title.Color = pg.Theme.Color.GrayText2
-
-					if pg.ticketOverview.All == 0 {
-						return pg.titleRow(gtx, title.Layout, func(gtx C) D { return D{} })
-					}
-					return pg.titleRow(gtx, title.Layout, pg.toTickets.Layout)
-				})
-			}),
-			layout.Rigid(func(gtx C) D {
-				wdgs := []layout.Widget{
-					pg.ticketRecordIconCount(pg.Icons.TicketUnminedIcon, pg.ticketOverview.Unmined, "Unmined"),
-					pg.ticketRecordIconCount(pg.Icons.TicketImmatureIcon, pg.ticketOverview.Immature, "Immature"),
-					pg.ticketRecordIconCount(pg.Icons.TicketLiveIcon, pg.ticketOverview.Live, "Live"),
-					pg.ticketRecordIconCount(pg.Icons.TicketVotedIcon, pg.ticketOverview.Voted, "Voted"),
-					pg.ticketRecordIconCount(pg.Icons.TicketExpiredIcon, pg.ticketOverview.Expired, "Expired"),
-					pg.ticketRecordIconCount(pg.Icons.TicketRevokedIcon, pg.ticketOverview.Revoked, "Revoked"),
-				}
-
-				return decredmaterial.GridWrap{
-					Axis:      layout.Horizontal,
-					Alignment: layout.End,
-				}.Layout(gtx, len(wdgs), func(gtx C, i int) D {
-					return wdgs[i](gtx)
-				})
-			}),
-			layout.Rigid(func(gtx C) D {
-				return decredmaterial.LinearLayout{
-					Width:       decredmaterial.MatchParent,
-					Height:      decredmaterial.WrapContent,
-					Background:  pg.Theme.Color.Success2,
-					Padding:     layout.Inset{Top: values.MarginPadding16, Bottom: values.MarginPadding16},
-					Border:      decredmaterial.Border{Radius: decredmaterial.Radius(8)},
-					Direction:   layout.Center,
-					Alignment:   layout.Middle,
-					Orientation: layout.Vertical,
-				}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
-						return layout.Inset{Bottom: values.MarginPadding4}.Layout(gtx, func(gtx C) D {
-							txt := pg.Theme.Label(values.TextSize14, "Rewards Earned")
-							txt.Color = pg.Theme.Color.Turquoise700
-							return txt.Layout(gtx)
-						})
-					}),
-					layout.Rigid(func(gtx C) D {
-						return layout.Flex{}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								ic := pg.Icons.StakeyIcon
-								return layout.Inset{Right: values.MarginPadding6}.Layout(gtx, ic.Layout24dp)
-							}),
-							layout.Rigid(func(gtx C) D {
-								award := pg.Theme.Color.Text
-								noAward := pg.Theme.Color.GrayText3
-								if pg.WL.MultiWallet.ReadBoolConfigValueForKey(load.DarkModeConfigKey, false) {
-									award = pg.Theme.Color.Gray3
-									noAward = pg.Theme.Color.Gray3
-								}
-
-								if pg.totalRewards == "0 DCR" {
-									txt := pg.Theme.Label(values.TextSize16, "Stakey sees no rewards")
-									txt.Color = noAward
-									return txt.Layout(gtx)
-								}
-
-								return components.LayoutBalanceColor(gtx, pg.Load, pg.totalRewards, award)
-							}),
-						)
-					}),
-				)
-			}),
-		)
-	})
-}
-
-func (pg *Page) ticketRecordIconCount(icon *decredmaterial.Image, count int, status string) layout.Widget {
-	return func(gtx C) D {
-		return layout.Inset{Bottom: values.MarginPadding16, Right: values.MarginPadding40}.Layout(gtx, func(gtx C) D {
-			return layout.Flex{}.Layout(gtx,
-				layout.Rigid(func(gtx C) D {
-					return icon.Layout24dp(gtx)
-				}),
-				layout.Rigid(func(gtx C) D {
-					return layout.Inset{Left: values.MarginPadding4}.Layout(gtx, func(gtx C) D {
-						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-							layout.Rigid(func(gtx C) D {
-								label := pg.Theme.Label(values.TextSize16, fmt.Sprintf("%d", count))
-								return label.Layout(gtx)
-							}),
-							layout.Rigid(func(gtx C) D {
-								txt := pg.Theme.Label(values.TextSize12, status)
-								txt.Color = pg.Theme.Color.GrayText2
-								return txt.Layout(gtx)
-							}),
-						)
-					})
-				}),
-			)
-		})
-	}
 }
 
 // HandleUserInteractions is called just before Layout() to determine

--- a/ui/page/staking/overview.go
+++ b/ui/page/staking/overview.go
@@ -185,30 +185,33 @@ func (pg *Page) loadPageData() {
 // Layout draws the page UI components into the provided layout context
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
-func (pg *Page) Layout(gtx layout.Context) layout.Dimensions {
+func (pg *Page) Layout(gtx C) D {
 	widgets := []layout.Widget{
-		func(ctx layout.Context) layout.Dimensions {
+		func(gtx C) D {
 			return components.UniformHorizontalPadding(gtx, pg.stakePriceSection)
 		},
-		func(ctx layout.Context) layout.Dimensions {
+		func(gtx C) D {
+			return components.UniformHorizontalPadding(gtx, pg.walletBalanceLayout)
+		},
+		func(gtx C) D {
 			return components.UniformHorizontalPadding(gtx, pg.stakeLiveSection)
 		},
-		func(ctx layout.Context) layout.Dimensions {
+		func(gtx C) D {
 			return components.UniformHorizontalPadding(gtx, pg.stakingRecordSection)
 		},
 	}
 
-	return layout.Inset{Top: values.MarginPadding24}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+	return layout.Inset{Top: values.MarginPadding24}.Layout(gtx, func(gtx C) D {
 		return pg.Theme.List(pg.list).Layout(gtx, len(widgets), func(gtx C, i int) D {
 			return widgets[i](gtx)
 		})
 	})
 }
 
-func (pg *Page) pageSections(gtx layout.Context, body layout.Widget) layout.Dimensions {
+func (pg *Page) pageSections(gtx C, body layout.Widget) D {
 	return layout.Inset{
 		Bottom: values.MarginPadding8,
-	}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+	}.Layout(gtx, func(gtx C) D {
 		return pg.Theme.Card().Layout(gtx, func(gtx C) D {
 			gtx.Constraints.Min.X = gtx.Constraints.Max.X
 			return layout.UniformInset(values.MarginPadding16).Layout(gtx, body)
@@ -216,7 +219,7 @@ func (pg *Page) pageSections(gtx layout.Context, body layout.Widget) layout.Dime
 	})
 }
 
-func (pg *Page) titleRow(gtx layout.Context, leftWidget, rightWidget func(C) D) layout.Dimensions {
+func (pg *Page) titleRow(gtx C, leftWidget, rightWidget func(C) D) D {
 	return layout.Flex{Axis: layout.Horizontal, Spacing: layout.SpaceBetween}.Layout(gtx,
 		layout.Rigid(leftWidget),
 		layout.Rigid(rightWidget),

--- a/ui/page/staking/stake_layout.go
+++ b/ui/page/staking/stake_layout.go
@@ -1,0 +1,101 @@
+package staking
+
+import (
+	"gioui.org/layout"
+
+	"github.com/planetdecred/godcr/ui/load"
+	"github.com/planetdecred/godcr/ui/page/components"
+	"github.com/planetdecred/godcr/ui/values"
+)
+
+func (pg *Page) initStakePriceWidget() *Page {
+	pg.stakeBtn = pg.Theme.Button("Stake")
+	pg.autoPurchaseSettings = pg.Theme.NewClickable(false)
+	pg.autoPurchase = pg.Theme.Switch()
+	return pg
+}
+
+func (pg *Page) stakePriceSection(gtx C) D {
+	return pg.pageSections(gtx, func(gtx C) D {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				return layout.Inset{
+					Bottom: values.MarginPadding11,
+				}.Layout(gtx, func(gtx C) D {
+					leftWg := func(gtx C) D {
+						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								title := pg.Theme.Label(values.TextSize14, "Ticket Price")
+								title.Color = pg.Theme.Color.GrayText2
+								return title.Layout(gtx)
+							}),
+							layout.Rigid(func(gtx C) D {
+								return layout.Inset{
+									Left:  values.MarginPadding8,
+									Right: values.MarginPadding4,
+								}.Layout(gtx, func(gtx C) D {
+									ic := pg.Icons.TimerIcon
+									if pg.WL.MultiWallet.ReadBoolConfigValueForKey(load.DarkModeConfigKey, false) {
+										ic = pg.Icons.TimerDarkMode
+									}
+									return ic.Layout12dp(gtx)
+								})
+							}),
+							layout.Rigid(func(gtx C) D {
+								secs, _ := pg.WL.MultiWallet.NextTicketPriceRemaining()
+								txt := pg.Theme.Label(values.TextSize14, nextTicketRemaining(int(secs)))
+								txt.Color = pg.Theme.Color.GrayText2
+								return txt.Layout(gtx)
+							}),
+						)
+					}
+
+					rightWg := func(gtx C) D {
+						return layout.Flex{Alignment: layout.Middle}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								icon := pg.Icons.SettingsActiveIcon
+								if pg.ticketBuyerWallet.IsAutoTicketsPurchaseActive() {
+									icon = pg.Icons.SettingsInactiveIcon
+								}
+								return pg.autoPurchaseSettings.Layout(gtx, icon.Layout24dp)
+							}),
+							layout.Rigid(func(gtx C) D {
+								title := pg.Theme.Label(values.TextSize14, "Auto Purchase")
+								title.Color = pg.Theme.Color.GrayText2
+								return layout.Inset{
+									Left:  values.MarginPadding4,
+									Right: values.MarginPadding4,
+								}.Layout(gtx, title.Layout)
+							}),
+							layout.Rigid(pg.autoPurchase.Layout),
+						)
+					}
+					return pg.titleRow(gtx, leftWg, rightWg)
+				})
+			}),
+			layout.Rigid(func(gtx C) D {
+				return layout.Inset{
+					Bottom: values.MarginPadding8,
+				}.Layout(gtx, func(gtx C) D {
+					ic := pg.Icons.NewStakeIcon
+					return layout.Center.Layout(gtx, ic.Layout48dp)
+				})
+			}),
+			layout.Rigid(func(gtx C) D {
+				return layout.Inset{
+					Bottom: values.MarginPadding16,
+				}.Layout(gtx, func(gtx C) D {
+					return layout.Center.Layout(gtx, func(gtx C) D {
+						return components.LayoutBalanceSize(gtx, pg.Load, pg.ticketPrice, values.TextSize28)
+					})
+				})
+			}),
+			layout.Rigid(func(gtx C) D {
+				return layout.Center.Layout(gtx, func(gtx C) D {
+					gtx.Constraints.Min.X = gtx.Px(values.MarginPadding150)
+					return pg.stakeBtn.Layout(gtx)
+				})
+			}),
+		)
+	})
+}


### PR DESCRIPTION
Fix #781

This PR add total wallet balance to the staking page with progress bar showing locked and spendable balance.

<img width="800" alt="image" src="https://user-images.githubusercontent.com/27733432/161827895-728f2fac-41e3-401a-a701-a3b871c39c3e.png">

The use of a vertical alignment layout instead of the horizontal alignment was due to space constraint as the balance tend to wrap to the next line.

<img width="797" alt="image" src="https://user-images.githubusercontent.com/27733432/161828303-460253bb-05dd-4a32-a371-bf52590f6c68.png">

* Possible options are 
<img width="592" alt="image" src="https://user-images.githubusercontent.com/27733432/161828240-484ffe1e-45e3-4414-a1f7-3c123e084574.png">
