### PR TITLE
Mulit: hide reset dex option, Hide advanced send option

### DIFF
--- a/ui/page/debug_page.go
+++ b/ui/page/debug_page.go
@@ -52,12 +52,12 @@ func NewDebugPage(l *load.Load) *DebugPage {
 	pg.list.Radius = decredmaterial.Radius(14)
 
 	// Add a "Reset DEX Client" option.
-	pg.debugItems = append(pg.debugItems, debugItem{
-		text: "Reset DEX Client",
-		action: func() {
-			pg.resetDexData()
-		},
-	})
+	// pg.debugItems = append(pg.debugItems, debugItem{
+	// 	text: "Reset DEX Client",
+	// 	action: func() {
+	// 		pg.resetDexData()
+	// 	},
+	// })
 
 	pg.backButton, _ = components.SubpageHeaderButtons(l)
 

--- a/ui/page/debug_page.go
+++ b/ui/page/debug_page.go
@@ -51,6 +51,7 @@ func NewDebugPage(l *load.Load) *DebugPage {
 	}
 	pg.list.Radius = decredmaterial.Radius(14)
 
+	// TODO: temp removal till V1.0 is release
 	// Add a "Reset DEX Client" option.
 	// pg.debugItems = append(pg.debugItems, debugItem{
 	// 	text: "Reset DEX Client",

--- a/ui/page/send/layout.go
+++ b/ui/page/send/layout.go
@@ -90,14 +90,15 @@ func (pg *Page) topNav(gtx layout.Context) layout.Dimensions {
 
 func (pg *Page) getMoreItem() []moreItem {
 	return []moreItem{
-		{
-			text:   "Advanced mode",
-			button: pg.Theme.NewClickable(true),
-			id:     UTXOPageID,
-			action: func() {
-				pg.ChangeFragment(NewUTXOPage(pg.Load, pg.sourceAccountSelector.SelectedAccount()))
-			},
-		},
+		// TODO: temp removal till issue #658 is resolved and V1.0 is release
+		// {
+		// 	text:   "Advanced mode",
+		// 	button: pg.Theme.NewClickable(true),
+		// 	id:     UTXOPageID,
+		// 	action: func() {
+		// 		pg.ChangeFragment(NewUTXOPage(pg.Load, pg.sourceAccountSelector.SelectedAccount()))
+		// 	},
+		// },
 		{
 			text:   "Clear all fields",
 			button: pg.Theme.NewClickable(true),


### PR DESCRIPTION
Fix #819 
Fix #833
This Pr hides the advanced send option on the send page.
Also hides the reset dex option on the debug page.