### PR TITLE
Don't allow same account for mixed and unmixed account for manual cssp set up.

### DIFF
--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -94,9 +94,9 @@ func (as *AccountSelector) Handle() {
 }
 
 // SelectFirstWalletValidAccount selects the first valid account from the
-// first wallet in the SortedWalletList. If selectedWallet is not nil,
-// the first account for the selectWallet is selected.
-func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibwallet.Wallet) error {
+// first wallet in the SortedWalletList, skipping any account whose ID is == filter.
+// If selectedWallet is not nil, the first account for the selectWallet is selected.
+func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibwallet.Wallet, filter int32) error {
 	if as.selectedAccount != nil && as.accountIsValid(as.selectedAccount) {
 		as.UpdateSelectedAccountBalance()
 		// no need to select account
@@ -111,7 +111,7 @@ func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibw
 
 		accounts := accountsResult.Acc
 		for _, account := range accounts {
-			if as.accountIsValid(account) {
+			if as.accountIsValid(account) && account.Number != filter {
 				as.SetSelectedAccount(account)
 				as.callback(account)
 				return nil
@@ -127,29 +127,7 @@ func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibw
 
 		accounts := accountsResult.Acc
 		for _, account := range accounts {
-			if as.accountIsValid(account) {
-				as.SetSelectedAccount(account)
-				as.callback(account)
-				return nil
-			}
-		}
-	}
-
-	return errors.New("no valid account found")
-}
-
-// SelectValidAccountExcept selects a valid account from the selectedWallet
-// except the account with accountID.
-func (as *AccountSelector) SelectValidAccountExcept(selectedWallet *dcrlibwallet.Wallet, accountID int32) error {
-	if selectedWallet != nil {
-		accountsResult, err := selectedWallet.GetAccountsRaw()
-		if err != nil {
-			return err
-		}
-
-		accounts := accountsResult.Acc
-		for _, account := range accounts {
-			if as.accountIsValid(account) && account.Number != accountID {
+			if as.accountIsValid(account) && account.Number != filter {
 				as.SetSelectedAccount(account)
 				as.callback(account)
 				return nil

--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -138,6 +138,28 @@ func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibw
 	return errors.New("no valid account found")
 }
 
+// SelectValidAccountExcept selects a valid account from the selectedWallet
+// except the account with accountID.
+func (as *AccountSelector) SelectValidAccountExcept(selectedWallet *dcrlibwallet.Wallet, accountID int32) error {
+	if selectedWallet != nil {
+		accountsResult, err := selectedWallet.GetAccountsRaw()
+		if err != nil {
+			return err
+		}
+
+		accounts := accountsResult.Acc
+		for _, account := range accounts {
+			if as.accountIsValid(account) && account.Number != accountID {
+				as.SetSelectedAccount(account)
+				as.callback(account)
+				return nil
+			}
+		}
+	}
+
+	return errors.New("no valid account found")
+}
+
 func (as *AccountSelector) SetSelectedAccount(account *dcrlibwallet.Account) {
 	wal := as.multiWallet.WalletWithID(account.WalletID)
 

--- a/ui/page/dexclient/create_wallet_modal.go
+++ b/ui/page/dexclient/create_wallet_modal.go
@@ -97,7 +97,7 @@ func (md *createWalletModal) OnResume() {
 	md.ctx, md.ctxCancel = context.WithCancel(context.TODO())
 	md.sourceAccountSelector.ListenForTxNotifications(md.ctx)
 
-	err := md.sourceAccountSelector.SelectFirstWalletValidAccount(nil)
+	err := md.sourceAccountSelector.SelectFirstWalletValidAccount(nil, -1)
 	if err != nil {
 		md.Toast.NotifyError(err.Error())
 	}

--- a/ui/page/privacy/manual_mixer_setup_page.go
+++ b/ui/page/privacy/manual_mixer_setup_page.go
@@ -84,7 +84,7 @@ func (pg *ManualMixerSetupPage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 
 	pg.mixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet)
-	pg.unmixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet)
+	pg.unmixedAccountSelector.SelectValidAccountExcept(pg.wallet, pg.mixedAccountSelector.SelectedAccount().Number)
 }
 
 // Layout draws the page UI components into the provided layout context

--- a/ui/page/privacy/manual_mixer_setup_page.go
+++ b/ui/page/privacy/manual_mixer_setup_page.go
@@ -83,8 +83,8 @@ func (pg *ManualMixerSetupPage) ID() string {
 func (pg *ManualMixerSetupPage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 
-	pg.mixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet)
-	pg.unmixedAccountSelector.SelectValidAccountExcept(pg.wallet, pg.mixedAccountSelector.SelectedAccount().Number)
+	pg.mixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet, -1)
+	pg.unmixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet, pg.mixedAccountSelector.SelectedAccount().Number)
 }
 
 // Layout draws the page UI components into the provided layout context

--- a/ui/page/privacy/manual_mixer_setup_page.go
+++ b/ui/page/privacy/manual_mixer_setup_page.go
@@ -215,6 +215,12 @@ func (pg *ManualMixerSetupPage) HandleUserInteractions() {
 	if pg.toPrivacySetup.Clicked() {
 		go pg.showModalSetupMixerAcct()
 	}
+
+	if pg.mixedAccountSelector.SelectedAccount().Number == pg.unmixedAccountSelector.SelectedAccount().Number {
+		pg.toPrivacySetup.SetEnabled(false)
+	} else {
+		pg.toPrivacySetup.SetEnabled(true)
+	}
 }
 
 // OnNavigatedFrom is called when the page is about to be removed from

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -135,7 +135,7 @@ func (pg *ReceivePage) ID() string {
 func (pg *ReceivePage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 	pg.selector.ListenForTxNotifications(pg.ctx)
-	pg.selector.SelectFirstWalletValidAccount(nil) // Want to reset the user's selection everytime this page appears?
+	pg.selector.SelectFirstWalletValidAccount(nil, -1) // Want to reset the user's selection everytime this page appears?
 	// might be better to track the last selection in a variable and reselect it.
 }
 

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -128,7 +128,7 @@ func NewSendPage(l *load.Load) *Page {
 
 	pg.sendDestination.destinationAccountSelector.AccountSelected(func(selectedAccount *dcrlibwallet.Account) {
 		pg.validateAndConstructTx()
-		pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil) // refresh source account
+		pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil, -1) // refresh source account
 	})
 
 	pg.sendDestination.addressChanged = func() {
@@ -167,8 +167,8 @@ func (pg *Page) OnNavigatedTo() {
 
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 	pg.sourceAccountSelector.ListenForTxNotifications(pg.ctx)
-	pg.sendDestination.destinationAccountSelector.SelectFirstWalletValidAccount(nil)
-	pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil)
+	pg.sendDestination.destinationAccountSelector.SelectFirstWalletValidAccount(nil, -1)
+	pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil, -1)
 	pg.sendDestination.destinationAddressEditor.Editor.Focus()
 
 	currencyExchangeValue := pg.WL.MultiWallet.ReadStringConfigValueForKey(dcrlibwallet.CurrencyConversionConfigKey)

--- a/ui/page/staking/auto_ticket_modal.go
+++ b/ui/page/staking/auto_ticket_modal.go
@@ -95,7 +95,7 @@ func (tb *ticketBuyerModal) OnResume() {
 	}
 
 	if tb.accountSelector.SelectedAccount() == nil {
-		err := tb.accountSelector.SelectFirstWalletValidAccount(nil)
+		err := tb.accountSelector.SelectFirstWalletValidAccount(nil, -1)
 		if err != nil {
 			tb.Toast.NotifyError(err.Error())
 		}

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -90,7 +90,7 @@ func (tp *stakingModal) OnResume() {
 
 	tp.accountSelector.ListenForTxNotifications(tp.ctx)
 
-	err := tp.accountSelector.SelectFirstWalletValidAccount(nil)
+	err := tp.accountSelector.SelectFirstWalletValidAccount(nil, -1)
 	if err != nil {
 		tp.Toast.NotifyError(err.Error())
 	}


### PR DESCRIPTION
This PR closes #856. It disables the set-up button on the cssp manual setup page if the unmixed and mixed account selector is the same account. It also sets different accounts for mixed/unmixed accounts when the manual setup page is navigated to.