### PR TITLE
Fix seed editor bugs

### DIFF
--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -370,6 +370,7 @@ func (pg *Restore) layoutSeedMenu(gtx layout.Context, optionsSeedMenuIndex int) 
 	m := op.Record(gtx.Ops)
 	inset.Layout(gtx, func(gtx C) D {
 		if !pg.seedEditorChanged() && pg.caretCoordXChanged() {
+			fmt.Println(pg.selected)
 			border := widget.Border{Color: pg.Theme.Color.Gray4, CornerRadius: values.MarginPadding5, Width: values.MarginPadding2}
 			return border.Layout(gtx, func(gtx C) D {
 				return pg.optionsMenuCard.Layout(gtx, func(gtx C) D {
@@ -568,6 +569,7 @@ func (pg *Restore) HandleUserInteractions() {
 
 	if pg.seedEditorChanged() {
 		pg.suggestions = nil
+		pg.selected = 0
 	}
 
 }

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -519,7 +519,7 @@ func (pg *Restore) HandleUserInteractions() {
 	// handle key events
 	select {
 	case evt := <-pg.keyEvent:
-		if evt.Name == key.NameTab && evt.State == key.Press {
+		if evt.Name == key.NameTab && evt.Modifiers != key.ModShift && evt.State == key.Press {
 			if len(pg.suggestions) > 0 {
 				focus := pg.seedEditors.focusIndex
 				pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[pg.selected])

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -62,8 +62,8 @@ type Restore struct {
 
 	seedEditors        seedEditors
 	keyEvent           chan *key.Event
-	seedEditorTracker  int
-	caretCoordXTracker float32
+	seedEditorTracker  int     // stores the current focus index of seed editors
+	caretCoordXTracker float32 //stores the caret coord on the X-axis
 }
 
 func NewRestorePage(l *load.Load, onRestoreComplete func()) *Restore {
@@ -572,6 +572,7 @@ func (pg *Restore) HandleUserInteractions() {
 
 }
 
+// check if seed editor has changed
 func (pg *Restore) seedEditorChanged() bool {
 	focus := pg.seedEditors.focusIndex
 	if pg.seedEditorTracker != focus {
@@ -586,6 +587,7 @@ func (pg *Restore) seedEditorChanged() bool {
 	return false
 }
 
+// Check if caret cordinates on the x-axis has changed
 func (pg *Restore) caretCoordXChanged() bool {
 	focus := pg.seedEditors.focusIndex
 	if focus == -1 {

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -370,7 +370,6 @@ func (pg *Restore) layoutSeedMenu(gtx layout.Context, optionsSeedMenuIndex int) 
 	m := op.Record(gtx.Ops)
 	inset.Layout(gtx, func(gtx C) D {
 		if !pg.seedEditorChanged() && pg.caretCoordXChanged() {
-			fmt.Println(pg.selected)
 			border := widget.Border{Color: pg.Theme.Color.Gray4, CornerRadius: values.MarginPadding5, Width: values.MarginPadding2}
 			return border.Layout(gtx, func(gtx C) D {
 				return pg.optionsMenuCard.Layout(gtx, func(gtx C) D {
@@ -524,9 +523,9 @@ func (pg *Restore) HandleUserInteractions() {
 		if evt.Name == key.NameTab && evt.State == key.Press {
 			if len(pg.suggestions) > 0 {
 				focus := pg.seedEditors.focusIndex
-				pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[0])
+				pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[pg.selected])
 				pg.seedClicked = true
-				pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[0]), -1)
+				pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[pg.selected]), -1)
 			}
 			switchSeedEditors(pg.seedEditors.editors)
 		}

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -403,20 +403,33 @@ func (pg *Restore) updateSeedResetBtn() bool {
 
 func (pg *Restore) validateSeeds() bool {
 	pg.seedPhrase = ""
+	seedMatchCounter := 0
 	for i, editor := range pg.seedEditors.editors {
 		if editor.Edit.Editor.Text() == "" {
 			pg.seedEditors.editors[i].Edit.HintColor = pg.Theme.Color.Danger
 			return false
 		}
 
+		for i := 0; i < len(pg.allSuggestions); i++ {
+			if editor.Edit.Editor.Text() == pg.allSuggestions[i] {
+				seedMatchCounter += 1
+			}
+		}
 		pg.seedPhrase += editor.Edit.Editor.Text() + " "
 	}
 
+	for seedMatchCounter < 33 {
+		return false
+	}
+
+	return true
+}
+
+func (pg *Restore) verifySeedWords() bool {
 	if !dcrlibwallet.VerifySeed(pg.seedPhrase) {
 		pg.Toast.NotifyError("invalid seed phrase")
 		return false
 	}
-
 	return true
 }
 
@@ -449,7 +462,7 @@ func (pg *Restore) HandleUserInteractions() {
 	}
 
 	for pg.validateSeed.Clicked() {
-		if !pg.validateSeeds() {
+		if !pg.validateSeeds() || !pg.verifySeedWords() {
 			return
 		}
 

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -378,10 +378,9 @@ func (pg *Restore) layoutSeedMenu(gtx layout.Context, optionsSeedMenuIndex int) 
 					})
 				})
 			})
-		} else {
-			pg.suggestions = nil
-			return D{}
 		}
+		pg.suggestions = nil
+		return D{}
 	})
 	op.Defer(gtx.Ops, m.Stop())
 }
@@ -501,7 +500,7 @@ func (pg *Restore) HandleUserInteractions() {
 	select {
 	case evt := <-pg.keyEvent:
 		if evt.Name == key.NameTab && evt.State == key.Press {
-			if len(pg.suggestions) == 1 {
+			if len(pg.suggestions) > 0 {
 				focus := pg.seedEditors.focusIndex
 				pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[0])
 				pg.seedClicked = true
@@ -545,6 +544,10 @@ func (pg *Restore) HandleUserInteractions() {
 	pg.editorSeedsEventsHandler()
 	pg.onSuggestionSeedsClicked()
 	pg.suggestionSeedEffect()
+
+	if pg.seedEditorChanged() {
+		pg.suggestions = nil
+	}
 
 }
 

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -493,11 +493,11 @@ func (pg *Restore) HandleUserInteractions() {
 	select {
 	case evt := <-pg.keyEvent:
 		if evt.Name == key.NameTab && evt.State == key.Press {
-			if len(pg.suggestions) == 1 {
+			if len(pg.suggestions) > 0 {
 				focus := pg.seedEditors.focusIndex
-				pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[0])
+				pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[pg.selected])
 				pg.seedClicked = true
-				pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[0]), -1)
+				pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[pg.selected]), -1)
 			}
 			switchSeedEditors(pg.seedEditors.editors)
 		}

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -64,6 +64,7 @@ type Restore struct {
 	keyEvent           chan *key.Event
 	seedEditorTracker  int     // stores the current focus index of seed editors
 	caretCoordXTracker float32 //stores the caret coord on the X-axis
+	caretPosition      int     // current caret position
 }
 
 func NewRestorePage(l *load.Load, onRestoreComplete func()) *Restore {
@@ -569,8 +570,13 @@ func (pg *Restore) HandleUserInteractions() {
 	if pg.seedEditorChanged() {
 		pg.suggestions = nil
 		pg.selected = 0
+		_, caretPos := pg.seedEditors.editors[pg.seedEditors.focusIndex].Edit.Editor.CaretPos()
+		pg.caretPosition = caretPos
 	}
 
+	if pg.caretPositionChanged() {
+		pg.selected = 0
+	}
 }
 
 // check if seed editor has changed
@@ -596,6 +602,22 @@ func (pg *Restore) caretCoordXChanged() bool {
 	}
 
 	return pg.caretCoordXTracker != pg.seedEditors.editors[pg.seedEditors.focusIndex].Edit.Editor.CaretCoords().X
+}
+
+func (pg *Restore) caretPositionChanged() bool {
+	focus := pg.seedEditors.focusIndex
+	if !pg.seedEditorChanged() {
+		if focus == -1 {
+			return false
+		}
+		_, caretPos := pg.seedEditors.editors[pg.seedEditors.focusIndex].Edit.Editor.CaretPos()
+		if pg.caretPosition != caretPos {
+			pg.caretPosition = caretPos
+			return true
+		}
+	}
+
+	return false
 }
 
 // OnNavigatedFrom is called when the page is about to be removed from

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -569,7 +569,6 @@ func (pg *Restore) HandleUserInteractions() {
 
 	if pg.seedEditorChanged() {
 		pg.suggestions = nil
-		pg.selected = 0
 		_, caretPos := pg.seedEditors.editors[pg.seedEditors.focusIndex].Edit.Editor.CaretPos()
 		pg.caretPosition = caretPos
 	}

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -505,13 +505,12 @@ func (pg *Restore) HandleUserInteractions() {
 	// handle key events
 	select {
 	case evt := <-pg.keyEvent:
-		if evt.Name == key.NameTab && evt.Modifiers != key.ModShift && evt.State == key.Press {
-			if len(pg.suggestions) == 1 {
-				focus := pg.seedEditors.focusIndex
-				pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[0])
-				pg.seedClicked = true
-				pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[0]), -1)
-			}
+		if evt.Name == key.NameTab && evt.State == key.Press {
+			focus := pg.seedEditors.focusIndex
+			pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[0])
+			pg.seedClicked = true
+			pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[0]), -1)
+
 			switchSeedEditors(pg.seedEditors.editors)
 		}
 		if evt.Name == key.NameTab && evt.Modifiers == key.ModShift && evt.State == key.Press {

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -380,8 +380,14 @@ func (pg *Restore) layoutSeedMenu(gtx layout.Context, optionsSeedMenuIndex int) 
 
 func (pg Restore) suggestionSeeds(text string) []string {
 	var seeds []string
-	if text == "" {
-		return seeds
+	for _, editor := range pg.seedEditors.editors {
+		if editor.Edit.Editor.Focused() {
+			for i := 0; i < len(pg.allSuggestions); i++ {
+				if editor.Edit.Editor.Text() == pg.allSuggestions[i] || text == "" {
+					return seeds
+				}
+			}
+		}
 	}
 
 	for _, word := range pg.allSuggestions {
@@ -412,7 +418,7 @@ func (pg *Restore) validateSeeds() bool {
 
 		for i := 0; i < len(pg.allSuggestions); i++ {
 			if editor.Edit.Editor.Text() == pg.allSuggestions[i] {
-				seedMatchCounter += 1
+				seedMatchCounter++
 			}
 		}
 		pg.seedPhrase += editor.Edit.Editor.Text() + " "
@@ -506,10 +512,12 @@ func (pg *Restore) HandleUserInteractions() {
 	select {
 	case evt := <-pg.keyEvent:
 		if evt.Name == key.NameTab && evt.State == key.Press {
-			focus := pg.seedEditors.focusIndex
-			pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[0])
-			pg.seedClicked = true
-			pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[0]), -1)
+			if len(pg.suggestions) > 0 {
+				focus := pg.seedEditors.focusIndex
+				pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[0])
+				pg.seedClicked = true
+				pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[0]), -1)
+			}
 
 			switchSeedEditors(pg.seedEditors.editors)
 		}


### PR DESCRIPTION
Resolves #828 
This PR fixes the bugs listed below:
-  invalid suggestions showing up on some seed editors when navigated to.
- ` ìnvaid seed phrase ` error showing up before user has finished entering their seed phrase 

This PR also implements:
- Filling the seed editor with the first suggestion instead of the only suggestion 
- Setting the selected menu item to the first item when the seed editor is changed