### PR TITLE
add modal for redirect url

### DIFF
--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -26,6 +26,7 @@ type InfoModal struct {
 	dialogTitle    string
 	subtitle       string
 	customTemplate []layout.Widget
+	customWidget   layout.Widget
 
 	positiveButtonText    string
 	positiveButtonClicked func()
@@ -160,6 +161,11 @@ func (in *InfoModal) SetupWithTemplate(template string) *InfoModal {
 	return in
 }
 
+func (in *InfoModal) UseCustomWidget(layout layout.Widget) *InfoModal {
+	in.customWidget = layout
+	return in
+}
+
 func (in *InfoModal) dismissModalOnEnterKey() {
 	go func() {
 		for {
@@ -248,6 +254,10 @@ func (in *InfoModal) Layout(gtx layout.Context) D {
 
 	if in.checkbox.CheckBox != nil {
 		w = append(w, checkbox)
+	}
+
+	if in.customWidget != nil {
+		w = append(w, in.customWidget)
 	}
 
 	if in.negativeButtonText != "" || in.positiveButtonText != "" {

--- a/ui/page/governance/consensus_page.go
+++ b/ui/page/governance/consensus_page.go
@@ -126,8 +126,8 @@ func (pg *ConsensusPage) HandleUserInteractions() {
 		}
 
 		info := modal.NewInfoModal(pg.Load).
-			Title("View on Politeia").
-			Body("Copy the link below to your browser.").
+			Title("Consensus Vote Dashboard").
+			Body("Copy and paste the link below in your browser, to the view consensus vote dashboard.").
 			SetCancelable(true).
 			UseCustomWidget(func(gtx C) D {
 				return layout.Stack{}.Layout(gtx,
@@ -144,7 +144,7 @@ func (pg *ConsensusPage) HandleUserInteractions() {
 											return layout.E.Layout(gtx, func(gtx C) D {
 												if pg.copyRedirectURL.Clicked() {
 													clipboard.WriteOp{Text: host}.Add(gtx.Ops)
-													pg.Toast.Notify("Web link copied")
+													pg.Toast.Notify("URL copied")
 												}
 												return pg.copyRedirectURL.Layout(gtx, pg.Icons.CopyIcon.Layout24dp)
 											})

--- a/ui/page/governance/consensus_page.go
+++ b/ui/page/governance/consensus_page.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"gioui.org/font/gofont"
+	"gioui.org/io/clipboard"
 	"gioui.org/layout"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
@@ -33,6 +34,7 @@ type ConsensusPage struct {
 	listContainer       *widget.List
 	syncButton          *widget.Clickable
 	viewVotingDashboard *decredmaterial.Clickable
+	copyRedirectURL     *decredmaterial.Clickable
 	redirectIcon        *decredmaterial.Image
 
 	walletDropDown *decredmaterial.DropDown
@@ -57,7 +59,8 @@ func NewConsensusPage(l *load.Load) *ConsensusPage {
 		},
 		syncButton:          new(widget.Clickable),
 		redirectIcon:        l.Icons.RedirectIcon,
-		viewVotingDashboard: l.Theme.NewClickable(true),
+		viewVotingDashboard: l.Theme.NewClickable(false),
+		copyRedirectURL:     l.Theme.NewClickable(false),
 	}
 
 	pg.searchEditor = l.Theme.IconEditor(new(widget.Editor), "Search", l.Icons.SearchIcon, true)
@@ -122,7 +125,49 @@ func (pg *ConsensusPage) HandleUserInteractions() {
 			host = "https://voting.decred.org/testnet"
 		}
 
-		components.GoToURL(host)
+		info := modal.NewInfoModal(pg.Load).
+			Title("View on Politeia").
+			Body("Copy the link below to your browser.").
+			SetCancelable(true).
+			UseCustomWidget(func(gtx C) D {
+				return layout.Stack{}.Layout(gtx,
+					layout.Stacked(func(gtx C) D {
+						border := widget.Border{Color: pg.Theme.Color.Gray4, CornerRadius: values.MarginPadding10, Width: values.MarginPadding2}
+						wrapper := pg.Theme.Card()
+						wrapper.Color = pg.Theme.Color.Gray4
+						return border.Layout(gtx, func(gtx C) D {
+							return wrapper.Layout(gtx, func(gtx C) D {
+								return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
+									return layout.Flex{}.Layout(gtx,
+										layout.Flexed(0.9, pg.Theme.Body1(host).Layout),
+										layout.Flexed(0.1, func(gtx C) D {
+											return layout.E.Layout(gtx, func(gtx C) D {
+												if pg.copyRedirectURL.Clicked() {
+													clipboard.WriteOp{Text: host}.Add(gtx.Ops)
+													pg.Toast.Notify("Web link copied")
+												}
+												return pg.copyRedirectURL.Layout(gtx, pg.Icons.CopyIcon.Layout24dp)
+											})
+										}),
+									)
+								})
+							})
+						})
+					}),
+					layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+						return layout.Inset{
+							Top:  values.MarginPaddingMinus10,
+							Left: values.MarginPadding10,
+						}.Layout(gtx, func(gtx C) D {
+							label := pg.Theme.Body2("Web URL")
+							label.Color = pg.Theme.Color.GrayText2
+							return label.Layout(gtx)
+						})
+					}),
+				)
+			}).
+			PositiveButton("Got it", func() {})
+		pg.ShowModal(info)
 	}
 
 	if pg.syncCompleted {

--- a/ui/page/governance/proposal_details_page.go
+++ b/ui/page/governance/proposal_details_page.go
@@ -140,7 +140,7 @@ func (pg *ProposalDetails) HandleUserInteractions() {
 
 		info := modal.NewInfoModal(pg.Load).
 			Title("View on Politeia").
-			Body("Copy the link below to your browser.").
+			Body("Copy and paste the link below in your browser, to view proposal on Politeia dashboard.").
 			SetCancelable(true).
 			UseCustomWidget(func(gtx C) D {
 				return layout.Stack{}.Layout(gtx,
@@ -158,7 +158,7 @@ func (pg *ProposalDetails) HandleUserInteractions() {
 												return layout.Inset{Top: values.MarginPadding7}.Layout(gtx, func(gtx C) D {
 													if pg.copyRedirectURL.Clicked() {
 														clipboard.WriteOp{Text: host}.Add(gtx.Ops)
-														pg.Toast.Notify("Web link copied")
+														pg.Toast.Notify("URL copied")
 													}
 													return pg.copyRedirectURL.Layout(gtx, pg.Icons.CopyIcon.Layout24dp)
 												})
@@ -208,13 +208,13 @@ func (pg *ProposalDetails) listenForSyncNotifications() {
 						pg.RefreshWindow()
 					}
 				}
-			// not needed as lsitner as been set up on main.go
+			// is this really needed since listener has been set up on main.go
 			case <-pg.ctx.Done():
-				// 	pg.WL.MultiWallet.Politeia.RemoveNotificationListener(ProposalDetailsPageID)
+				pg.WL.MultiWallet.Politeia.RemoveNotificationListener(ProposalDetailsPageID)
 				close(pg.ProposalNotifChan)
-				// 	pg.ProposalNotificationListener = nil
+				pg.ProposalNotificationListener = nil
 
-				// 	return
+				return
 			}
 		}
 	}()

--- a/ui/page/governance/proposal_details_page.go
+++ b/ui/page/governance/proposal_details_page.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"gioui.org/io/clipboard"
 	"gioui.org/layout"
 	"gioui.org/text"
 	"gioui.org/unit"
@@ -15,6 +16,7 @@ import (
 	"github.com/planetdecred/godcr/listeners"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
+	"github.com/planetdecred/godcr/ui/modal"
 	"github.com/planetdecred/godcr/ui/page/components"
 	"github.com/planetdecred/godcr/ui/renderers"
 	"github.com/planetdecred/godcr/ui/values"
@@ -30,23 +32,33 @@ type proposalItemWidgets struct {
 
 type ProposalDetails struct {
 	*load.Load
-	*listeners.ProposalNotificationListener
-	ctx                context.Context // page context
-	ctxCancel          context.CancelFunc
+	*listeners.ProposalNotificationListener //not needed.
+
+	ctx       context.Context // page context
+	ctxCancel context.CancelFunc
+
+	descriptionList *layout.List
+
+	proposal      *dcrlibwallet.Proposal
+	proposalItems map[string]proposalItemWidgets
+
+	scrollbarList *widget.List
+	rejectedIcon  *widget.Icon
+	successIcon   *widget.Icon
+
+	redirectIcon *decredmaterial.Image
+	downloadIcon *decredmaterial.Image
+	copyIcon     *decredmaterial.Image
+
+	viewInPoliteiaBtn *decredmaterial.Clickable
+	copyRedirectUrl   *decredmaterial.Clickable
+
+	descriptionCard decredmaterial.Card
+	vote            decredmaterial.Button
+	backButton      decredmaterial.IconButton
+
 	voteBar            *components.VoteBar
 	loadingDescription bool
-	proposal           *dcrlibwallet.Proposal
-	descriptionCard    decredmaterial.Card
-	proposalItems      map[string]proposalItemWidgets
-	descriptionList    *layout.List
-	scrollbarList      *widget.List
-	redirectIcon       *decredmaterial.Image
-	rejectedIcon       *widget.Icon
-	downloadIcon       *decredmaterial.Image
-	successIcon        *widget.Icon
-	vote               decredmaterial.Button
-	backButton         decredmaterial.IconButton
-	viewInPoliteiaBtn  *decredmaterial.Clickable
 }
 
 func NewProposalDetailsPage(l *load.Load, proposal *dcrlibwallet.Proposal) *ProposalDetails {
@@ -65,7 +77,8 @@ func NewProposalDetailsPage(l *load.Load, proposal *dcrlibwallet.Proposal) *Prop
 		proposalItems:     make(map[string]proposalItemWidgets),
 		rejectedIcon:      l.Icons.NavigationCancel,
 		successIcon:       l.Icons.ActionCheckCircle,
-		viewInPoliteiaBtn: l.Theme.NewClickable(true),
+		viewInPoliteiaBtn: l.Theme.NewClickable(false),
+		copyRedirectUrl:   l.Theme.NewClickable(false),
 		voteBar:           components.NewVoteBar(l),
 	}
 
@@ -120,12 +133,56 @@ func (pg *ProposalDetails) HandleUserInteractions() {
 	}
 
 	for pg.viewInPoliteiaBtn.Clicked() {
-		host := "https://proposals.decred.org/record/"
+		host := "https://proposals.decred.org/record/" + pg.proposal.Token
 		if pg.WL.MultiWallet.NetType() == dcrlibwallet.Testnet3 {
-			host = "https://test-proposals.decred.org/record/"
+			host = "https://test-proposals.decred.org/record/" + pg.proposal.Token
 		}
 
-		components.GoToURL(host + pg.proposal.Token)
+		info := modal.NewInfoModal(pg.Load).
+			Title("View on Politeia").
+			Body("Copy the link below to your browser.").
+			UseCustomWidget(func(gtx C) D {
+				// return layout.Rigid(func(gtx C) D {
+				return layout.Stack{}.Layout(gtx,
+					layout.Stacked(func(gtx C) D {
+						border := widget.Border{Color: pg.Theme.Color.Gray4, CornerRadius: values.MarginPadding10, Width: values.MarginPadding2}
+						wrapper := pg.Theme.Card()
+						wrapper.Color = pg.Theme.Color.Gray4
+						return border.Layout(gtx, func(gtx C) D {
+							return wrapper.Layout(gtx, func(gtx C) D {
+								return layout.UniformInset(values.MarginPadding10).Layout(gtx, func(gtx C) D {
+									return layout.Flex{}.Layout(gtx,
+										layout.Flexed(0.9, pg.Theme.Body1(host).Layout),
+										layout.Flexed(0.1, func(gtx C) D {
+											return layout.E.Layout(gtx, func(gtx C) D {
+												return layout.Inset{Top: values.MarginPadding7}.Layout(gtx, func(gtx C) D {
+													if pg.copyRedirectUrl.Clicked() {
+														clipboard.WriteOp{Text: host}.Add(gtx.Ops)
+														pg.Toast.Notify("Web link copied")
+													}
+													return pg.copyRedirectUrl.Layout(gtx, pg.Icons.CopyIcon.Layout24dp)
+												})
+											})
+										}),
+									)
+								})
+							})
+						})
+					}),
+					layout.Stacked(func(gtx layout.Context) layout.Dimensions {
+						return layout.Inset{
+							Top:  values.MarginPaddingMinus10,
+							Left: values.MarginPadding10,
+						}.Layout(gtx, func(gtx C) D {
+							label := pg.Theme.Body2("Web URL")
+							label.Color = pg.Theme.Color.GrayText2
+							return label.Layout(gtx)
+						})
+					}),
+				)
+			}).
+			PositiveButton("Got it", func() {})
+		pg.ShowModal(info)
 	}
 }
 
@@ -151,12 +208,13 @@ func (pg *ProposalDetails) listenForSyncNotifications() {
 						pg.RefreshWindow()
 					}
 				}
+			// not needed as lsitner as been set up on main.go
 			case <-pg.ctx.Done():
-				pg.WL.MultiWallet.Politeia.RemoveNotificationListener(ProposalDetailsPageID)
+				// 	pg.WL.MultiWallet.Politeia.RemoveNotificationListener(ProposalDetailsPageID)
 				close(pg.ProposalNotifChan)
-				pg.ProposalNotificationListener = nil
+				// 	pg.ProposalNotificationListener = nil
 
-				return
+				// 	return
 			}
 		}
 	}()
@@ -502,10 +560,18 @@ func (pg *ProposalDetails) Layout(gtx C) D {
 				)
 			},
 			ExtraItem: pg.viewInPoliteiaBtn,
-			ExtraText: "View on Politeia",
 			Extra: func(gtx C) D {
 				return layout.Inset{}.Layout(gtx, func(gtx C) D {
-					return layout.E.Layout(gtx, pg.redirectIcon.Layout24dp)
+					return layout.E.Layout(gtx, func(gtx C) D {
+						return layout.Flex{}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								return layout.Inset{
+									Top: values.MarginPadding5,
+								}.Layout(gtx, pg.Theme.Caption("View in politeia").Layout)
+							}),
+							layout.Rigid(pg.redirectIcon.Layout24dp),
+						)
+					})
 				})
 			},
 		}

--- a/ui/page/governance/proposal_details_page.go
+++ b/ui/page/governance/proposal_details_page.go
@@ -51,7 +51,7 @@ type ProposalDetails struct {
 	copyIcon     *decredmaterial.Image
 
 	viewInPoliteiaBtn *decredmaterial.Clickable
-	copyRedirectUrl   *decredmaterial.Clickable
+	copyRedirectURL   *decredmaterial.Clickable
 
 	descriptionCard decredmaterial.Card
 	vote            decredmaterial.Button
@@ -78,7 +78,7 @@ func NewProposalDetailsPage(l *load.Load, proposal *dcrlibwallet.Proposal) *Prop
 		rejectedIcon:      l.Icons.NavigationCancel,
 		successIcon:       l.Icons.ActionCheckCircle,
 		viewInPoliteiaBtn: l.Theme.NewClickable(false),
-		copyRedirectUrl:   l.Theme.NewClickable(false),
+		copyRedirectURL:   l.Theme.NewClickable(false),
 		voteBar:           components.NewVoteBar(l),
 	}
 
@@ -141,8 +141,8 @@ func (pg *ProposalDetails) HandleUserInteractions() {
 		info := modal.NewInfoModal(pg.Load).
 			Title("View on Politeia").
 			Body("Copy the link below to your browser.").
+			SetCancelable(true).
 			UseCustomWidget(func(gtx C) D {
-				// return layout.Rigid(func(gtx C) D {
 				return layout.Stack{}.Layout(gtx,
 					layout.Stacked(func(gtx C) D {
 						border := widget.Border{Color: pg.Theme.Color.Gray4, CornerRadius: values.MarginPadding10, Width: values.MarginPadding2}
@@ -156,11 +156,11 @@ func (pg *ProposalDetails) HandleUserInteractions() {
 										layout.Flexed(0.1, func(gtx C) D {
 											return layout.E.Layout(gtx, func(gtx C) D {
 												return layout.Inset{Top: values.MarginPadding7}.Layout(gtx, func(gtx C) D {
-													if pg.copyRedirectUrl.Clicked() {
+													if pg.copyRedirectURL.Clicked() {
 														clipboard.WriteOp{Text: host}.Add(gtx.Ops)
 														pg.Toast.Notify("Web link copied")
 													}
-													return pg.copyRedirectUrl.Layout(gtx, pg.Icons.CopyIcon.Layout24dp)
+													return pg.copyRedirectURL.Layout(gtx, pg.Icons.CopyIcon.Layout24dp)
 												})
 											})
 										}),


### PR DESCRIPTION
fix #837

This PR adds a modal fro copying the redirect url for both consensus and proposals.

It also males the view in politaie text at the top of the page clickable.

<img width="797" alt="image" src="https://user-images.githubusercontent.com/27733432/160814561-cc472799-63f3-4b48-8d5b-cd8f22bba1cd.png">

<img width="789" alt="image" src="https://user-images.githubusercontent.com/27733432/160814637-338e24e9-552b-4ed0-8386-e59f1e17c9bf.png">
