### PR TITLE
rework key event handling

### DIFF
--- a/ui/decredmaterial/theme.go
+++ b/ui/decredmaterial/theme.go
@@ -287,32 +287,28 @@ func HandleEditorEvents(editors ...*widget.Editor) (bool, bool) {
 	return submit, changed
 }
 
-func SwitchEditors(keyEvent chan *key.Event, editors ...*widget.Editor) {
-	select {
-	case event := <-keyEvent:
-		if event.Name == key.NameTab && event.Modifiers != key.ModShift && event.State == key.Press {
-			for i := 0; i < len(editors); i++ {
-				if editors[i].Focused() {
-					if i == len(editors)-1 {
-						editors[0].Focus()
-					} else {
-						editors[i+1].Focus()
-					}
+func SwitchEditors(event *key.Event, editors ...*widget.Editor) {
+	if event.Name == key.NameTab && event.Modifiers != key.ModShift && event.State == key.Press {
+		for i := 0; i < len(editors); i++ {
+			if editors[i].Focused() {
+				if i == len(editors)-1 {
+					editors[0].Focus()
+				} else {
+					editors[i+1].Focus()
 				}
 			}
 		}
+	}
 
-		if event.Name == key.NameTab && event.Modifiers == key.ModShift && event.State == key.Press {
-			for i := 0; i < len(editors); i++ {
-				if editors[i].Focused() {
-					if i == 0 {
-						editors[len(editors)-1].Focus()
-					} else {
-						editors[i-1].Focus()
-					}
+	if event.Name == key.NameTab && event.Modifiers == key.ModShift && event.State == key.Press {
+		for i := 0; i < len(editors); i++ {
+			if editors[i].Focused() {
+				if i == 0 {
+					editors[len(editors)-1].Focus()
+				} else {
+					editors[i-1].Focus()
 				}
 			}
 		}
-	default:
 	}
 }

--- a/ui/load/interface.go
+++ b/ui/load/interface.go
@@ -1,6 +1,9 @@
 package load
 
-import "gioui.org/layout"
+import (
+	"gioui.org/io/key"
+	"gioui.org/layout"
+)
 
 // Page defines methods that control the appearance and functionality of
 // UI components displayed on a window.
@@ -52,4 +55,11 @@ type AppSettingsChangeHandler interface {
 	// OnLanguageChanged is triggered whenever the language setting is changed
 	// to enable UI language update where necessary especially on page Nav
 	OnLanguageChanged()
+}
+
+// KeyEventHandler is implemented by pages and modals that require key event
+// notifications.
+type KeyEventHandler interface {
+	// HandleKeyEvent is called when a key is pressed on the current window.
+	HandleKeyEvent(*key.Event)
 }

--- a/ui/load/load.go
+++ b/ui/load/load.go
@@ -8,8 +8,6 @@ package load
 import (
 	"golang.org/x/text/message"
 
-	"gioui.org/io/key"
-
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/assets"
 	"github.com/planetdecred/godcr/ui/decredmaterial"
@@ -21,34 +19,27 @@ type DCRUSDTBittrex struct {
 	LastTradeRate string
 }
 
-type Receiver struct {
-	KeyEvents map[string]chan *key.Event
-}
-
 type Load struct {
 	Theme *decredmaterial.Theme
 
-	WL       *WalletLoad
-	Receiver *Receiver
-	Printer  *message.Printer
-	Network  string
+	WL      *WalletLoad
+	Printer *message.Printer
+	Network string
 
 	Toast *notification.Toast
 
 	SelectedUTXO map[int]map[int32]map[string]*wallet.UnspentOutput
 
-	ToggleSync          func()
-	RefreshWindow       func()
-	ShowModal           func(Modal)
-	DismissModal        func(Modal)
-	ChangeWindowPage    func(page Page, keepBackStack bool)
-	PopWindowPage       func() bool
-	ChangeFragment      func(page Page)
-	PopFragment         func()
-	PopToFragment       func(pageID string)
-	SubscribeKeyEvent   func(eventChan chan *key.Event, pageID string) // Widgets call this function to recieve key events.
-	UnsubscribeKeyEvent func(pageID string) error
-	ReloadApp           func()
+	ToggleSync       func()
+	RefreshWindow    func()
+	ShowModal        func(Modal)
+	DismissModal     func(Modal)
+	ChangeWindowPage func(page Page, keepBackStack bool)
+	PopWindowPage    func() bool
+	ChangeFragment   func(page Page)
+	PopFragment      func()
+	PopToFragment    func(pageID string)
+	ReloadApp        func()
 
 	DarkModeSettingChanged func(bool)
 	LanguageSettingChanged func()

--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -26,7 +26,6 @@ type CreatePasswordModal struct {
 	passwordEditor        decredmaterial.Editor
 	confirmPasswordEditor decredmaterial.Editor
 	passwordStrength      decredmaterial.ProgressBarStyle
-	keyEvent              chan *key.Event
 
 	isLoading          bool
 	isCancelable       bool
@@ -58,7 +57,6 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 		btnPositve:       l.Theme.Button("Confirm"),
 		btnNegative:      l.Theme.OutlineButton("Cancel"),
 		isCancelable:     true,
-		keyEvent:         make(chan *key.Event),
 	}
 
 	cm.btnPositve.Font.Weight = text.Medium
@@ -77,8 +75,6 @@ func NewCreatePasswordModal(l *load.Load) *CreatePasswordModal {
 
 	cm.materialLoader = material.Loader(l.Theme.Base)
 
-	l.SubscribeKeyEvent(cm.keyEvent, cm.randomID)
-
 	return cm
 }
 
@@ -94,9 +90,7 @@ func (cm *CreatePasswordModal) OnResume() {
 	}
 }
 
-func (cm *CreatePasswordModal) OnDismiss() {
-	cm.Load.UnsubscribeKeyEvent(cm.randomID)
-}
+func (cm *CreatePasswordModal) OnDismiss() {}
 
 func (cm *CreatePasswordModal) Show() {
 	cm.ShowModal(cm)
@@ -235,10 +229,15 @@ func (cm *CreatePasswordModal) Handle() {
 	}
 
 	computePasswordStrength(&cm.passwordStrength, cm.Theme, cm.passwordEditor.Editor)
+}
+
+// HandleKeyEvent is called when a key is pressed on the current window.
+// Satisfies the load.KeyEventHandler interface for receiving key events.
+func (cm *CreatePasswordModal) HandleKeyEvent(evt *key.Event) {
 	if cm.walletNameEnabled {
-		decredmaterial.SwitchEditors(cm.keyEvent, cm.walletName.Editor, cm.passwordEditor.Editor, cm.confirmPasswordEditor.Editor)
+		decredmaterial.SwitchEditors(evt, cm.walletName.Editor, cm.passwordEditor.Editor, cm.confirmPasswordEditor.Editor)
 	} else {
-		decredmaterial.SwitchEditors(cm.keyEvent, cm.passwordEditor.Editor, cm.confirmPasswordEditor.Editor)
+		decredmaterial.SwitchEditors(evt, cm.passwordEditor.Editor, cm.confirmPasswordEditor.Editor)
 	}
 }
 

--- a/ui/modal/create_watch_only_modal.go
+++ b/ui/modal/create_watch_only_modal.go
@@ -27,7 +27,6 @@ type CreateWatchOnlyModal struct {
 
 	btnPositve  decredmaterial.Button
 	btnNegative decredmaterial.Button
-	keyEvent    chan *key.Event
 
 	randomID string
 
@@ -46,7 +45,6 @@ func NewCreateWatchOnlyModal(l *load.Load) *CreateWatchOnlyModal {
 		btnPositve:   l.Theme.Button(values.String(values.StrImport)),
 		btnNegative:  l.Theme.OutlineButton(values.String(values.StrCancel)),
 		isCancelable: true,
-		keyEvent:     make(chan *key.Event),
 	}
 
 	cm.btnPositve.Font.Weight = text.Medium
@@ -71,12 +69,9 @@ func (cm *CreateWatchOnlyModal) ModalID() string {
 
 func (cm *CreateWatchOnlyModal) OnResume() {
 	cm.walletName.Editor.Focus()
-	cm.Load.SubscribeKeyEvent(cm.keyEvent, cm.randomID)
 }
 
-func (cm *CreateWatchOnlyModal) OnDismiss() {
-	cm.Load.UnsubscribeKeyEvent(cm.randomID)
-}
+func (cm *CreateWatchOnlyModal) OnDismiss() {}
 
 func (cm *CreateWatchOnlyModal) Show() {
 	cm.ShowModal(cm)
@@ -165,7 +160,12 @@ func (cm *CreateWatchOnlyModal) Handle() {
 			cm.Dismiss()
 		}
 	}
-	decredmaterial.SwitchEditors(cm.keyEvent, cm.walletName.Editor, cm.extendedPubKey.Editor)
+}
+
+// HandleKeyEvent is called when a key is pressed on the current window.
+// Satisfies the load.KeyEventHandler interface for receiving key events.
+func (cm *CreateWatchOnlyModal) HandleKeyEvent(evt *key.Event) {
+	decredmaterial.SwitchEditors(evt, cm.walletName.Editor, cm.extendedPubKey.Editor)
 }
 
 func (cm *CreateWatchOnlyModal) Layout(gtx layout.Context) D {

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -18,7 +18,6 @@ type InfoModal struct {
 	*load.Load
 	randomID        string
 	modal           decredmaterial.Modal
-	keyEvent        chan *key.Event
 	enterKeyPressed bool
 
 	dialogIcon *decredmaterial.Icon
@@ -51,15 +50,12 @@ func NewInfoModal(l *load.Load) *InfoModal {
 		modal:        *l.Theme.ModalFloatTitle(),
 		btnPositve:   l.Theme.OutlineButton("Yes"),
 		btnNegative:  l.Theme.OutlineButton("No"),
-		keyEvent:     make(chan *key.Event),
 		isCancelable: true,
 		btnAlignment: layout.E,
 	}
 
 	in.btnPositve.Font.Weight = text.Medium
 	in.btnNegative.Font.Weight = text.Medium
-
-	in.dismissModalOnEnterKey()
 
 	return in
 }
@@ -76,13 +72,9 @@ func (in *InfoModal) Dismiss() {
 	in.DismissModal(in)
 }
 
-func (in *InfoModal) OnResume() {
-	in.Load.SubscribeKeyEvent(in.keyEvent, in.randomID)
-}
+func (in *InfoModal) OnResume() {}
 
-func (in *InfoModal) OnDismiss() {
-	in.Load.UnsubscribeKeyEvent(in.randomID)
-}
+func (in *InfoModal) OnDismiss() {}
 
 func (in *InfoModal) SetCancelable(min bool) *InfoModal {
 	in.isCancelable = min
@@ -168,16 +160,13 @@ func (in *InfoModal) UseCustomWidget(layout layout.Widget) *InfoModal {
 	return in
 }
 
-func (in *InfoModal) dismissModalOnEnterKey() {
-	go func() {
-		for {
-			event := <-in.keyEvent
-			if (event.Name == key.NameReturn || event.Name == key.NameEnter) && event.State == key.Press {
-				in.btnPositve.Click()
-				in.RefreshWindow()
-			}
-		}
-	}()
+// HandleKeyEvent is called when a key is pressed on the current window.
+// Satisfies the load.KeyEventHandler interface for receiving key events.
+func (in *InfoModal) HandleKeyEvent(evt *key.Event) {
+	if (evt.Name == key.NameReturn || evt.Name == key.NameEnter) && evt.State == key.Press {
+		in.btnPositve.Click()
+		in.RefreshWindow()
+	}
 }
 
 func (in *InfoModal) Handle() {

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"gioui.org/io/key"
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
@@ -464,6 +465,16 @@ func (mp *MainPage) HandleUserInteractions() {
 	for mp.hideBalanceItem.hideBalanceButton.Button.Clicked() {
 		mp.isBalanceHidden = !mp.isBalanceHidden
 		mp.WL.MultiWallet.SetBoolConfigValueForKey(load.HideBalanceConfigKey, mp.isBalanceHidden)
+	}
+}
+
+// HandleKeyEvent is called when a key is pressed on the current window.
+// Satisfies the load.KeyEventHandler interface for receiving key events.
+func (mp *MainPage) HandleKeyEvent(evt *key.Event) {
+	if mp.currentPage != nil {
+		if keyEvtHandler, ok := mp.currentPage.(load.KeyEventHandler); ok {
+			keyEvtHandler.HandleKeyEvent(evt)
+		}
 	}
 }
 

--- a/ui/page/verify_message_page.go
+++ b/ui/page/verify_message_page.go
@@ -23,7 +23,6 @@ type VerifyMessagePage struct {
 	signatureEditor        decredmaterial.Editor
 	clearBtn, verifyButton decredmaterial.Button
 	verifyMessage          decredmaterial.Label
-	keyEvent               chan *key.Event
 	EnableEditorSwitch     bool
 
 	verifyMessageStatus *decredmaterial.Icon
@@ -38,7 +37,6 @@ func NewVerifyMessagePage(l *load.Load) *VerifyMessagePage {
 	pg := &VerifyMessagePage{
 		Load:               l,
 		verifyMessage:      l.Theme.Body1(""),
-		keyEvent:           make(chan *key.Event),
 		EnableEditorSwitch: false,
 	}
 
@@ -77,7 +75,6 @@ func (pg *VerifyMessagePage) ID() string {
 // Part of the load.Page interface.
 func (pg *VerifyMessagePage) OnNavigatedTo() {
 	pg.addressEditor.Editor.Focus()
-	pg.Load.SubscribeKeyEvent(pg.keyEvent, pg.ID())
 }
 
 // Layout draws the page UI components into the provided layout context
@@ -212,10 +209,15 @@ func (pg *VerifyMessagePage) HandleUserInteractions() {
 	if pg.clearBtn.Clicked() {
 		pg.clearInputs()
 	}
-
-	//Switch editors on tab press
-	decredmaterial.SwitchEditors(pg.keyEvent, pg.addressEditor.Editor, pg.signatureEditor.Editor, pg.messageEditor.Editor)
 }
+
+// HandleKeyEvent is called when a key is pressed on the current window.
+// Satisfies the load.KeyEventHandler interface for receiving key events.
+func (pg *VerifyMessagePage) HandleKeyEvent(evt *key.Event) {
+	// Switch editors on tab press.
+	decredmaterial.SwitchEditors(evt, pg.addressEditor.Editor, pg.signatureEditor.Editor, pg.messageEditor.Editor)
+}
+
 func (pg *VerifyMessagePage) validateAllInputs() bool {
 	if !pg.validateAddress() {
 		return false
@@ -285,6 +287,4 @@ func (pg *VerifyMessagePage) validateAddress() bool {
 // OnNavigatedTo() will be called again. This method should not destroy UI
 // components unless they'll be recreated in the OnNavigatedTo() method.
 // Part of the load.Page interface.
-func (pg *VerifyMessagePage) OnNavigatedFrom() {
-	pg.Load.UnsubscribeKeyEvent(pg.ID())
-}
+func (pg *VerifyMessagePage) OnNavigatedFrom() {}

--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -37,6 +37,7 @@ type seedItemMenu struct {
 
 type Restore struct {
 	*load.Load
+	isRestoring     bool
 	restoreComplete func()
 
 	seedList *layout.List
@@ -61,7 +62,6 @@ type Restore struct {
 	isLastEditor bool
 
 	seedEditors              seedEditors
-	keyEvent                 chan *key.Event
 	nextcurrentCaretPosition int // caret position when seed editor is switched
 	currentCaretPosition     int // current caret position
 	selectedSeedEditor       int // stores the current focus index of seed editors
@@ -73,8 +73,6 @@ func NewRestorePage(l *load.Load, onRestoreComplete func()) *Restore {
 		restoreComplete: onRestoreComplete,
 
 		seedList: &layout.List{Axis: layout.Vertical},
-
-		keyEvent: make(chan *key.Event),
 
 		suggestionLimit: 3,
 		openPopupIndex:  -1,
@@ -105,7 +103,6 @@ func NewRestorePage(l *load.Load, onRestoreComplete func()) *Restore {
 
 	// set suggestions
 	pg.allSuggestions = dcrlibwallet.PGPWordList()
-	l.SubscribeKeyEvent(pg.keyEvent, pg.ID())
 
 	return pg
 }
@@ -121,9 +118,7 @@ func (pg *Restore) ID() string {
 // may be used to initialize page features that are only relevant when
 // the page is displayed.
 // Part of the load.Page interface.
-func (pg *Restore) OnNavigatedTo() {
-	pg.Load.SubscribeKeyEvent(pg.keyEvent, pg.ID())
-}
+func (pg *Restore) OnNavigatedTo() {}
 
 // Layout draws the page UI components into the provided layout context
 // to be eventually drawn on screen.
@@ -503,8 +498,7 @@ func (pg *Restore) HandleUserInteractions() {
 			return
 		}
 
-		pg.Load.UnsubscribeKeyEvent(pg.ID())
-
+		pg.isRestoring = true
 		modal.NewCreatePasswordModal(pg.Load).
 			Title("Enter wallet details").
 			EnableName(true).
@@ -516,6 +510,7 @@ func (pg *Restore) HandleUserInteractions() {
 					if err != nil {
 						m.SetError(components.TranslateErr(err))
 						m.SetLoading(false)
+						pg.isRestoring = false
 						return
 					}
 
@@ -539,51 +534,6 @@ func (pg *Restore) HandleUserInteractions() {
 		pg.seedEditors.focusIndex = -1
 	}
 
-	// handle key events
-	select {
-	case evt := <-pg.keyEvent:
-		if evt.Name == key.NameTab && evt.Modifiers != key.ModShift && evt.State == key.Press {
-			if len(pg.suggestions) > 0 {
-				focus := pg.seedEditors.focusIndex
-				pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[pg.selected])
-				pg.seedClicked = true
-				pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[pg.selected]), -1)
-			}
-			switchSeedEditors(pg.seedEditors.editors)
-		}
-		if evt.Name == key.NameTab && evt.Modifiers == key.ModShift && evt.State == key.Press {
-			for i := 0; i < len(pg.seedEditors.editors); i++ {
-				if pg.seedEditors.editors[i].Edit.Editor.Focused() {
-					if i == 0 {
-						pg.seedEditors.editors[len(pg.seedEditors.editors)-1].Edit.Editor.Focus()
-					} else {
-						pg.seedEditors.editors[i-1].Edit.Editor.Focus()
-					}
-				}
-			}
-		}
-		if evt.Name == key.NameUpArrow && pg.openPopupIndex != -1 && evt.State == key.Press {
-			pg.selected--
-			if pg.selected < 0 {
-				pg.selected = 0
-			}
-		}
-		if evt.Name == key.NameDownArrow && pg.openPopupIndex != -1 && evt.State == key.Press {
-			pg.selected++
-			if pg.selected >= len(pg.suggestions) {
-				pg.selected = len(pg.suggestions) - 1
-			}
-		}
-		if (evt.Name == key.NameReturn || evt.Name == key.NameEnter) && pg.openPopupIndex != -1 && evt.State == key.Press && len(pg.suggestions) != 0 {
-			if pg.seedEditors.focusIndex == -1 && len(pg.suggestions) == 1 {
-				return
-			}
-
-			pg.seedMenu[pg.selected].button.Click()
-		}
-	default:
-	}
-
 	pg.editorSeedsEventsHandler()
 	pg.onSuggestionSeedsClicked()
 	pg.suggestionSeedEffect()
@@ -597,6 +547,53 @@ func (pg *Restore) HandleUserInteractions() {
 
 	if pg.currentCaretPositionChanged() {
 		pg.selected = 0
+	}
+}
+
+// HandleKeyEvent is called when a key is pressed on the current window.
+// Satisfies the load.KeyEventHandler interface for receiving key events.
+func (pg *Restore) HandleKeyEvent(evt *key.Event) {
+	if pg.isRestoring {
+		return
+	}
+	if evt.Name == key.NameTab && evt.Modifiers != key.ModShift && evt.State == key.Press {
+		if len(pg.suggestions) > 0 {
+			focus := pg.seedEditors.focusIndex
+			pg.seedEditors.editors[focus].Edit.Editor.SetText(pg.suggestions[pg.selected])
+			pg.seedClicked = true
+			pg.seedEditors.editors[focus].Edit.Editor.MoveCaret(len(pg.suggestions[pg.selected]), -1)
+		}
+		switchSeedEditors(pg.seedEditors.editors)
+	}
+	if evt.Name == key.NameTab && evt.Modifiers == key.ModShift && evt.State == key.Press {
+		for i := 0; i < len(pg.seedEditors.editors); i++ {
+			if pg.seedEditors.editors[i].Edit.Editor.Focused() {
+				if i == 0 {
+					pg.seedEditors.editors[len(pg.seedEditors.editors)-1].Edit.Editor.Focus()
+				} else {
+					pg.seedEditors.editors[i-1].Edit.Editor.Focus()
+				}
+			}
+		}
+	}
+	if evt.Name == key.NameUpArrow && pg.openPopupIndex != -1 && evt.State == key.Press {
+		pg.selected--
+		if pg.selected < 0 {
+			pg.selected = 0
+		}
+	}
+	if evt.Name == key.NameDownArrow && pg.openPopupIndex != -1 && evt.State == key.Press {
+		pg.selected++
+		if pg.selected >= len(pg.suggestions) {
+			pg.selected = len(pg.suggestions) - 1
+		}
+	}
+	if (evt.Name == key.NameReturn || evt.Name == key.NameEnter) && pg.openPopupIndex != -1 && evt.State == key.Press && len(pg.suggestions) != 0 {
+		if pg.seedEditors.focusIndex == -1 && len(pg.suggestions) == 1 {
+			return
+		}
+
+		pg.seedMenu[pg.selected].button.Click()
 	}
 }
 
@@ -636,6 +633,4 @@ func (pg *Restore) seedEditorChanged() bool {
 // OnNavigatedTo() will be called again. This method should not destroy UI
 // components unless they'll be recreated in the OnNavigatedTo() method.
 // Part of the load.Page interface.
-func (pg *Restore) OnNavigatedFrom() {
-	pg.Load.UnsubscribeKeyEvent(pg.ID())
-}
+func (pg *Restore) OnNavigatedFrom() {}

--- a/ui/page/wallets/sign_message_page.go
+++ b/ui/page/wallets/sign_message_page.go
@@ -21,7 +21,6 @@ type SignMessagePage struct {
 	*load.Load
 	container layout.List
 	wallet    *dcrlibwallet.Wallet
-	keyEvent  chan *key.Event
 
 	isSigningMessage bool
 	addressIsValid   bool
@@ -72,7 +71,6 @@ func NewSignMessagePage(l *load.Load, wallet *dcrlibwallet.Wallet) *SignMessageP
 		copyButton:         l.Theme.Button("Copy"),
 		copySignature:      l.Theme.NewClickable(false),
 		copyIcon:           copyIcon,
-		keyEvent:           make(chan *key.Event),
 	}
 
 	pg.signedMessageLabel.Color = l.Theme.Color.GrayText2
@@ -94,7 +92,6 @@ func (pg *SignMessagePage) ID() string {
 // Part of the load.Page interface.
 func (pg *SignMessagePage) OnNavigatedTo() {
 	pg.addressEditor.Editor.Focus()
-	pg.Load.SubscribeKeyEvent(pg.keyEvent, pg.ID())
 }
 
 // Layout draws the page UI components into the provided layout context
@@ -286,9 +283,13 @@ func (pg *SignMessagePage) HandleUserInteractions() {
 				}).Show()
 		}
 	}
+}
 
-	//Switch editors when tab key is pressed
-	decredmaterial.SwitchEditors(pg.keyEvent, pg.addressEditor.Editor, pg.messageEditor.Editor)
+// HandleKeyEvent is called when a key is pressed on the current window.
+// Satisfies the load.KeyEventHandler interface for receiving key events.
+func (pg *SignMessagePage) HandleKeyEvent(evt *key.Event) {
+	// Switch editors when tab key is pressed.
+	decredmaterial.SwitchEditors(evt, pg.addressEditor.Editor, pg.messageEditor.Editor)
 }
 
 func (pg *SignMessagePage) validate() bool {
@@ -352,6 +353,4 @@ func (pg *SignMessagePage) clearForm() {
 // OnNavigatedTo() will be called again. This method should not destroy UI
 // components unless they'll be recreated in the OnNavigatedTo() method.
 // Part of the load.Page interface.
-func (pg *SignMessagePage) OnNavigatedFrom() {
-	pg.Load.UnsubscribeKeyEvent(pg.ID())
-}
+func (pg *SignMessagePage) OnNavigatedFrom() {}

--- a/ui/window.go
+++ b/ui/window.go
@@ -241,11 +241,15 @@ func (win *Window) drawWindowUI(gtx C) {
 }
 
 func (win *Window) handleKeyEvent(evt *key.Event) {
-	if handler, ok := win.currentPage.(load.KeyEventHandler); ok {
-		handler.HandleKeyEvent(evt)
-	}
+	// Handle key events on any displayed modals first.
 	for _, modal := range win.modals {
 		if handler, ok := modal.(load.KeyEventHandler); ok {
+			handler.HandleKeyEvent(evt)
+		}
+	}
+	// Only handle key events on the current page if no modal is displayed.
+	if len(win.modals) == 0 {
+		if handler, ok := win.currentPage.(load.KeyEventHandler); ok {
 			handler.HandleKeyEvent(evt)
 		}
 	}


### PR DESCRIPTION
This is part of a larger body of work to refactor the codebase.

The current use of channels to notify pages and modals of key events
is inefficient because to work effectively, pages and modals will need to
start goroutines to intercept key events as soon as it is sent into the
channel.

Most of the uses of the event channel do not currently constantly check if
the event channel has received a new event, only checking the channel when
`HandleUserInteractions` is called and that is only called when some other
action causes a `FrameEvent` to be generated. Inefficient, and was responsible
for a bug on the info modal that was recently fixed using a goroutine.

To work effectively, pages and modals should be able to identify key events as
they happen, not only when some other action (like moving the mouse or clicking
a button) triggers a FrameEvent. This solution achieves this aim without using
goroutines or channels.