### PR TITLE
Skip Set up needed accounts page when there is only the default account.

### DIFF
--- a/log.go
+++ b/log.go
@@ -19,6 +19,7 @@ import (
 	"github.com/planetdecred/godcr/ui/page/components"
 	"github.com/planetdecred/godcr/ui/page/governance"
 	"github.com/planetdecred/godcr/ui/page/overview"
+	"github.com/planetdecred/godcr/ui/page/privacy"
 	"github.com/planetdecred/godcr/ui/page/staking"
 	"github.com/planetdecred/godcr/ui/page/transaction"
 	walletPage "github.com/planetdecred/godcr/ui/page/wallets"
@@ -75,6 +76,7 @@ func init() {
 	walletPage.UseLogger(winLog)
 	overview.UseLogger(winLog)
 	staking.UseLogger(winLog)
+	privacy.UseLogger(winLog)
 }
 
 // subsystemLoggers maps each subsystem identifier to its associated logger.

--- a/ui/page/privacy/setup_privacy_page.go
+++ b/ui/page/privacy/setup_privacy_page.go
@@ -5,7 +5,6 @@ import (
 
 	"gioui.org/layout"
 	"gioui.org/text"
-	"gioui.org/widget"
 
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
@@ -13,7 +12,6 @@ import (
 	"github.com/planetdecred/godcr/ui/modal"
 	"github.com/planetdecred/godcr/ui/page/components"
 	"github.com/planetdecred/godcr/ui/values"
-	"golang.org/x/exp/shiny/materialdesign/icons"
 )
 
 const SetupPrivacyPageID = "SetupPrivacy"
@@ -159,62 +157,14 @@ func (pg *SetupPrivacyPage) HandleUserInteractions() {
 		}
 		// We are using 2 here because of imported wallet.
 		if accounts.Count <= 2 {
-			pg.showModalSetupMixerInfo()
+			go showModalSetupMixerInfo(&sharedModalConf{
+				Load:   pg.Load,
+				wallet: pg.wallet,
+			})
 		} else {
 			pg.ChangeFragment(NewSetupMixerAccountsPage(pg.Load, pg.wallet))
 		}
 	}
-}
-
-func (pg *SetupPrivacyPage) showModalSetupMixerInfo() {
-	info := modal.NewInfoModal(pg.Load).
-		Title("Set up mixer by creating two needed accounts").
-		SetupWithTemplate(modal.SetupMixerInfoTemplate).
-		NegativeButton(values.String(values.StrCancel), func() {}).
-		PositiveButton("Begin setup", func() {
-			pg.showModalSetupMixerAcct()
-		})
-	pg.ShowModal(info)
-}
-
-func (pg *SetupPrivacyPage) showModalSetupMixerAcct() {
-	accounts, _ := pg.wallet.GetAccountsRaw()
-	txt := "There are existing accounts named mixed or unmixed. Please change the name to something else for now. You can change them back after the setup."
-	for _, acct := range accounts.Acc {
-		if acct.Name == "mixed" || acct.Name == "unmixed" {
-			alert := decredmaterial.NewIcon(decredmaterial.MustIcon(widget.NewIcon(icons.AlertError)))
-			alert.Color = pg.Theme.Color.DeepBlue
-			info := modal.NewInfoModal(pg.Load).
-				Icon(alert).
-				Title("Account name is taken").
-				Body(txt).
-				PositiveButton("Go back & rename", func() {
-					pg.PopFragment()
-				})
-			pg.ShowModal(info)
-			return
-		}
-	}
-
-	modal.NewPasswordModal(pg.Load).
-		Title("Confirm to create needed accounts").
-		NegativeButton("Cancel", func() {}).
-		PositiveButton("Confirm", func(password string, pm *modal.PasswordModal) bool {
-			go func() {
-				err := pg.wallet.CreateMixerAccounts("mixed", "unmixed", password)
-				if err != nil {
-					pm.SetError(err.Error())
-					pm.SetLoading(false)
-					return
-				}
-				pg.WL.MultiWallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
-				pm.Dismiss()
-
-				pg.ChangeFragment(NewAccountMixerPage(pg.Load, pg.wallet))
-			}()
-
-			return false
-		}).Show()
 }
 
 // OnNavigatedFrom is called when the page is about to be removed from

--- a/ui/page/privacy/setup_privacy_page.go
+++ b/ui/page/privacy/setup_privacy_page.go
@@ -155,8 +155,16 @@ func (pg *SetupPrivacyPage) HandleUserInteractions() {
 		if err != nil {
 			log.Error(err)
 		}
-		// We are using 2 here because of imported wallet.
-		if accounts.Count <= 2 {
+
+		walCount := accounts.Count
+		// Filter out imported account.
+		for _, v := range accounts.Acc {
+			if v.Number == dcrlibwallet.ImportedAccountNumber {
+				walCount--
+			}
+		}
+
+		if walCount <= 1 {
 			go showModalSetupMixerInfo(&sharedModalConf{
 				Load:   pg.Load,
 				wallet: pg.wallet,

--- a/ui/page/privacy/shared_modals.go
+++ b/ui/page/privacy/shared_modals.go
@@ -1,0 +1,68 @@
+package privacy
+
+import (
+	"gioui.org/widget"
+
+	"github.com/planetdecred/dcrlibwallet"
+	"github.com/planetdecred/godcr/ui/decredmaterial"
+	"github.com/planetdecred/godcr/ui/load"
+	"github.com/planetdecred/godcr/ui/modal"
+	"github.com/planetdecred/godcr/ui/values"
+	"golang.org/x/exp/shiny/materialdesign/icons"
+)
+
+type sharedModalConf struct {
+	*load.Load
+	wallet *dcrlibwallet.Wallet
+}
+
+func showModalSetupMixerInfo(conf *sharedModalConf) {
+	info := modal.NewInfoModal(conf.Load).
+		Title("Set up mixer by creating two needed accounts").
+		SetupWithTemplate(modal.SetupMixerInfoTemplate).
+		NegativeButton(values.String(values.StrCancel), func() {}).
+		PositiveButton("Begin setup", func() {
+			showModalSetupMixerAcct(conf)
+		})
+	conf.ShowModal(info)
+}
+
+func showModalSetupMixerAcct(conf *sharedModalConf) {
+	accounts, _ := conf.wallet.GetAccountsRaw()
+	txt := "There are existing accounts named mixed or unmixed. Please change the name to something else for now. You can change them back after the setup."
+	for _, acct := range accounts.Acc {
+		if acct.Name == "mixed" || acct.Name == "unmixed" {
+			alert := decredmaterial.NewIcon(decredmaterial.MustIcon(widget.NewIcon(icons.AlertError)))
+			alert.Color = conf.Theme.Color.DeepBlue
+			info := modal.NewInfoModal(conf.Load).
+				Icon(alert).
+				Title("Account name is taken").
+				Body(txt).
+				PositiveButton("Go back & rename", func() {
+					conf.PopFragment()
+				})
+			conf.ShowModal(info)
+			return
+		}
+	}
+
+	modal.NewPasswordModal(conf.Load).
+		Title("Confirm to create needed accounts").
+		NegativeButton("Cancel", func() {}).
+		PositiveButton("Confirm", func(password string, pm *modal.PasswordModal) bool {
+			go func() {
+				err := conf.wallet.CreateMixerAccounts("mixed", "unmixed", password)
+				if err != nil {
+					pm.SetError(err.Error())
+					pm.SetLoading(false)
+					return
+				}
+				conf.WL.MultiWallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
+				pm.Dismiss()
+
+				conf.ChangeFragment(NewAccountMixerPage(conf.Load, conf.wallet))
+			}()
+
+			return false
+		}).Show()
+}


### PR DESCRIPTION
This PR Skips the setup needed accounts page when setting up Stake-Shuffle, for cases where additional accounts are not detected. Closes #853 .