### PR TITLE
add transfer fund checkbox to auto mixer setup

### DIFF
--- a/ui/page/components/sub_page.go
+++ b/ui/page/components/sub_page.go
@@ -134,7 +134,7 @@ func (sp *SubPage) EventHandler() {
 				Title(sp.Title).
 				SetupWithTemplate(sp.InfoTemplate).
 				SetCancelable(true).
-				NegativeButton("Got it", func() {}).Show()
+				PositiveButton("Got it", func(isChecked bool) {}).Show()
 		}
 	}
 

--- a/ui/page/debug_page.go
+++ b/ui/page/debug_page.go
@@ -170,7 +170,7 @@ func (pg *DebugPage) resetDexData() {
 		Title("Confirm DEX Client Reset").
 		Body("You may need to restart godcr before you can use the DEX again. Proceed?").
 		NegativeButton(values.String(values.StrCancel), func() {}).
-		PositiveButton("Reset DEX Client", func() {
+		PositiveButton("Reset DEX Client", func(isChecked bool) {
 			if pg.Dexc().Reset() {
 				pg.Toast.Notify("DEX client data reset complete.")
 			} else {

--- a/ui/page/governance/consensus_page.go
+++ b/ui/page/governance/consensus_page.go
@@ -117,7 +117,7 @@ func (pg *ConsensusPage) HandleUserInteractions() {
 			Title("Consensus changes").
 			Body("On-chain voting for upgrading the Decred network consensus rules.").
 			SetCancelable(true).
-			PositiveButton("Got it", func() {}).Show()
+			PositiveButton("Got it", func(isChecked bool) {}).Show()
 	}
 
 	for pg.viewVotingDashboard.Clicked() {
@@ -167,7 +167,7 @@ func (pg *ConsensusPage) HandleUserInteractions() {
 					}),
 				)
 			}).
-			PositiveButton("Got it", func() {})
+			PositiveButton("Got it", func(isChecked bool) {})
 		pg.ShowModal(info)
 	}
 

--- a/ui/page/governance/proposal_details_page.go
+++ b/ui/page/governance/proposal_details_page.go
@@ -179,7 +179,7 @@ func (pg *ProposalDetails) HandleUserInteractions() {
 					}),
 				)
 			}).
-			PositiveButton("Got it", func() {})
+			PositiveButton("Got it", func(isChecked bool) {})
 		pg.ShowModal(info)
 	}
 }

--- a/ui/page/governance/proposals_page.go
+++ b/ui/page/governance/proposals_page.go
@@ -183,7 +183,7 @@ func (pg *ProposalsPage) HandleUserInteractions() {
 			Title("Proposals").
 			Body("Off-chain voting for development and marketing initiatives funded by the Decred treasury.").
 			SetCancelable(true).
-			PositiveButton("Got it", func() {}).Show()
+			PositiveButton("Got it", func(isChecked bool) {}).Show()
 	}
 
 	if pg.syncCompleted {

--- a/ui/page/governance/splash_screen.go
+++ b/ui/page/governance/splash_screen.go
@@ -73,6 +73,6 @@ func (pg *Page) showInfoModal() {
 	info := modal.NewInfoModal(pg.Load).
 		Title("Governance").
 		Body("Proposals and politeia notifications can be enabled or disabled from the settings page.").
-		PositiveButton("Got it", func() {})
+		PositiveButton("Got it", func(isChecked bool) {})
 	pg.ShowModal(info)
 }

--- a/ui/page/overview/overview_layout.go
+++ b/ui/page/overview/overview_layout.go
@@ -229,12 +229,12 @@ func (pg *AppOverviewPage) showBackupInfo() {
 		SetupWithTemplate(modal.WalletBackupInfoTemplate).
 		SetCancelable(false).
 		SetContentAlignment(layout.W, layout.Center).
-		CheckBox(pg.checkBox).
+		CheckBox(pg.checkBox, true).
 		NegativeButton("Backup later", func() {
 			pg.WL.Wallet.SaveConfigValueForKey(load.SeedBackupNotificationConfigKey, true)
 		}).
 		PositiveButtonStyle(pg.Load.Theme.Color.Primary, pg.Load.Theme.Color.InvText).
-		PositiveButton("Backup now", func() {
+		PositiveButton("Backup now", func(isChecked bool) {
 			pg.WL.Wallet.SaveConfigValueForKey(load.SeedBackupNotificationConfigKey, true)
 			pg.ChangeFragment(wPage.NewWalletPage(pg.Load))
 		}).Show()

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -246,7 +246,7 @@ func (pg *AccountMixerPage) HandleUserInteractions() {
 				Title("Cancel mixer?").
 				Body("Are you sure you want to cancel mixer action?").
 				NegativeButton("No", func() {}).
-				PositiveButton("Yes", func() {
+				PositiveButton("Yes", func(isChecked bool) {
 					pg.toggleMixer.SetChecked(false)
 					go pg.WL.MultiWallet.StopAccountMixer(pg.wallet.ID)
 				})

--- a/ui/page/privacy/setup_mixer_accounts_page.go
+++ b/ui/page/privacy/setup_mixer_accounts_page.go
@@ -2,10 +2,10 @@ package privacy
 
 import (
 	"context"
-	"fmt"
 
 	"gioui.org/layout"
 	"gioui.org/text"
+	"gioui.org/widget"
 
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
@@ -30,14 +30,12 @@ type SetupMixerAccountsPage struct {
 	autoSetupClickable      *decredmaterial.Clickable
 	manualSetupClickable    *decredmaterial.Clickable
 	autoSetupIcon, nextIcon *decredmaterial.Icon
-	checkBox                decredmaterial.CheckBoxStyle
 }
 
 func NewSetupMixerAccountsPage(l *load.Load, wallet *dcrlibwallet.Wallet) *SetupMixerAccountsPage {
 	pg := &SetupMixerAccountsPage{
-		Load:     l,
-		wallet:   wallet,
-		checkBox: l.Theme.CheckBox(new(widget.Bool), "Automatically move funds from default to unmixed account"),
+		Load:   l,
+		wallet: wallet,
 	}
 	pg.backButton, pg.infoButton = components.SubpageHeaderButtons(l)
 
@@ -226,136 +224,6 @@ func (pg *SetupMixerAccountsPage) manualSetupLayout(gtx C) D {
 	})
 }
 
-func (pg *SetupMixerAccountsPage) showModalSetupMixerInfo() {
-	info := modal.NewInfoModal(pg.Load).
-		Title("Set up mixer by creating two needed accounts").
-		SetupWithTemplate(modal.SetupMixerInfoTemplate).
-		CheckBox(pg.checkBox, false).
-		NegativeButton(values.String(values.StrCancel), func() {}).
-		PositiveButton("Begin setup", func(movefundsChecked bool) {
-			pg.showModalSetupMixerAcct(movefundsChecked)
-		})
-	pg.ShowModal(info)
-}
-
-func (pg *SetupMixerAccountsPage) showInfoModal(title, body, btnText string, isError, alignCenter bool) {
-	icon := decredmaterial.NewIcon(decredmaterial.MustIcon(widget.NewIcon(icons.AlertError)))
-	icon.Color = pg.Theme.Color.DeepBlue
-	if !isError {
-		icon = decredmaterial.NewIcon(pg.Theme.Icons.ActionCheckCircle)
-		icon.Color = pg.Theme.Color.Success
-	}
-
-	info := modal.NewInfoModal(pg.Load).
-		Icon(icon).
-		Title(title).
-		Body(body).
-		PositiveButton(btnText, func(isChecked bool) {})
-
-	if alignCenter {
-		align := layout.Center
-		info.SetContentAlignment(align, align)
-	}
-
-	pg.ShowModal(info)
-}
-
-func (pg *SetupMixerAccountsPage) showModalSetupMixerAcct(movefundsChecked bool) {
-	accounts, _ := pg.wallet.GetAccountsRaw()
-	txt := "There are existing accounts named mixed or unmixed. Please change the name to something else for now. You can change them back after the setup."
-	for _, acct := range accounts.Acc {
-		if acct.Name == "mixed" || acct.Name == "unmixed" {
-			alert := decredmaterial.NewIcon(decredmaterial.MustIcon(widget.NewIcon(icons.AlertError)))
-			alert.Color = pg.Theme.Color.DeepBlue
-			info := modal.NewInfoModal(pg.Load).
-				Icon(alert).
-				Title("Account name is taken").
-				Body(txt).
-				PositiveButton("Go back & rename", func(isChecked bool) {
-					pg.PopFragment()
-				})
-			pg.ShowModal(info)
-			return
-		}
-	}
-
-	modal.NewPasswordModal(pg.Load).
-		Title("Confirm to create needed accounts").
-		NegativeButton("Cancel", func() {}).
-		PositiveButton("Confirm", func(password string, pm *modal.PasswordModal) bool {
-			go func() {
-				err := pg.wallet.CreateMixerAccounts("mixed", "unmixed", password)
-				if err != nil {
-					pm.SetError(err.Error())
-					pm.SetLoading(false)
-					return
-				}
-				pg.WL.MultiWallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
-
-				if movefundsChecked {
-					err := pg.moveFundsFromDefaultToUnmixed(password)
-					if err != nil {
-						log.Error(err)
-						txt := fmt.Sprintf("Error moving funds: %s.\n%s", err.Error(), "Auto funds transfer has been skipped. Move funds to unmixed account manually from the send page.")
-						pg.showInfoModal("Move funds to unmixed account", txt, "Got it", true, false)
-					}
-				}
-
-				pm.Dismiss()
-
-				pg.ChangeFragment(NewAccountMixerPage(pg.Load, pg.wallet))
-			}()
-
-			return false
-		}).Show()
-}
-
-// moveFundsFromDefaultToUnmixed moves funds from the default wallet account to the
-// newly created unmixed account
-func (pg *SetupMixerAccountsPage) moveFundsFromDefaultToUnmixed(password string) error {
-	acc, err := pg.wallet.GetAccountsRaw()
-	if err != nil {
-		return err
-	}
-
-	// get the first account in the wallet as this is the default
-	sourceAccount := acc.Acc[0]
-	destinationAccount := pg.wallet.UnmixedAccountNumber()
-
-	destinationAddress, err := pg.wallet.CurrentAddress(destinationAccount)
-	if err != nil {
-		return err
-	}
-
-	unsignedTx, err := pg.WL.MultiWallet.NewUnsignedTx(sourceAccount.WalletID, sourceAccount.Number)
-	if err != nil {
-		return err
-	}
-
-	// get tx fees
-	feeAndSize, err := unsignedTx.EstimateFeeAndSize()
-	if err != nil {
-		return err
-	}
-
-	// calculate max amount to be sent
-	amountAtom := sourceAccount.Balance.Spendable - feeAndSize.Fee.AtomValue
-	err = unsignedTx.AddSendDestination(destinationAddress, amountAtom, true)
-	if err != nil {
-		return err
-	}
-
-	// send fund
-	_, err = unsignedTx.Broadcast([]byte(password))
-	if err != nil {
-		return err
-	}
-
-	pg.showInfoModal("Transaction sent!", "", "Got it", false, true)
-
-	return err
-}
-
 // HandleUserInteractions is called just before Layout() to determine
 // if any user interaction recently occurred on the page and may be
 // used to update the page's UI components shortly before they are
@@ -363,9 +231,10 @@ func (pg *SetupMixerAccountsPage) moveFundsFromDefaultToUnmixed(password string)
 // Part of the load.Page interface.
 func (pg *SetupMixerAccountsPage) HandleUserInteractions() {
 	if pg.autoSetupClickable.Clicked() {
-		go showModalSetupMixerInfo(&sharedModalConf{
-			Load:   pg.Load,
-			wallet: pg.wallet,
+		showModalSetupMixerInfo(&sharedModalConf{
+			Load:     pg.Load,
+			wallet:   pg.wallet,
+			checkBox: pg.Theme.CheckBox(new(widget.Bool), "Automatically move funds from default to unmixed account"),
 		})
 	}
 

--- a/ui/page/privacy/setup_privacy_page.go
+++ b/ui/page/privacy/setup_privacy_page.go
@@ -5,6 +5,7 @@ import (
 
 	"gioui.org/layout"
 	"gioui.org/text"
+	"gioui.org/widget"
 
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
@@ -166,8 +167,9 @@ func (pg *SetupPrivacyPage) HandleUserInteractions() {
 
 		if walCount <= 1 {
 			go showModalSetupMixerInfo(&sharedModalConf{
-				Load:   pg.Load,
-				wallet: pg.wallet,
+				Load:     pg.Load,
+				wallet:   pg.wallet,
+				checkBox: pg.Theme.CheckBox(new(widget.Bool), "Automatically move funds from default to unmixed account"),
 			})
 		} else {
 			pg.ChangeFragment(NewSetupMixerAccountsPage(pg.Load, pg.wallet))

--- a/ui/page/privacy/shared_modals.go
+++ b/ui/page/privacy/shared_modals.go
@@ -1,6 +1,9 @@
 package privacy
 
 import (
+	"fmt"
+
+	"gioui.org/layout"
 	"gioui.org/widget"
 
 	"github.com/planetdecred/dcrlibwallet"
@@ -13,21 +16,45 @@ import (
 
 type sharedModalConf struct {
 	*load.Load
-	wallet *dcrlibwallet.Wallet
+	wallet   *dcrlibwallet.Wallet
+	checkBox decredmaterial.CheckBoxStyle
+}
+
+func showInfoModal(conf *sharedModalConf, title, body, btnText string, isError, alignCenter bool) {
+	icon := decredmaterial.NewIcon(decredmaterial.MustIcon(widget.NewIcon(icons.AlertError)))
+	icon.Color = conf.Theme.Color.DeepBlue
+	if !isError {
+		icon = decredmaterial.NewIcon(conf.Theme.Icons.ActionCheckCircle)
+		icon.Color = conf.Theme.Color.Success
+	}
+
+	info := modal.NewInfoModal(conf.Load).
+		Icon(icon).
+		Title(title).
+		Body(body).
+		PositiveButton(btnText, func(isChecked bool) {})
+
+	if alignCenter {
+		align := layout.Center
+		info.SetContentAlignment(align, align)
+	}
+
+	conf.ShowModal(info)
 }
 
 func showModalSetupMixerInfo(conf *sharedModalConf) {
 	info := modal.NewInfoModal(conf.Load).
 		Title("Set up mixer by creating two needed accounts").
 		SetupWithTemplate(modal.SetupMixerInfoTemplate).
+		CheckBox(conf.checkBox, false).
 		NegativeButton(values.String(values.StrCancel), func() {}).
-		PositiveButton("Begin setup", func() {
-			showModalSetupMixerAcct(conf)
+		PositiveButton("Begin setup", func(movefundsChecked bool) {
+			showModalSetupMixerAcct(conf, movefundsChecked)
 		})
 	conf.ShowModal(info)
 }
 
-func showModalSetupMixerAcct(conf *sharedModalConf) {
+func showModalSetupMixerAcct(conf *sharedModalConf, movefundsChecked bool) {
 	accounts, _ := conf.wallet.GetAccountsRaw()
 	txt := "There are existing accounts named mixed or unmixed. Please change the name to something else for now. You can change them back after the setup."
 	for _, acct := range accounts.Acc {
@@ -38,7 +65,7 @@ func showModalSetupMixerAcct(conf *sharedModalConf) {
 				Icon(alert).
 				Title("Account name is taken").
 				Body(txt).
-				PositiveButton("Go back & rename", func() {
+				PositiveButton("Go back & rename", func(movefundsChecked bool) {
 					conf.PopFragment()
 				})
 			conf.ShowModal(info)
@@ -58,6 +85,16 @@ func showModalSetupMixerAcct(conf *sharedModalConf) {
 					return
 				}
 				conf.WL.MultiWallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
+
+				if movefundsChecked {
+					err := moveFundsFromDefaultToUnmixed(conf, password)
+					if err != nil {
+						log.Error(err)
+						txt := fmt.Sprintf("Error moving funds: %s.\n%s", err.Error(), "Auto funds transfer has been skipped. Move funds to unmixed account manually from the send page.")
+						showInfoModal(conf, "Move funds to unmixed account", txt, "Got it", true, false)
+					}
+				}
+
 				pm.Dismiss()
 
 				conf.ChangeFragment(NewAccountMixerPage(conf.Load, conf.wallet))
@@ -65,4 +102,50 @@ func showModalSetupMixerAcct(conf *sharedModalConf) {
 
 			return false
 		}).Show()
+}
+
+// moveFundsFromDefaultToUnmixed moves funds from the default wallet account to the
+// newly created unmixed account
+func moveFundsFromDefaultToUnmixed(conf *sharedModalConf, password string) error {
+	acc, err := conf.wallet.GetAccountsRaw()
+	if err != nil {
+		return err
+	}
+
+	// get the first account in the wallet as this is the default
+	sourceAccount := acc.Acc[0]
+	destinationAccount := conf.wallet.UnmixedAccountNumber()
+
+	destinationAddress, err := conf.wallet.CurrentAddress(destinationAccount)
+	if err != nil {
+		return err
+	}
+
+	unsignedTx, err := conf.WL.MultiWallet.NewUnsignedTx(sourceAccount.WalletID, sourceAccount.Number)
+	if err != nil {
+		return err
+	}
+
+	// get tx fees
+	feeAndSize, err := unsignedTx.EstimateFeeAndSize()
+	if err != nil {
+		return err
+	}
+
+	// calculate max amount to be sent
+	amountAtom := sourceAccount.Balance.Spendable - feeAndSize.Fee.AtomValue
+	err = unsignedTx.AddSendDestination(destinationAddress, amountAtom, true)
+	if err != nil {
+		return err
+	}
+
+	// send fund
+	_, err = unsignedTx.Broadcast([]byte(password))
+	if err != nil {
+		return err
+	}
+
+	showInfoModal(conf, "Transaction sent!", "", "Got it", false, true)
+
+	return err
 }

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -363,7 +363,7 @@ func (pg *ReceivePage) HandleUserInteractions() {
 		info := modal.NewInfoModal(pg.Load).
 			Title("Receive DCR").
 			Body("Each time you receive a payment, a new address is generated to protect your privacy.").
-			PositiveButton("Got it", func() {})
+			PositiveButton("Got it", func(isChecked bool) {})
 		pg.ShowModal(info)
 	}
 

--- a/ui/page/seedbackup/backup_instructions.go
+++ b/ui/page/seedbackup/backup_instructions.go
@@ -93,7 +93,7 @@ func promptToExit(load *load.Load) {
 		Title("Exit?").
 		Body("Are you sure you want to exit the seed backup process?").
 		NegativeButton("No", func() {}).
-		PositiveButton("Yes", func() {
+		PositiveButton("Yes", func(isChecked bool) {
 			load.PopToFragment(components.WalletsPageID)
 		}).
 		Show()

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -368,7 +368,7 @@ func (pg *Page) HandleUserInteractions() {
 		info := modal.NewInfoModal(pg.Load).
 			Title("Send DCR").
 			Body("Input or scan the destination wallet address and input the amount to send funds.").
-			PositiveButton("Got it", func() {})
+			PositiveButton("Got it", func(isChecked bool) {})
 		pg.ShowModal(info)
 	}
 

--- a/ui/page/settings_page.go
+++ b/ui/page/settings_page.go
@@ -381,7 +381,7 @@ func (pg *SettingsPage) showWarningModalDialog(title, msg, key string) {
 		Body(msg).
 		NegativeButton(values.String(values.StrCancel), func() {}).
 		PositiveButtonStyle(pg.Theme.Color.Surface, pg.Theme.Color.Danger).
-		PositiveButton("Remove", func() {
+		PositiveButton("Remove", func(isChecked bool) {
 			pg.WL.MultiWallet.DeleteUserConfigValueForKey(key)
 		})
 	pg.ShowModal(info)
@@ -434,7 +434,7 @@ func (pg *SettingsPage) HandleUserInteractions() {
 				Body("Are you sure you want to disable governance? This will clear all available proposals").
 				NegativeButton(values.String(values.StrCancel), func() {}).
 				PositiveButtonStyle(pg.Theme.Color.Surface, pg.Theme.Color.Danger).
-				PositiveButton("Disable", func() {
+				PositiveButton("Disable", func(isChecked bool) {
 					if pg.WL.MultiWallet.Politeia.IsSyncing() {
 						go pg.WL.MultiWallet.Politeia.StopSync()
 					}
@@ -472,7 +472,7 @@ func (pg *SettingsPage) HandleUserInteractions() {
 		info := modal.NewInfoModal(pg.Load).
 			Title("Set up startup password").
 			Body("Startup password helps protect your wallet from unauthorized access.").
-			PositiveButton("Got it", func() {})
+			PositiveButton("Got it", func(isChecked bool) {})
 		pg.ShowModal(info)
 	}
 

--- a/ui/page/staking/overview.go
+++ b/ui/page/staking/overview.go
@@ -252,7 +252,7 @@ func (pg *Page) HandleUserInteractions() {
 					Icon(successIcon).
 					Title("Ticket(s) Confirmed").
 					SetContentAlignment(align, align).
-					PositiveButton("Back to staking", func() {})
+					PositiveButton("Back to staking", func(isChecked bool) {})
 				pg.ShowModal(info)
 				pg.loadPageData()
 			}).Show()

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -1207,7 +1207,7 @@ func (pg *WalletPage) deleteBadWallet(badWalletID int) {
 		Body("You can restore this wallet from seed word after it is deleted.").
 		NegativeButton(values.String(values.StrCancel), func() {}).
 		PositiveButtonStyle(pg.Load.Theme.Color.Surface, pg.Load.Theme.Color.Danger).
-		PositiveButton(values.String(values.StrRemove), func() {
+		PositiveButton(values.String(values.StrRemove), func(isChecked bool) {
 			go func() {
 				err := pg.WL.MultiWallet.DeleteBadWallet(badWalletID)
 				if err != nil {

--- a/ui/page/wallets/wallet_settings_page.go
+++ b/ui/page/wallets/wallet_settings_page.go
@@ -224,7 +224,7 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 				Body("Rescanning may help resolve some balance errors. This will take some time, as it scans the entire"+
 					" blockchain for transactions").
 				NegativeButton(values.String(values.StrCancel), func() {}).
-				PositiveButton(values.String(values.StrRescan), func() {
+				PositiveButton(values.String(values.StrRescan), func(isChecked bool) {
 					err := pg.WL.MultiWallet.RescanBlocks(pg.wallet.ID)
 					if err != nil {
 						if err.Error() == dcrlibwallet.ErrNotConnected {
@@ -253,7 +253,7 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 			Body(warningMsg).
 			NegativeButton(values.String(values.StrCancel), func() {}).
 			PositiveButtonStyle(pg.Load.Theme.Color.Surface, pg.Load.Theme.Color.Danger).
-			PositiveButton(values.String(values.StrRemove), func() {
+			PositiveButton(values.String(values.StrRemove), func(isChecked bool) {
 				walletDeleted := func() {
 					if pg.WL.MultiWallet.LoadedWalletsCount() > 0 {
 						pg.Toast.Notify("Wallet removed")
@@ -299,7 +299,7 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 		info := modal.NewInfoModal(pg.Load).
 			Title("Spending password").
 			Body("A spending password helps secure your wallet transactions.").
-			PositiveButton("Got it", func() {})
+			PositiveButton("Got it", func(isChecked bool) {})
 		pg.ShowModal(info)
 	}
 }

--- a/ui/page/wallets/wallet_settings_page.go
+++ b/ui/page/wallets/wallet_settings_page.go
@@ -53,7 +53,7 @@ func (pg *WalletSettingsPage) ID() string {
 // the page is displayed.
 // Part of the load.Page interface.
 func (pg *WalletSettingsPage) OnNavigatedTo() {
-	pg.wallet.ClearMixerConfig()
+
 }
 
 // Layout draws the page UI components into the provided layout context

--- a/ui/page/wallets/wallet_settings_page.go
+++ b/ui/page/wallets/wallet_settings_page.go
@@ -53,7 +53,7 @@ func (pg *WalletSettingsPage) ID() string {
 // the page is displayed.
 // Part of the load.Page interface.
 func (pg *WalletSettingsPage) OnNavigatedTo() {
-
+	pg.wallet.ClearMixerConfig()
 }
 
 // Layout draws the page UI components into the provided layout context


### PR DESCRIPTION
Fix #874

This PR add option to transfer all spendable funds in the users default wallet to a newly created mixed account.

<img width="783" alt="image" src="https://user-images.githubusercontent.com/27733432/164716114-4656e260-419f-4990-8e59-0b1841767c43.png">

Error handling modal.
<img width="785" alt="image" src="https://user-images.githubusercontent.com/27733432/164716340-f69edf10-f9e8-41e8-8558-62406f568548.png">
