### PR TITLE
rename accounts to mixed and unmixed after manual mixer setup

### DIFF
--- a/ui/page/privacy/manual_mixer_setup_page.go
+++ b/ui/page/privacy/manual_mixer_setup_page.go
@@ -175,13 +175,28 @@ func (pg *ManualMixerSetupPage) showModalSetupMixerAcct() {
 		NegativeButton("Cancel", func() {}).
 		PositiveButton("Confirm", func(password string, pm *modal.PasswordModal) bool {
 			go func() {
-				err := pg.wallet.SetAccountMixerConfig(pg.mixedAccountSelector.SelectedAccount().Number, pg.unmixedAccountSelector.SelectedAccount().Number, password)
+				mixedAcctNumber := pg.mixedAccountSelector.SelectedAccount().Number
+				unmixedAcctNumber := pg.unmixedAccountSelector.SelectedAccount().Number
+				err := pg.wallet.SetAccountMixerConfig(mixedAcctNumber, unmixedAcctNumber, password)
 				if err != nil {
 					pm.SetError(err.Error())
 					pm.SetLoading(false)
 					return
 				}
 				pg.WL.MultiWallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
+
+				// rename mixed account
+				err = pg.wallet.RenameAccount(mixedAcctNumber, "mixed")
+				if err != nil {
+					log.Error(err)
+				}
+
+				// rename unmixed account
+				err = pg.wallet.RenameAccount(unmixedAcctNumber, "unmixed")
+				if err != nil {
+					log.Error(err)
+				}
+
 				pm.Dismiss()
 
 				pg.ChangeFragment(NewAccountMixerPage(pg.Load, pg.wallet))

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -275,7 +275,7 @@ func (tp *stakingModal) canPurchase() bool {
 	}
 
 	// this is needed to generate the transaction fees before calculating
-	// tottal ticket cost
+	// total ticket cost
 	if tp.vspSelector.SelectedVSP() == nil {
 		return false
 	}


### PR DESCRIPTION
Fix #858

This Pr renames accounts to mixed and unmixed after using the manual mixer set up.