### PR TITLE
filter out watchonly wallets

### DIFF
--- a/ui/page/staking/live_stake_record.go
+++ b/ui/page/staking/live_stake_record.go
@@ -46,7 +46,7 @@ func (pg *Page) stakeLiveSection(gtx layout.Context) layout.Dimensions {
 			}),
 			layout.Rigid(func(gtx C) D {
 				if len(pg.liveTickets) == 0 {
-					noLiveStake := pg.Theme.Label(values.TextSize16, "No live tickets yet.")
+					noLiveStake := pg.Theme.Label(values.TextSize16, "No active tickets.")
 					noLiveStake.Color = pg.Theme.Color.GrayText3
 					return noLiveStake.Layout(gtx)
 				}


### PR DESCRIPTION
Fix #873 

This Pr removes watch only wallets from account selector modal and update no staking phrase.