### PR TITLE
makes wallet page remember expanded state

### DIFF
--- a/ui/decredmaterial/collapsible.go
+++ b/ui/decredmaterial/collapsible.go
@@ -113,18 +113,17 @@ func (c *Collapsible) IsExpanded() bool {
 
 var rememberExpand map[int]bool
 
-func (c *CollapsibleWithOption) Layout(gtx layout.Context, header, body func(C) D, more func(C), walletID int) layout.Dimensions {
+func (c *CollapsibleWithOption) Layout(gtx layout.Context, header, body func(C) D, more func(C), rowID int) layout.Dimensions {
 	if rememberExpand == nil {
 		rememberExpand = make(map[int]bool)
 	}
 
-	for c.button.Clicked() {
-		c.isExpanded = !c.isExpanded
-		rememberExpand[walletID] = c.isExpanded
+	if c.button.Clicked() {
+		rememberExpand[rowID] = !rememberExpand[rowID]
 	}
 
 	icon := c.collapsedIcon
-	if rememberExpand[walletID] {
+	if rememberExpand[rowID] {
 		icon = c.expandedIcon
 	}
 
@@ -155,7 +154,7 @@ func (c *CollapsibleWithOption) Layout(gtx layout.Context, header, body func(C) 
 				})
 			}),
 			layout.Rigid(func(gtx C) D {
-				if rememberExpand[walletID] {
+				if rememberExpand[rowID] {
 					return body(gtx)
 				}
 				return D{}

--- a/ui/decredmaterial/collapsible.go
+++ b/ui/decredmaterial/collapsible.go
@@ -111,13 +111,20 @@ func (c *Collapsible) IsExpanded() bool {
 	return c.isExpanded
 }
 
-func (c *CollapsibleWithOption) Layout(gtx layout.Context, header, body func(C) D, more func(C)) layout.Dimensions {
+var rememberExpand map[int]bool
+
+func (c *CollapsibleWithOption) Layout(gtx layout.Context, header, body func(C) D, more func(C), walletID int) layout.Dimensions {
+	if rememberExpand == nil {
+		rememberExpand = make(map[int]bool)
+	}
+
 	for c.button.Clicked() {
 		c.isExpanded = !c.isExpanded
+		rememberExpand[walletID] = c.isExpanded
 	}
 
 	icon := c.collapsedIcon
-	if c.isExpanded {
+	if rememberExpand[walletID] {
 		icon = c.expandedIcon
 	}
 
@@ -148,7 +155,7 @@ func (c *CollapsibleWithOption) Layout(gtx layout.Context, header, body func(C) 
 				})
 			}),
 			layout.Rigid(func(gtx C) D {
-				if c.isExpanded {
+				if rememberExpand[walletID] {
 					return body(gtx)
 				}
 				return D{}

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -597,7 +597,7 @@ func (pg *WalletPage) walletSection(gtx layout.Context) layout.Dimensions {
 		return layout.Inset{Bottom: values.MarginPadding10}.Layout(gtx, func(gtx C) D {
 			var children []layout.FlexChild
 			children = append(children, layout.Rigid(func(gtx C) D {
-				return listItem.collapsible.Layout(gtx, collapsibleHeader, collapsibleBody, collapsibleMore)
+				return listItem.collapsible.Layout(gtx, collapsibleHeader, collapsibleBody, collapsibleMore, listItem.wal.ID)
 			}))
 
 			if listItem.wal.IsAccountMixerActive() {


### PR DESCRIPTION
Closes #846 

This PR makes it such that when you expand a wallet, click an account to go to the account view, and the return back to the wallets page with the back arrow; the wallets that were expanded, remain expanded.