### PR TITLE
Get recent address when Receive page is navigated to

### DIFF
--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -400,7 +400,7 @@ func (mp *MainPage) HandleUserInteractions() {
 				if mp.receivePage == nil {
 					mp.receivePage = NewReceivePage(mp.Load)
 				}
-				pg = NewReceivePage(mp.Load)
+				pg = mp.receivePage
 			}
 
 			if pg.ID() == mp.currentPageID() {

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -408,9 +408,11 @@ func (mp *MainPage) HandleUserInteractions() {
 			}
 
 			if !mp.WL.MultiWallet.IsSynced() {
-				mp.Toast.Notify("Wallet not synced")
-			} else {
 				mp.ChangeFragment(pg)
+			} else if mp.WL.MultiWallet.IsSyncing() {
+				mp.Toast.Notify("Wallet is syncing, please wait")
+			} else {
+				mp.Toast.Notify("Wallet not synced")
 			}
 		}
 	}

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -407,7 +407,13 @@ func (mp *MainPage) HandleUserInteractions() {
 				continue
 			}
 
-			mp.ChangeFragment(pg)
+			if !mp.WL.MultiWallet.IsConnectedToDecredNetwork() {
+				mp.Toast.Notify("Connect to the decred network and wait for sync to complete")
+			} else if mp.WL.MultiWallet.IsSyncing() {
+				mp.Toast.Notify("Wait for sync to complete")
+			} else {
+				mp.ChangeFragment(pg)
+			}
 		}
 	}
 

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -410,9 +410,9 @@ func (mp *MainPage) HandleUserInteractions() {
 			if mp.WL.MultiWallet.IsSynced() {
 				mp.ChangeFragment(pg)
 			} else if mp.WL.MultiWallet.IsSyncing() {
-				mp.Toast.Notify("Wallet is syncing, please wait")
+				mp.Toast.NotifyError("Wallet is syncing, please wait")
 			} else {
-				mp.Toast.Notify("Not connected to the Decred network")
+				mp.Toast.NotifyError("Not connected to the Decred network")
 			}
 		}
 	}

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -407,10 +407,8 @@ func (mp *MainPage) HandleUserInteractions() {
 				continue
 			}
 
-			if !mp.WL.MultiWallet.IsConnectedToDecredNetwork() {
-				mp.Toast.Notify("Connect to the decred network and wait for sync to complete")
-			} else if mp.WL.MultiWallet.IsSyncing() {
-				mp.Toast.Notify("Wait for sync to complete")
+			if !mp.WL.MultiWallet.IsSynced() {
+				mp.Toast.Notify("Wallet not synced")
 			} else {
 				mp.ChangeFragment(pg)
 			}

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -407,12 +407,12 @@ func (mp *MainPage) HandleUserInteractions() {
 				continue
 			}
 
-			if !mp.WL.MultiWallet.IsSynced() {
+			if mp.WL.MultiWallet.IsSynced() {
 				mp.ChangeFragment(pg)
 			} else if mp.WL.MultiWallet.IsSyncing() {
 				mp.Toast.Notify("Wallet is syncing, please wait")
 			} else {
-				mp.Toast.Notify("Wallet not synced")
+				mp.Toast.Notify("Not connected to the Decred network")
 			}
 		}
 	}

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -400,7 +400,7 @@ func (mp *MainPage) HandleUserInteractions() {
 				if mp.receivePage == nil {
 					mp.receivePage = NewReceivePage(mp.Load)
 				}
-				pg = mp.receivePage
+				pg = NewReceivePage(mp.Load)
 			}
 
 			if pg.ID() == mp.currentPageID() {

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -3,6 +3,7 @@ package page
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"image"
 	"image/color"
 	"time"
@@ -141,6 +142,7 @@ func (pg *ReceivePage) OnNavigatedTo() {
 	currentAddress, err := selectedWallet.CurrentAddress(pg.selector.SelectedAccount().Number)
 	if err != nil {
 		log.Errorf("Error getting current address: %v", err)
+		pg.Toast.NotifyError(fmt.Sprintf("Error getting current address: %v", err))
 	} else {
 		pg.currentAddress = currentAddress
 	}

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -145,9 +145,8 @@ func (pg *ReceivePage) OnNavigatedTo() {
 		pg.Toast.NotifyError(fmt.Sprintf("Error getting current address: %v", err))
 	} else {
 		pg.currentAddress = currentAddress
+		pg.generateQRForAddress()
 	}
-
-	pg.generateQRForAddress()
 }
 
 func (pg *ReceivePage) generateQRForAddress() {

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -137,6 +137,15 @@ func (pg *ReceivePage) OnNavigatedTo() {
 	pg.selector.ListenForTxNotifications(pg.ctx)
 	pg.selector.SelectFirstWalletValidAccount(nil) // Want to reset the user's selection everytime this page appears?
 	// might be better to track the last selection in a variable and reselect it.
+	selectedWallet := pg.multiWallet.WalletWithID(pg.selector.SelectedAccount().WalletID)
+	currentAddress, err := selectedWallet.CurrentAddress(pg.selector.SelectedAccount().Number)
+	if err != nil {
+		log.Errorf("Error getting current address: %v", err)
+	} else {
+		pg.currentAddress = currentAddress
+	}
+
+	pg.generateQRForAddress()
 }
 
 func (pg *ReceivePage) generateQRForAddress() {


### PR DESCRIPTION
Resolves #863 
This PR implements the following:
- Prevent access to send and receive pages until sync is complete. This is to prevent an unsynced account from calling the function that checks if an address has been used and returns a new one. Wallets that are not synced to the tip would not have enough information to get the last transaction 
- Generate a new instance of receive page whenever it is navigated to. This is to ensure that transaction addresses are not reused which improves wallet privacy 
- Add notification messages to let users know that sync needs to be completed before send and receive pages can be accessed
