### PR TITLE
Make shift+tab switch to the previous editor

### DIFF
--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -288,7 +288,7 @@ func HandleEditorEvents(editors ...*widget.Editor) (bool, bool) {
 func SwitchEditors(keyEvent chan *key.Event, editors ...*widget.Editor) {
 	select {
 	case event := <-keyEvent:
-		if event.Name == key.NameTab && event.State == key.Press {
+		if event.Name == key.NameTab && event.Modifiers != key.ModShift && event.State == key.Press {
 			for i := 0; i < len(editors); i++ {
 				if editors[i].Focused() {
 					if i == len(editors)-1 {

--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -285,30 +285,32 @@ func HandleEditorEvents(editors ...*widget.Editor) (bool, bool) {
 	return submit, changed
 }
 
-//Tab key event handler for pages withe ditors
-func HandleTabEvent(event chan *key.Event) bool {
-	var isTabPressed bool
-	select {
-	case event := <-event:
-		if event.Name == key.NameTab && event.State == key.Press {
-			isTabPressed = true
-		}
-	default:
-	}
-	return isTabPressed
-}
-
-//Switch editors when tab key is pressed
 func SwitchEditors(keyEvent chan *key.Event, editors ...*widget.Editor) {
-	for i := 0; i < len(editors); i++ {
-		if editors[i].Focused() {
-			if HandleTabEvent(keyEvent) {
-				if i == len(editors)-1 {
-					editors[0].Focus()
-				} else {
-					editors[i+1].Focus()
+	select {
+	case event := <-keyEvent:
+		if event.Name == key.NameTab && event.State == key.Press {
+			for i := 0; i < len(editors); i++ {
+				if editors[i].Focused() {
+					if i == len(editors)-1 {
+						editors[0].Focus()
+					} else {
+						editors[i+1].Focus()
+					}
 				}
 			}
 		}
+
+		if event.Name == key.NameTab && event.Modifiers == key.ModShift && event.State == key.Press {
+			for i := 0; i < len(editors); i++ {
+				if editors[i].Focused() {
+					if i == 0 {
+						editors[len(editors)-1].Focus()
+					} else {
+						editors[i-1].Focus()
+					}
+				}
+			}
+		}
+	default:
 	}
 }

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -492,7 +492,7 @@ func (pg *Restore) HandleUserInteractions() {
 	// handle key events
 	select {
 	case evt := <-pg.keyEvent:
-		if evt.Name == key.NameTab && evt.State == key.Press {
+		if evt.Name == key.NameTab && evt.Modifiers != key.ModShift && evt.State == key.Press {
 			if len(pg.suggestions) == 1 {
 				focus := pg.seedEditors.focusIndex
 				pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[0])
@@ -500,6 +500,17 @@ func (pg *Restore) HandleUserInteractions() {
 				pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[0]), -1)
 			}
 			switchSeedEditors(pg.seedEditors.editors)
+		}
+		if evt.Name == key.NameTab && evt.Modifiers == key.ModShift && evt.State == key.Press {
+			for i := 0; i < len(pg.seedEditors.editors); i++ {
+				if pg.seedEditors.editors[i].Edit.Editor.Focused() {
+					if i == 0 {
+						pg.seedEditors.editors[len(pg.seedEditors.editors)-1].Edit.Editor.Focus()
+					} else {
+						pg.seedEditors.editors[i-1].Edit.Editor.Focus()
+					}
+				}
+			}
 		}
 		if evt.Name == key.NameUpArrow && pg.openPopupIndex != -1 && evt.State == key.Press {
 			pg.selected--


### PR DESCRIPTION
Closes #844
This PR ensures that Shift+Tab switches to the previous editor when pressed.