### PR TITLE
Toggle account mixer switch off if password modal is dismissed.

### DIFF
--- a/ui/modal/password_modal.go
+++ b/ui/modal/password_modal.go
@@ -168,6 +168,7 @@ func (pm *PasswordModal) Handle() {
 	if pm.modal.BackdropClicked(pm.isCancelable) {
 		if !pm.isLoading {
 			pm.Dismiss()
+			pm.negativeButtonClicked()
 		}
 	}
 }


### PR DESCRIPTION
Closes #909

This PR makes the toggle switch to start mixing automatically turn off if the password is not entered and the modal is dismissed.