### PR TITLE
Prevent duplicate wallets.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/nxadm/tail v1.4.4
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
-	github.com/planetdecred/dcrlibwallet v1.6.2-0.20220414074738-62281e38109a
+	github.com/planetdecred/dcrlibwallet v1.6.2-0.20220422064641-2e5c424c649c
 	github.com/yeqown/go-qrcode v1.5.1
 	golang.org/x/exp v0.0.0-20210722180016-6781d3edade3
 	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/nxadm/tail v1.4.4
 	github.com/onsi/ginkgo v1.14.0
 	github.com/onsi/gomega v1.10.1
-	github.com/planetdecred/dcrlibwallet v1.6.2-0.20220422064641-2e5c424c649c
+	github.com/planetdecred/dcrlibwallet v1.6.2-0.20220425133823-833d52a7cdd5
 	github.com/yeqown/go-qrcode v1.5.1
 	golang.org/x/exp v0.0.0-20210722180016-6781d3edade3
 	golang.org/x/image v0.0.0-20210628002857-a66eb6448b8d

--- a/go.sum
+++ b/go.sum
@@ -917,6 +917,8 @@ github.com/planetdecred/dcrlibwallet v1.6.2-0.20220414074738-62281e38109a h1:doO
 github.com/planetdecred/dcrlibwallet v1.6.2-0.20220414074738-62281e38109a/go.mod h1:d65xdeAh2Z9tm6WDdcAtrjO6Cph4WJDS6uDq6JVNHmM=
 github.com/planetdecred/dcrlibwallet v1.6.2-0.20220422064641-2e5c424c649c h1:+h7RbahsLipRxnTNhCtqVIPqoaIt/iU/fDSx/A0yJ/A=
 github.com/planetdecred/dcrlibwallet v1.6.2-0.20220422064641-2e5c424c649c/go.mod h1:L/S3dlrJLwvXSQijUQ0JEcgR52LDiV2/embkwrvwksc=
+github.com/planetdecred/dcrlibwallet v1.6.2-0.20220425133823-833d52a7cdd5 h1:GEdjcKQA6jHISMufQird5WWscP1WnZMIJo+FGcLD31E=
+github.com/planetdecred/dcrlibwallet v1.6.2-0.20220425133823-833d52a7cdd5/go.mod h1:L/S3dlrJLwvXSQijUQ0JEcgR52LDiV2/embkwrvwksc=
 github.com/planetdecred/dcrlibwallet/dexdcr v0.0.0-20220223161805-c736f970653d h1:egC6nx+qP3QMwKQhA+JdJReKV9NhG17Ag+3oCVCsj3c=
 github.com/planetdecred/dcrlibwallet/dexdcr v0.0.0-20220223161805-c736f970653d/go.mod h1:jO4RP2rgqom8CLgl3rMwZ4cGzmalJqBkKjHgVS812lM=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/go.sum
+++ b/go.sum
@@ -915,6 +915,8 @@ github.com/pkg/profile v1.2.1/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6J
 github.com/pkg/term v0.0.0-20180730021639-bffc007b7fd5/go.mod h1:eCbImbZ95eXtAUIbLAuAVnBnwf83mjf6QIVH8SHYwqQ=
 github.com/planetdecred/dcrlibwallet v1.6.2-0.20220414074738-62281e38109a h1:doO14vqlC/HX9Mm6gHyEMxz5zk5VdpNYoL6Adg494Ko=
 github.com/planetdecred/dcrlibwallet v1.6.2-0.20220414074738-62281e38109a/go.mod h1:d65xdeAh2Z9tm6WDdcAtrjO6Cph4WJDS6uDq6JVNHmM=
+github.com/planetdecred/dcrlibwallet v1.6.2-0.20220422064641-2e5c424c649c h1:+h7RbahsLipRxnTNhCtqVIPqoaIt/iU/fDSx/A0yJ/A=
+github.com/planetdecred/dcrlibwallet v1.6.2-0.20220422064641-2e5c424c649c/go.mod h1:L/S3dlrJLwvXSQijUQ0JEcgR52LDiV2/embkwrvwksc=
 github.com/planetdecred/dcrlibwallet/dexdcr v0.0.0-20220223161805-c736f970653d h1:egC6nx+qP3QMwKQhA+JdJReKV9NhG17Ag+3oCVCsj3c=
 github.com/planetdecred/dcrlibwallet/dexdcr v0.0.0-20220223161805-c736f970653d/go.mod h1:jO4RP2rgqom8CLgl3rMwZ4cGzmalJqBkKjHgVS812lM=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/log.go
+++ b/log.go
@@ -15,6 +15,7 @@ import (
 	"github.com/planetdecred/godcr/listeners"
 	"github.com/planetdecred/godcr/ui"
 	"github.com/planetdecred/godcr/ui/load"
+	"github.com/planetdecred/godcr/ui/modal"
 	"github.com/planetdecred/godcr/ui/page"
 	"github.com/planetdecred/godcr/ui/page/components"
 	"github.com/planetdecred/godcr/ui/page/governance"
@@ -77,6 +78,7 @@ func init() {
 	overview.UseLogger(winLog)
 	staking.UseLogger(winLog)
 	privacy.UseLogger(winLog)
+	modal.UseLogger(winLog)
 }
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -133,6 +133,18 @@ func (cm *CreateWatchOnlyModal) Handle() {
 			return
 		}
 
+		// Check if there are existing wallets with identical Xpub.
+		// matchedWalletID == ID of the wallet whose xpub is identical to provided xpub.
+		matchedWalletID, err := cm.WL.MultiWallet.WalletWithXPub(cm.extendedPubKey.Editor.Text())
+		if err != nil {
+			//log.Error(err)  // Non Fatal error continue.
+		}
+
+		if matchedWalletID != -1 {
+			cm.Toast.NotifyError("A wallet with an identical extended public key already exists.")
+			return
+		}
+
 		cm.SetLoading(true)
 		if cm.callback(cm.walletName.Editor.Text(), cm.extendedPubKey.Editor.Text(), cm) {
 			cm.Dismiss()

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -137,7 +137,7 @@ func (cm *CreateWatchOnlyModal) Handle() {
 		// matchedWalletID == ID of the wallet whose xpub is identical to provided xpub.
 		matchedWalletID, err := cm.WL.MultiWallet.WalletWithXPub(cm.extendedPubKey.Editor.Text())
 		if err != nil {
-			//log.Error(err)  // Non Fatal error continue.
+			log.Error(err) // Non Fatal error continue.
 		}
 
 		if matchedWalletID != -1 {

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -137,7 +137,9 @@ func (cm *CreateWatchOnlyModal) Handle() {
 		// matchedWalletID == ID of the wallet whose xpub is identical to provided xpub.
 		matchedWalletID, err := cm.WL.MultiWallet.WalletWithXPub(cm.extendedPubKey.Editor.Text())
 		if err != nil {
-			log.Error(err) // Non Fatal error continue.
+			log.Errorf("Error checking xpub: %v", err)
+			cm.Toast.NotifyError("Error checking xpub: " + err.Error()) // Error maybe useful to user.
+			return
 		}
 
 		if matchedWalletID != -1 {

--- a/ui/modal/log.go
+++ b/ui/modal/log.go
@@ -1,0 +1,19 @@
+package modal
+
+import "github.com/decred/slog"
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log = slog.Disabled
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until UseLogger is called.
+func DisableLog() {
+	log = slog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+func UseLogger(logger slog.Logger) {
+	log = logger
+}

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -441,15 +441,15 @@ func (pg *Restore) verifySeeds() bool {
 		}
 	}
 
-	// Compare seed with existing wallets seed. On positive match abort,
-	// import to prevent duplicate wallet. seedMatch == walled.ID if there is a match.
-	seedMatch, err := pg.WL.MultiWallet.WalletWithSeed(pg.seedPhrase)
+	// Compare seed with existing wallets seed. On positive match abort import
+	// to prevent duplicate wallet. walletWithSameSeed >= 0 if there is a match.
+	walletWithSameSeed, err := pg.WL.MultiWallet.WalletWithSeed(pg.seedPhrase)
 	if err != nil {
 		log.Error(err)
 		return false
 	}
 
-	if seedMatch != -1 {
+	if walletWithSameSeed != -1 {
 		pg.Toast.NotifyError("A wallet with an identical seed already exists.")
 		return false
 	}

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -441,6 +441,19 @@ func (pg *Restore) verifySeeds() bool {
 		}
 	}
 
+	// Compare seed with existing wallets seed. On positive match abort,
+	// import to prevent duplicate wallet. seedMatch == walled.ID if there is a match.
+	seedMatch, err := pg.WL.MultiWallet.WalletWithSeed(pg.seedPhrase)
+	if err != nil {
+		log.Error(err)
+		return false
+	}
+
+	if seedMatch != -1 {
+		pg.Toast.NotifyError("A wallet with an identical seed already exists.")
+		return false
+	}
+
 	return true
 }
 


### PR DESCRIPTION
This PR prevents users from importing wallets using the seed of an already existing wallet. Also checks the xpub of a watch-only wallet a user is about to import against the xpub of existing wallets, it warns and prevents the import if a match is detected. Summary: It prevents duplication of wallets. Closes issue #816  and PR #881. Depends on https://github.com/planetdecred/dcrlibwallet/pull/244