### PR TITLE
don't use default account during stake shuffle.

### DIFF
--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -94,9 +94,9 @@ func (as *AccountSelector) Handle() {
 }
 
 // SelectFirstWalletValidAccount selects the first valid account from the
-// first wallet in the SortedWalletList, skipping any account whose number is in filterAccounts slice.
+// first wallet in the SortedWalletList
 // If selectedWallet is not nil, the first account for the selectWallet is selected.
-func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibwallet.Wallet, filterAccounts []int32) error {
+func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibwallet.Wallet) error {
 	if as.selectedAccount != nil && as.accountIsValid(as.selectedAccount) {
 		as.UpdateSelectedAccountBalance()
 		// no need to select account
@@ -111,25 +111,10 @@ func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibw
 
 		accounts := accountsResult.Acc
 		for _, account := range accounts {
-			if len(filterAccounts) > 0 {
-				accFound := false
-				for _, v := range filterAccounts {
-					if account.Number == v {
-						accFound = true
-					}
-				}
-
-				if as.accountIsValid(account) && !accFound {
-					as.SetSelectedAccount(account)
-					as.callback(account)
-					return nil
-				}
-			} else {
-				if as.accountIsValid(account) {
-					as.SetSelectedAccount(account)
-					as.callback(account)
-					return nil
-				}
+			if as.accountIsValid(account) {
+				as.SetSelectedAccount(account)
+				as.callback(account)
+				return nil
 			}
 		}
 	}
@@ -142,25 +127,10 @@ func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibw
 
 		accounts := accountsResult.Acc
 		for _, account := range accounts {
-			if len(filterAccounts) > 0 {
-				accFound := false
-				for _, v := range filterAccounts {
-					if account.Number == v {
-						accFound = true
-					}
-				}
-
-				if as.accountIsValid(account) && !accFound {
-					as.SetSelectedAccount(account)
-					as.callback(account)
-					return nil
-				}
-			} else {
-				if as.accountIsValid(account) {
-					as.SetSelectedAccount(account)
-					as.callback(account)
-					return nil
-				}
+			if as.accountIsValid(account) {
+				as.SetSelectedAccount(account)
+				as.callback(account)
+				return nil
 			}
 		}
 	}

--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -94,9 +94,9 @@ func (as *AccountSelector) Handle() {
 }
 
 // SelectFirstWalletValidAccount selects the first valid account from the
-// first wallet in the SortedWalletList, skipping any account whose ID is == filter.
+// first wallet in the SortedWalletList, skipping any account whose number is in filterAccounts slice.
 // If selectedWallet is not nil, the first account for the selectWallet is selected.
-func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibwallet.Wallet, filter int32) error {
+func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibwallet.Wallet, filterAccounts []int32) error {
 	if as.selectedAccount != nil && as.accountIsValid(as.selectedAccount) {
 		as.UpdateSelectedAccountBalance()
 		// no need to select account
@@ -111,10 +111,25 @@ func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibw
 
 		accounts := accountsResult.Acc
 		for _, account := range accounts {
-			if as.accountIsValid(account) && account.Number != filter {
-				as.SetSelectedAccount(account)
-				as.callback(account)
-				return nil
+			if len(filterAccounts) > 0 {
+				accFound := false
+				for _, v := range filterAccounts {
+					if account.Number == v {
+						accFound = true
+					}
+				}
+
+				if as.accountIsValid(account) && !accFound {
+					as.SetSelectedAccount(account)
+					as.callback(account)
+					return nil
+				}
+			} else {
+				if as.accountIsValid(account) {
+					as.SetSelectedAccount(account)
+					as.callback(account)
+					return nil
+				}
 			}
 		}
 	}
@@ -127,10 +142,25 @@ func (as *AccountSelector) SelectFirstWalletValidAccount(selectedWallet *dcrlibw
 
 		accounts := accountsResult.Acc
 		for _, account := range accounts {
-			if as.accountIsValid(account) && account.Number != filter {
-				as.SetSelectedAccount(account)
-				as.callback(account)
-				return nil
+			if len(filterAccounts) > 0 {
+				accFound := false
+				for _, v := range filterAccounts {
+					if account.Number == v {
+						accFound = true
+					}
+				}
+
+				if as.accountIsValid(account) && !accFound {
+					as.SetSelectedAccount(account)
+					as.callback(account)
+					return nil
+				}
+			} else {
+				if as.accountIsValid(account) {
+					as.SetSelectedAccount(account)
+					as.callback(account)
+					return nil
+				}
 			}
 		}
 	}

--- a/ui/page/dexclient/create_wallet_modal.go
+++ b/ui/page/dexclient/create_wallet_modal.go
@@ -97,7 +97,7 @@ func (md *createWalletModal) OnResume() {
 	md.ctx, md.ctxCancel = context.WithCancel(context.TODO())
 	md.sourceAccountSelector.ListenForTxNotifications(md.ctx)
 
-	err := md.sourceAccountSelector.SelectFirstWalletValidAccount(nil, []int32{})
+	err := md.sourceAccountSelector.SelectFirstWalletValidAccount(nil)
 	if err != nil {
 		md.Toast.NotifyError(err.Error())
 	}

--- a/ui/page/dexclient/create_wallet_modal.go
+++ b/ui/page/dexclient/create_wallet_modal.go
@@ -97,7 +97,7 @@ func (md *createWalletModal) OnResume() {
 	md.ctx, md.ctxCancel = context.WithCancel(context.TODO())
 	md.sourceAccountSelector.ListenForTxNotifications(md.ctx)
 
-	err := md.sourceAccountSelector.SelectFirstWalletValidAccount(nil, -1)
+	err := md.sourceAccountSelector.SelectFirstWalletValidAccount(nil, []int32{})
 	if err != nil {
 		md.Toast.NotifyError(err.Error())
 	}

--- a/ui/page/privacy/manual_mixer_setup_page.go
+++ b/ui/page/privacy/manual_mixer_setup_page.go
@@ -221,6 +221,13 @@ func (pg *ManualMixerSetupPage) HandleUserInteractions() {
 	} else {
 		pg.toPrivacySetup.SetEnabled(true)
 	}
+
+	// Disable set up button if either mixed or unmixed account is the default account.
+	if pg.mixedAccountSelector.SelectedAccount().Number == dcrlibwallet.DefaultAccountNum ||
+		pg.unmixedAccountSelector.SelectedAccount().Number == dcrlibwallet.DefaultAccountNum {
+		pg.toPrivacySetup.SetEnabled(false)
+	}
+
 }
 
 // OnNavigatedFrom is called when the page is about to be removed from

--- a/ui/page/privacy/manual_mixer_setup_page.go
+++ b/ui/page/privacy/manual_mixer_setup_page.go
@@ -45,10 +45,19 @@ func NewManualMixerSetupPage(l *load.Load, wallet *dcrlibwallet.Wallet) *ManualM
 		AccountValidator(func(account *dcrlibwallet.Account) bool {
 			wal := pg.Load.WL.MultiWallet.WalletWithID(account.WalletID)
 
-			// Imported and watch only wallet accounts are invalid to use as a mixed account
-			accountIsValid := account.Number != load.MaxInt32 && !wal.IsWatchingOnlyWallet()
+			var unmixedAccNo int32 = -1
+			if unmixedAcc := pg.unmixedAccountSelector.SelectedAccount(); unmixedAcc != nil {
+				unmixedAccNo = unmixedAcc.Number
+			}
 
-			return accountIsValid
+			// Imported, watch only and default wallet accounts are invalid to use as a mixed account
+			accountIsValid := account.Number != load.MaxInt32 && !wal.IsWatchingOnlyWallet() && account.Number != dcrlibwallet.DefaultAccountNum
+
+			if !accountIsValid || account.Number == unmixedAccNo {
+				return false
+			}
+
+			return true
 		})
 
 	// Unmixed account picker
@@ -58,10 +67,20 @@ func NewManualMixerSetupPage(l *load.Load, wallet *dcrlibwallet.Wallet) *ManualM
 		AccountValidator(func(account *dcrlibwallet.Account) bool {
 			wal := pg.Load.WL.MultiWallet.WalletWithID(account.WalletID)
 
-			// Imported and watch only wallet accounts are invalid to use as an unmixed account
-			accountIsValid := account.Number != load.MaxInt32 && !wal.IsWatchingOnlyWallet()
+			var mixedAccNo int32 = -1
+			if mixedAcc := pg.mixedAccountSelector.SelectedAccount(); mixedAcc != nil {
+				mixedAccNo = mixedAcc.Number
+			}
 
-			return accountIsValid
+			// Imported, watch only and default wallet accounts are invalid to use as an unmixed account
+			accountIsValid := account.Number != load.MaxInt32 && !wal.IsWatchingOnlyWallet() && account.Number != dcrlibwallet.DefaultAccountNum
+
+			// Account is invalid if already selected by mixed account selector.
+			if !accountIsValid || account.Number == mixedAccNo {
+				return false
+			}
+
+			return true
 		})
 
 	pg.backButton, pg.infoButton = components.SubpageHeaderButtons(l)
@@ -83,8 +102,8 @@ func (pg *ManualMixerSetupPage) ID() string {
 func (pg *ManualMixerSetupPage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 
-	pg.mixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet, []int32{dcrlibwallet.DefaultAccountNum})
-	pg.unmixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet, []int32{dcrlibwallet.DefaultAccountNum, pg.mixedAccountSelector.SelectedAccount().Number})
+	pg.mixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet)
+	pg.unmixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet)
 }
 
 // Layout draws the page UI components into the provided layout context

--- a/ui/page/privacy/manual_mixer_setup_page.go
+++ b/ui/page/privacy/manual_mixer_setup_page.go
@@ -83,8 +83,8 @@ func (pg *ManualMixerSetupPage) ID() string {
 func (pg *ManualMixerSetupPage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 
-	pg.mixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet, -1)
-	pg.unmixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet, pg.mixedAccountSelector.SelectedAccount().Number)
+	pg.mixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet, []int32{dcrlibwallet.DefaultAccountNum})
+	pg.unmixedAccountSelector.SelectFirstWalletValidAccount(pg.wallet, []int32{dcrlibwallet.DefaultAccountNum, pg.mixedAccountSelector.SelectedAccount().Number})
 }
 
 // Layout draws the page UI components into the provided layout context

--- a/ui/page/privacy/setup_privacy_page.go
+++ b/ui/page/privacy/setup_privacy_page.go
@@ -158,9 +158,9 @@ func (pg *SetupPrivacyPage) HandleUserInteractions() {
 		}
 
 		walCount := accounts.Count
-		// Filter out imported account.
+		// Filter out imported account and default account.
 		for _, v := range accounts.Acc {
-			if v.Number == dcrlibwallet.ImportedAccountNumber {
+			if v.Number == dcrlibwallet.ImportedAccountNumber || v.Number == dcrlibwallet.DefaultAccountNum {
 				walCount--
 			}
 		}

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -135,7 +135,7 @@ func (pg *ReceivePage) ID() string {
 func (pg *ReceivePage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 	pg.selector.ListenForTxNotifications(pg.ctx)
-	pg.selector.SelectFirstWalletValidAccount(nil, -1) // Want to reset the user's selection everytime this page appears?
+	pg.selector.SelectFirstWalletValidAccount(nil, []int32{}) // Want to reset the user's selection everytime this page appears?
 	// might be better to track the last selection in a variable and reselect it.
 }
 

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -135,7 +135,7 @@ func (pg *ReceivePage) ID() string {
 func (pg *ReceivePage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 	pg.selector.ListenForTxNotifications(pg.ctx)
-	pg.selector.SelectFirstWalletValidAccount(nil, []int32{}) // Want to reset the user's selection everytime this page appears?
+	pg.selector.SelectFirstWalletValidAccount(nil) // Want to reset the user's selection everytime this page appears?
 	// might be better to track the last selection in a variable and reselect it.
 }
 

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -128,7 +128,7 @@ func NewSendPage(l *load.Load) *Page {
 
 	pg.sendDestination.destinationAccountSelector.AccountSelected(func(selectedAccount *dcrlibwallet.Account) {
 		pg.validateAndConstructTx()
-		pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil, -1) // refresh source account
+		pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil, []int32{}) // refresh source account
 	})
 
 	pg.sendDestination.addressChanged = func() {
@@ -167,8 +167,8 @@ func (pg *Page) OnNavigatedTo() {
 
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 	pg.sourceAccountSelector.ListenForTxNotifications(pg.ctx)
-	pg.sendDestination.destinationAccountSelector.SelectFirstWalletValidAccount(nil, -1)
-	pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil, -1)
+	pg.sendDestination.destinationAccountSelector.SelectFirstWalletValidAccount(nil, []int32{})
+	pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil, []int32{})
 	pg.sendDestination.destinationAddressEditor.Editor.Focus()
 
 	currencyExchangeValue := pg.WL.MultiWallet.ReadStringConfigValueForKey(dcrlibwallet.CurrencyConversionConfigKey)

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -128,7 +128,7 @@ func NewSendPage(l *load.Load) *Page {
 
 	pg.sendDestination.destinationAccountSelector.AccountSelected(func(selectedAccount *dcrlibwallet.Account) {
 		pg.validateAndConstructTx()
-		pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil, []int32{}) // refresh source account
+		pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil) // refresh source account
 	})
 
 	pg.sendDestination.addressChanged = func() {
@@ -167,8 +167,8 @@ func (pg *Page) OnNavigatedTo() {
 
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 	pg.sourceAccountSelector.ListenForTxNotifications(pg.ctx)
-	pg.sendDestination.destinationAccountSelector.SelectFirstWalletValidAccount(nil, []int32{})
-	pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil, []int32{})
+	pg.sendDestination.destinationAccountSelector.SelectFirstWalletValidAccount(nil)
+	pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil)
 	pg.sendDestination.destinationAddressEditor.Editor.Focus()
 
 	currencyExchangeValue := pg.WL.MultiWallet.ReadStringConfigValueForKey(dcrlibwallet.CurrencyConversionConfigKey)

--- a/ui/page/staking/auto_ticket_modal.go
+++ b/ui/page/staking/auto_ticket_modal.go
@@ -95,7 +95,7 @@ func (tb *ticketBuyerModal) OnResume() {
 	}
 
 	if tb.accountSelector.SelectedAccount() == nil {
-		err := tb.accountSelector.SelectFirstWalletValidAccount(nil, []int32{})
+		err := tb.accountSelector.SelectFirstWalletValidAccount(nil)
 		if err != nil {
 			tb.Toast.NotifyError(err.Error())
 		}

--- a/ui/page/staking/auto_ticket_modal.go
+++ b/ui/page/staking/auto_ticket_modal.go
@@ -95,7 +95,7 @@ func (tb *ticketBuyerModal) OnResume() {
 	}
 
 	if tb.accountSelector.SelectedAccount() == nil {
-		err := tb.accountSelector.SelectFirstWalletValidAccount(nil, -1)
+		err := tb.accountSelector.SelectFirstWalletValidAccount(nil, []int32{})
 		if err != nil {
 			tb.Toast.NotifyError(err.Error())
 		}

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -90,7 +90,7 @@ func (tp *stakingModal) OnResume() {
 
 	tp.accountSelector.ListenForTxNotifications(tp.ctx)
 
-	err := tp.accountSelector.SelectFirstWalletValidAccount(nil, []int32{})
+	err := tp.accountSelector.SelectFirstWalletValidAccount(nil)
 	if err != nil {
 		tp.Toast.NotifyError(err.Error())
 	}

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -90,7 +90,7 @@ func (tp *stakingModal) OnResume() {
 
 	tp.accountSelector.ListenForTxNotifications(tp.ctx)
 
-	err := tp.accountSelector.SelectFirstWalletValidAccount(nil, -1)
+	err := tp.accountSelector.SelectFirstWalletValidAccount(nil, []int32{})
 	if err != nil {
 		tp.Toast.NotifyError(err.Error())
 	}


### PR DESCRIPTION
This PR closes #903, specifically:
1. It doesn't count the default account when determining if manual/auto-setup should be used.
2. When on manual set up page it doesn't prefill default account.
3. It disables set up button if the default account is set for either the mixed or unmixed account. 