### PR TITLE
fix crash that occurs when navigating to the consensus page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,3 +23,5 @@ require (
 	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d
 	golang.org/x/text v0.3.7
 )
+
+replace github.com/planetdecred/dcrlibwallet => github.com/dreacot/dcrlibwallet v1.6.1-0.20220413224710-65562e7583c6

--- a/go.mod
+++ b/go.mod
@@ -17,11 +17,9 @@ require (
 	github.com/nxadm/tail v1.4.4
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
-	github.com/planetdecred/dcrlibwallet v1.6.2-0.20220406110328-6579699b4794
+	github.com/planetdecred/dcrlibwallet v1.6.2-0.20220414074738-62281e38109a
 	github.com/yeqown/go-qrcode v1.5.1
 	golang.org/x/exp v0.0.0-20210722180016-6781d3edade3
 	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d
 	golang.org/x/text v0.3.7
 )
-
-replace github.com/planetdecred/dcrlibwallet => github.com/dreacot/dcrlibwallet v1.6.1-0.20220413224710-65562e7583c6

--- a/go.sum
+++ b/go.sum
@@ -473,8 +473,6 @@ github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwu
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/dop251/goja v0.0.0-20211011172007-d99e4b8cbf48/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
-github.com/dreacot/dcrlibwallet v1.6.1-0.20220413224710-65562e7583c6 h1:We2s7E8/Wj7GvUNOVp7h6SWN8bDzz+l4muyn71hcxwM=
-github.com/dreacot/dcrlibwallet v1.6.1-0.20220413224710-65562e7583c6/go.mod h1:d65xdeAh2Z9tm6WDdcAtrjO6Cph4WJDS6uDq6JVNHmM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -915,6 +913,8 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
+github.com/planetdecred/dcrlibwallet v1.6.2-0.20220414074738-62281e38109a h1:doO14vqlC/HX9Mm6gHyEMxz5zk5VdpNYoL6Adg494Ko=
+github.com/planetdecred/dcrlibwallet v1.6.2-0.20220414074738-62281e38109a/go.mod h1:d65xdeAh2Z9tm6WDdcAtrjO6Cph4WJDS6uDq6JVNHmM=
 github.com/planetdecred/dcrlibwallet/dexdcr v0.0.0-20220223161805-c736f970653d h1:egC6nx+qP3QMwKQhA+JdJReKV9NhG17Ag+3oCVCsj3c=
 github.com/planetdecred/dcrlibwallet/dexdcr v0.0.0-20220223161805-c736f970653d/go.mod h1:jO4RP2rgqom8CLgl3rMwZ4cGzmalJqBkKjHgVS812lM=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.sum
+++ b/go.sum
@@ -473,6 +473,8 @@ github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91/go.mod h1:2pZnwu
 github.com/docker/docker v1.4.2-0.20180625184442-8e610b2b55bf/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/dop251/goja v0.0.0-20211011172007-d99e4b8cbf48/go.mod h1:R9ET47fwRVRPZnOGvHxxhuZcbrMCuiqOz3Rlrh4KSnk=
 github.com/dop251/goja_nodejs v0.0.0-20210225215109-d91c329300e7/go.mod h1:hn7BA7c8pLvoGndExHudxTDKZ84Pyvv+90pbBjbTz0Y=
+github.com/dreacot/dcrlibwallet v1.6.1-0.20220413224710-65562e7583c6 h1:We2s7E8/Wj7GvUNOVp7h6SWN8bDzz+l4muyn71hcxwM=
+github.com/dreacot/dcrlibwallet v1.6.1-0.20220413224710-65562e7583c6/go.mod h1:d65xdeAh2Z9tm6WDdcAtrjO6Cph4WJDS6uDq6JVNHmM=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -913,8 +915,6 @@ github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
-github.com/planetdecred/dcrlibwallet v1.6.2-0.20220406110328-6579699b4794 h1:uUfxEDwXVQG4/HVjNM5cOmocOZgDlFOBPhL3FXQOZLw=
-github.com/planetdecred/dcrlibwallet v1.6.2-0.20220406110328-6579699b4794/go.mod h1:d65xdeAh2Z9tm6WDdcAtrjO6Cph4WJDS6uDq6JVNHmM=
 github.com/planetdecred/dcrlibwallet/dexdcr v0.0.0-20220223161805-c736f970653d h1:egC6nx+qP3QMwKQhA+JdJReKV9NhG17Ag+3oCVCsj3c=
 github.com/planetdecred/dcrlibwallet/dexdcr v0.0.0-20220223161805-c736f970653d/go.mod h1:jO4RP2rgqom8CLgl3rMwZ4cGzmalJqBkKjHgVS812lM=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/ui/page/components/consensus_list.go
+++ b/ui/page/components/consensus_list.go
@@ -41,24 +41,42 @@ func layoutAgendaStatus(gtx C, l *load.Load, agenda dcrlibwallet.Agenda) D {
 	var backgroundColor color.NRGBA
 
 	switch agenda.Status {
-	case dcrlibwallet.AgendaStatusFinished:
+	case dcrlibwallet.AgendaStatusFinished.String():
 		statusLabel = l.Theme.Label(values.MarginPadding14, agenda.Status)
 		statusLabel.Color = l.Theme.Color.GreenText
 		statusIcon = decredmaterial.NewIcon(l.Icons.NavigationCheck)
 		statusIcon.Color = l.Theme.Color.Green500
 		backgroundColor = l.Theme.Color.Green50
-	case dcrlibwallet.AgendaStatusInProgress:
+	case dcrlibwallet.AgendaStatusLockedIn.String():
+		statusLabel = l.Theme.Label(values.MarginPadding14, agenda.Status)
+		statusLabel.Color = l.Theme.Color.GreenText
+		statusIcon = decredmaterial.NewIcon(l.Icons.NavigationCheck)
+		statusIcon.Color = l.Theme.Color.Green500
+		backgroundColor = l.Theme.Color.Green50
+	case dcrlibwallet.AgendaStatusFailed.String():
+		statusLabel = l.Theme.Label(values.MarginPadding14, agenda.Status)
+		statusLabel.Color = l.Theme.Color.Text
+		statusIcon = decredmaterial.NewIcon(l.Icons.NavigationCancel)
+		statusIcon.Color = l.Theme.Color.GrayText1
+		backgroundColor = l.Theme.Color.Gray2
+	case dcrlibwallet.AgendaStatusInProgress.String():
 		clr := l.Theme.Color.Primary
 		statusLabel = l.Theme.Label(values.MarginPadding14, agenda.Status)
 		statusLabel.Color = clr
 		statusIcon = decredmaterial.NewIcon(l.Icons.NavMoreIcon)
 		statusIcon.Color = clr
 		backgroundColor = l.Theme.Color.LightBlue
-	case dcrlibwallet.AgendaStatusUpcoming:
+	case dcrlibwallet.AgendaStatusUpcoming.String():
 		statusLabel = l.Theme.Label(values.MarginPadding14, agenda.Status)
 		statusLabel.Color = l.Theme.Color.Text
 		statusIcon = decredmaterial.NewIcon(l.Icons.PlayIcon)
 		statusIcon.Color = l.Theme.Color.DeepBlue
+		backgroundColor = l.Theme.Color.Gray2
+	default:
+		statusLabel = l.Theme.Label(values.MarginPadding14, agenda.Status)
+		statusLabel.Color = l.Theme.Color.Text
+		statusIcon = decredmaterial.NewIcon(l.Icons.NavMoreIcon)
+		statusIcon.Color = l.Theme.Color.GrayText1
 		backgroundColor = l.Theme.Color.Gray2
 	}
 
@@ -101,10 +119,9 @@ func layoutAgendaDetails(l *load.Load, data string) layout.Widget {
 
 func layoutAgendaVoteAction(gtx C, l *load.Load, item *ConsensusItem) D {
 	gtx.Constraints.Min.X, gtx.Constraints.Max.X = gtx.Px(unit.Dp(150)), gtx.Px(unit.Dp(200))
-	if item.Agenda.Status == dcrlibwallet.AgendaStatusFinished {
-		item.VoteButton.Background = l.Theme.Color.Gray3
-		item.VoteButton.SetEnabled(false)
-	} else {
+	item.VoteButton.Background = l.Theme.Color.Gray3
+	item.VoteButton.SetEnabled(false)
+	if item.Agenda.Status == dcrlibwallet.AgendaStatusUpcoming.String() || item.Agenda.Status == dcrlibwallet.AgendaStatusInProgress.String() {
 		item.VoteButton.Background = l.Theme.Color.Primary
 		item.VoteButton.SetEnabled(true)
 	}

--- a/ui/page/components/consensus_list.go
+++ b/ui/page/components/consensus_list.go
@@ -57,7 +57,7 @@ func layoutAgendaStatus(gtx C, l *load.Load, agenda dcrlibwallet.Agenda) D {
 		statusLabel = l.Theme.Label(values.MarginPadding14, agenda.Status)
 		statusLabel.Color = l.Theme.Color.Text
 		statusIcon = decredmaterial.NewIcon(l.Icons.NavigationCancel)
-		statusIcon.Color = l.Theme.Color.GrayText1
+		statusIcon.Color = l.Theme.Color.Gray1
 		backgroundColor = l.Theme.Color.Gray2
 	case dcrlibwallet.AgendaStatusInProgress.String():
 		clr := l.Theme.Color.Primary
@@ -76,7 +76,7 @@ func layoutAgendaStatus(gtx C, l *load.Load, agenda dcrlibwallet.Agenda) D {
 		statusLabel = l.Theme.Label(values.MarginPadding14, agenda.Status)
 		statusLabel.Color = l.Theme.Color.Text
 		statusIcon = decredmaterial.NewIcon(l.Icons.NavMoreIcon)
-		statusIcon.Color = l.Theme.Color.GrayText1
+		statusIcon.Color = l.Theme.Color.Gray1
 		backgroundColor = l.Theme.Color.Gray2
 	}
 


### PR DESCRIPTION
Requires https://github.com/planetdecred/dcrlibwallet/pull/243
Resolves #883

The crash was caused because an agenda type which wasn't accounted for was provided from the API, and there wasn't any assets(icons, colors, etc) provided for the rogue status type, which led to a nil pointer exception.

The fix was to check for all possible agenda status types, and provide assets for them to render to the UI