### PR TITLE
Staking update

### DIFF
--- a/ui/page/governance/consensus_page.go
+++ b/ui/page/governance/consensus_page.go
@@ -226,21 +226,22 @@ func (pg *ConsensusPage) Layout(gtx C) D {
 							Top: values.MarginPadding60,
 						}.Layout(gtx, pg.layoutContent)
 					}),
-					layout.Expanded(func(gtx C) D {
-						gtx.Constraints.Max.X = gtx.Px(values.MarginPadding150)
-						gtx.Constraints.Min.X = gtx.Constraints.Max.X
+					// layout.Expanded(func(gtx C) D {
+					// 	gtx.Constraints.Max.X = gtx.Px(values.MarginPadding150)
+					// 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
 
-						card := pg.Theme.Card()
-						card.Radius = decredmaterial.Radius(8)
-						return card.Layout(gtx, func(gtx C) D {
-							return layout.Inset{
-								Left:   values.MarginPadding10,
-								Right:  values.MarginPadding10,
-								Top:    values.MarginPadding2,
-								Bottom: values.MarginPadding2,
-							}.Layout(gtx, pg.searchEditor.Layout)
-						})
-					}),
+					//TODO: temp removal till after V1
+					// card := pg.Theme.Card()
+					// card.Radius = decredmaterial.Radius(8)
+					// return card.Layout(gtx, func(gtx C) D {
+					// 	return layout.Inset{
+					// 		Left:   values.MarginPadding10,
+					// 		Right:  values.MarginPadding10,
+					// 		Top:    values.MarginPadding2,
+					// 		Bottom: values.MarginPadding2,
+					// 	}.Layout(gtx, pg.searchEditor.Layout)
+					// })
+					// }),
 					layout.Expanded(func(gtx C) D {
 						gtx.Constraints.Min.X = gtx.Constraints.Max.X
 						return layout.E.Layout(gtx, func(gtx C) D {

--- a/ui/page/governance/proposals_page.go
+++ b/ui/page/governance/proposals_page.go
@@ -223,21 +223,22 @@ func (pg *ProposalsPage) Layout(gtx C) D {
 					layout.Expanded(func(gtx C) D {
 						return layout.Inset{Top: values.MarginPadding60}.Layout(gtx, pg.layoutContent)
 					}),
-					layout.Expanded(func(gtx C) D {
-						gtx.Constraints.Max.X = gtx.Px(values.MarginPadding150)
-						gtx.Constraints.Min.X = gtx.Constraints.Max.X
+					//TODO: temp removal till after V1
+					// layout.Expanded(func(gtx C) D {
+					// 	gtx.Constraints.Max.X = gtx.Px(values.MarginPadding150)
+					// 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
 
-						card := pg.Theme.Card()
-						card.Radius = decredmaterial.Radius(8)
-						return card.Layout(gtx, func(gtx C) D {
-							return layout.Inset{
-								Left:   values.MarginPadding10,
-								Right:  values.MarginPadding10,
-								Top:    values.MarginPadding2,
-								Bottom: values.MarginPadding2,
-							}.Layout(gtx, pg.searchEditor.Layout)
-						})
-					}),
+					// 	card := pg.Theme.Card()
+					// 	card.Radius = decredmaterial.Radius(8)
+					// 	return card.Layout(gtx, func(gtx C) D {
+					// 		return layout.Inset{
+					// 			Left:   values.MarginPadding10,
+					// 			Right:  values.MarginPadding10,
+					// 			Top:    values.MarginPadding2,
+					// 			Bottom: values.MarginPadding2,
+					// 		}.Layout(gtx, pg.searchEditor.Layout)
+					// 	})
+					// }),
 					layout.Expanded(func(gtx C) D {
 						gtx.Constraints.Min.X = gtx.Constraints.Max.X
 						return layout.E.Layout(gtx, func(gtx C) D {

--- a/ui/page/staking/live_stake_record.go
+++ b/ui/page/staking/live_stake_record.go
@@ -46,9 +46,10 @@ func (pg *Page) stakeLiveSection(gtx layout.Context) layout.Dimensions {
 			}),
 			layout.Rigid(func(gtx C) D {
 				if len(pg.liveTickets) == 0 {
-					noLiveStake := pg.Theme.Label(values.TextSize16, "No active tickets.")
+					noLiveStake := pg.Theme.Label(values.TextSize16, "No active tickets")
 					noLiveStake.Color = pg.Theme.Color.GrayText3
-					return noLiveStake.Layout(gtx)
+					gtx.Constraints.Min.X = gtx.Constraints.Max.X
+					return layout.Center.Layout(gtx, noLiveStake.Layout)
 				}
 				return pg.ticketsLive.Layout(gtx, len(pg.liveTickets), func(gtx C, index int) D {
 					return ticketListLayout(gtx, pg.Load, pg.liveTickets[index], index, true)

--- a/ui/page/staking/overview.go
+++ b/ui/page/staking/overview.go
@@ -96,7 +96,7 @@ func (pg *Page) OnNavigatedTo() {
 
 	pg.autoPurchase.SetChecked(pg.ticketBuyerWallet.IsAutoTicketsPurchaseActive())
 
-	pg.setStakingButtons()
+	pg.setStakingButtonsState()
 }
 
 // fetch ticket price only when the wallet is synced
@@ -114,7 +114,7 @@ func (pg *Page) fetchTicketPrice() {
 	}
 }
 
-func (pg *Page) setStakingButtons() {
+func (pg *Page) setStakingButtonsState() {
 	//disable staking btn is wallet is not synced
 	pg.stakeBtn.SetEnabled(pg.WL.MultiWallet.IsSynced())
 
@@ -241,7 +241,23 @@ func (pg *Page) titleRow(gtx C, leftWidget, rightWidget func(C) D) D {
 // displayed.
 // Part of the load.Page interface.
 func (pg *Page) HandleUserInteractions() {
-	pg.setStakingButtons()
+	pg.setStakingButtonsState()
+
+	if pg.stakeBtn.Clicked() {
+		newStakingModal(pg.Load).
+			TicketPurchased(func() {
+				align := layout.Center
+				successIcon := decredmaterial.NewIcon(pg.Icons.ActionCheckCircle)
+				successIcon.Color = pg.Theme.Color.Success
+				info := modal.NewInfoModal(pg.Load).
+					Icon(successIcon).
+					Title("Ticket(s) Confirmed").
+					SetContentAlignment(align, align).
+					PositiveButton("Back to staking", func() {})
+				pg.ShowModal(info)
+				pg.loadPageData()
+			}).Show()
+	}
 
 	if pg.toTickets.Button.Clicked() {
 		pg.ChangeFragment(newListPage(pg.Load))

--- a/ui/page/staking/overview.go
+++ b/ui/page/staking/overview.go
@@ -14,10 +14,8 @@ import (
 	"github.com/planetdecred/godcr/ui/load"
 	"github.com/planetdecred/godcr/ui/modal"
 	"github.com/planetdecred/godcr/ui/page/components"
-	// "github.com/planetdecred/godcr/ui/page/overview"
 	tpage "github.com/planetdecred/godcr/ui/page/transaction"
 	"github.com/planetdecred/godcr/ui/values"
-	// "github.com/planetdecred/godcr/wallet"
 )
 
 type (
@@ -247,7 +245,7 @@ func (pg *Page) HandleUserInteractions() {
 		newStakingModal(pg.Load).
 			TicketPurchased(func() {
 				align := layout.Center
-				successIcon := decredmaterial.NewIcon(pg.Icons.ActionCheckCircle)
+				successIcon := decredmaterial.NewIcon(pg.Theme.Icons.ActionCheckCircle)
 				successIcon.Color = pg.Theme.Color.Success
 				info := modal.NewInfoModal(pg.Load).
 					Icon(successIcon).

--- a/ui/page/staking/overview.go
+++ b/ui/page/staking/overview.go
@@ -104,6 +104,7 @@ func (pg *Page) fetchTicketPrice() {
 	} else {
 		ticketPrice, err := pg.WL.MultiWallet.TicketPrice()
 		if err != nil && !pg.WL.MultiWallet.IsSynced() {
+			log.Error(err)
 			pg.ticketPrice = "Not available"
 			pg.Toast.NotifyError("wallet not synced")
 		} else {
@@ -113,10 +114,10 @@ func (pg *Page) fetchTicketPrice() {
 }
 
 func (pg *Page) setStakingButtonsState() {
-	//disable staking btn is wallet is not synced
+	//disable staking btn is wallet if not synced
 	pg.stakeBtn.SetEnabled(pg.WL.MultiWallet.IsSynced())
 
-	//disable auto ticket purchase is wallet is not synced
+	//disable auto ticket purchase if wallet is not synced
 	pg.autoPurchase.SetEnabled(!pg.WL.MultiWallet.IsSynced())
 }
 

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -274,19 +274,19 @@ func (tp *stakingModal) canPurchase() bool {
 		return false
 	}
 
-	if tp.vspSelector.SelectedVSP() == nil {
-		return false
-	}
-
-	if tp.spendingPassword.Editor.Text() == "" {
-		return false
-	}
-
 	tp.calculateTotals()
 
 	accountBalance := tp.accountSelector.SelectedAccount().Balance.Spendable
 	if accountBalance < tp.totalCost || tp.balanceLessCost < 0 {
 		tp.balanceError = "Insufficient funds"
+		return false
+	}
+
+	if tp.vspSelector.SelectedVSP() == nil {
+		return false
+	}
+
+	if tp.spendingPassword.Editor.Text() == "" {
 		return false
 	}
 

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -274,15 +274,17 @@ func (tp *stakingModal) canPurchase() bool {
 		return false
 	}
 
+	// this is needed to generate the transaction fees before calculating
+	// tottal ticket cost
+	if tp.vspSelector.SelectedVSP() == nil {
+		return false
+	}
+
 	tp.calculateTotals()
 
 	accountBalance := tp.accountSelector.SelectedAccount().Balance.Spendable
 	if accountBalance < tp.totalCost || tp.balanceLessCost < 0 {
 		tp.balanceError = "Insufficient funds"
-		return false
-	}
-
-	if tp.vspSelector.SelectedVSP() == nil {
 		return false
 	}
 

--- a/ui/page/staking/stake_layout.go
+++ b/ui/page/staking/stake_layout.go
@@ -38,6 +38,10 @@ func (pg *Page) stakePriceSection(gtx C) D {
 								secs, _ := pg.WL.MultiWallet.NextTicketPriceRemaining()
 								txt := pg.Theme.Label(values.TextSize14, nextTicketRemaining(int(secs)))
 								txt.Color = pg.Theme.Color.GrayText2
+
+								if pg.WL.MultiWallet.IsSyncing() {
+									txt.Text = "Syncing"
+								}
 								return txt.Layout(gtx)
 							}),
 						)

--- a/ui/page/staking/stake_layout.go
+++ b/ui/page/staking/stake_layout.go
@@ -93,6 +93,15 @@ func (pg *Page) stakePriceSection(gtx C) D {
 					return pg.stakeBtn.Layout(gtx)
 				})
 			}),
+			layout.Rigid(func(gtx C) D {
+				if pg.WL.MultiWallet.IsSynced() {
+					return D{}
+				}
+
+				notSynced := pg.Theme.Label(values.TextSize10, "Wallets not synced")
+				notSynced.Color = pg.Theme.Color.Danger
+				return layout.Center.Layout(gtx, notSynced.Layout)
+			}),
 		)
 	})
 }


### PR DESCRIPTION
Fix #836
Fix #884 

* This Pr set the auto ticket and stake button state to disabled until wallet is fully synced.
* Centralizes the `no active tickets` label
* Allow validation of spendable funds against ticket amount without password is added
* Temp remove governance page search editors.