### PR TITLE
Filter out default account from selected account when privacy is set

### DIFF
--- a/ui/page/components/account_selector.go
+++ b/ui/page/components/account_selector.go
@@ -3,7 +3,6 @@ package components
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 
 	"gioui.org/io/event"
@@ -340,7 +339,7 @@ func (asm *AccountSelectorModal) setupWalletAccounts() {
 
 			accountsResult, err := wal.GetAccountsRaw()
 			if err != nil {
-				fmt.Println("Error getting accounts:", err)
+				log.Errorf("Error getting accounts:", err)
 				continue
 			}
 
@@ -357,7 +356,7 @@ func (asm *AccountSelectorModal) setupWalletAccounts() {
 		} else if wal.ID == asm.selectedWallet.ID {
 			accountsResult, err := wal.GetAccountsRaw()
 			if err != nil {
-				fmt.Println("Error getting accounts:", err)
+				log.Errorf("Error getting accounts:", err)
 				continue
 			}
 

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -112,15 +112,9 @@ func NewSendPage(l *load.Load) *Page {
 			if wal.ReadBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, false) {
 				// privacy is enabled for selected wallet
 
-				if pg.sendDestination.sendToAddress {
-					// only mixed can send to address
+				// only mixed accounts can send to address for wallet with privacy setup
+				if pg.sendDestination.accountSwitch.SelectedIndex() == 1 {
 					accountIsValid = account.Number == wal.MixedAccountNumber()
-				} else {
-					// send to account, check if selected destination account belongs to wallet
-					destinationAccount := pg.sendDestination.destinationAccountSelector.SelectedAccount()
-					if destinationAccount.WalletID != account.WalletID {
-						accountIsValid = account.Number == wal.MixedAccountNumber()
-					}
 				}
 			}
 			return accountIsValid
@@ -132,6 +126,8 @@ func NewSendPage(l *load.Load) *Page {
 	})
 
 	pg.sendDestination.addressChanged = func() {
+		// refresh selected account when addressChanged is called
+		pg.sourceAccountSelector.SelectFirstWalletValidAccount(nil)
 		pg.validateAndConstructTx()
 	}
 
@@ -183,7 +179,7 @@ func (pg *Page) OnNavigatedTo() {
 
 // OnDarkModeChanged is triggered whenever the dark mode setting is changed
 // to enable restyling UI elements where necessary.
-// Satisfies the load.AppSettingsChangeHandler interface.
+// Satisfies the load.DarkModeChangeHandler interface.
 func (pg *Page) OnDarkModeChanged(isDarkModeOn bool) {
 	pg.amount.styleWidgets()
 }


### PR DESCRIPTION
Fix #908 
This PR
- Filter out default account from selected account when privacy is set
- allow sending from all account when sending to account
- Refresh the source account selector when account preference switch is toggled.