### PR TITLE
fix stakeshuffle setup page showing on wallet where its already set up

### DIFF
--- a/ui/page/privacy/setup_privacy_page.go
+++ b/ui/page/privacy/setup_privacy_page.go
@@ -61,10 +61,6 @@ func (pg *SetupPrivacyPage) ID() string {
 // Part of the load.Page interface.
 func (pg *SetupPrivacyPage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
-
-	if pg.wallet.MixedAccountNumber() > 0 && pg.wallet.UnmixedAccountNumber() > 0 {
-		go pg.ChangeFragment(NewAccountMixerPage(pg.Load, pg.wallet))
-	}
 }
 
 // Layout draws the page UI components into the provided layout context

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -277,7 +277,10 @@ func (pg *WalletPage) getWalletMenu(wal *dcrlibwallet.Wallet) []menuItem {
 	if wal.IsWatchingOnlyWallet() {
 		return pg.getWatchOnlyWalletMenu(wal)
 	}
-
+	privacyPageID := privacy.SetupPrivacyPageID
+	if wal.AccountMixerConfigIsSet() {
+		privacyPageID = privacy.AccountMixerPageID
+	}
 	return []menuItem{
 		{
 			text:   values.String(values.StrSignMessage),
@@ -294,7 +297,7 @@ func (pg *WalletPage) getWalletMenu(wal *dcrlibwallet.Wallet) []menuItem {
 			text:     values.String(values.StrStakeShuffle),
 			button:   pg.Theme.NewClickable(true),
 			separate: true,
-			id:       privacy.SetupPrivacyPageID,
+			id:       privacyPageID,
 		},
 		{
 			text:   values.String(values.StrRename),
@@ -1173,6 +1176,8 @@ func (pg *WalletPage) HandleUserInteractions() {
 					pg.ChangeFragment(NewSignMessagePage(pg.Load, listItem.wal))
 				case privacy.SetupPrivacyPageID:
 					pg.ChangeFragment(privacy.NewSetupPrivacyPage(pg.Load, listItem.wal))
+				case privacy.AccountMixerPageID:
+					pg.ChangeFragment(privacy.NewAccountMixerPage(pg.Load, listItem.wal))
 				case WalletSettingsPageID:
 					pg.ChangeFragment(NewWalletSettingsPage(pg.Load, listItem.wal))
 				default:


### PR DESCRIPTION
Closes #864  

This PR stops the StakeShuffle set up page from showing on a wallet where it has already been set up.