### PR TITLE
hide recent proposal section on overview page when there are no proposals

### DIFF
--- a/ui/page/overview/overview_layout.go
+++ b/ui/page/overview/overview_layout.go
@@ -190,7 +190,7 @@ func (pg *AppOverviewPage) Layout(gtx layout.Context) layout.Dimensions {
 			return pg.recentTransactionsSection(gtx)
 		},
 		func(gtx C) D {
-			if pg.WL.Wallet.ReadBoolConfigValueForKey(load.FetchProposalConfigKey) {
+			if pg.WL.Wallet.ReadBoolConfigValueForKey(load.FetchProposalConfigKey) && len(pg.proposalItems) != 0 {
 				return pg.recentProposalsSection(gtx)
 			}
 			return D{}

--- a/ui/page/overview/recent_proposals.go
+++ b/ui/page/overview/recent_proposals.go
@@ -63,9 +63,6 @@ func (pg *AppOverviewPage) recentProposalsSection(gtx C) D {
 				}),
 				layout.Rigid(pg.Theme.Separator().Layout),
 				layout.Rigid(func(gtx C) D {
-					if len(proposalItems) == 0 {
-						return components.LayoutNoProposalsFound(gtx, pg.Load, pg.WL.MultiWallet.Politeia.IsSyncing(), dcrlibwallet.ProposalCategoryAll)
-					}
 					return pg.proposalsList.Layout(gtx, len(proposalItems), func(gtx C, i int) D {
 						return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 							layout.Rigid(func(gtx C) D {


### PR DESCRIPTION
Resolves #877 
When there are no recent proposals the proposal section on the overview page is hidden.