### PR TITLE
Fix panic on wallet restore

### DIFF
--- a/ui/page/wallets/restore_page.go
+++ b/ui/page/wallets/restore_page.go
@@ -239,17 +239,19 @@ func (pg *Restore) inputsGroup(gtx layout.Context, l *layout.List, len, startInd
 
 func (pg *Restore) onSuggestionSeedsClicked() {
 	index := pg.seedEditors.focusIndex
-	for i, b := range pg.seedMenu {
-		for pg.seedMenu[i].button.Clicked() {
-			pg.seedEditors.editors[index].Edit.Editor.SetText(b.text)
-			pg.seedEditors.editors[index].Edit.Editor.MoveCaret(len(b.text), 0)
-			pg.seedClicked = true
-			if index != numberOfSeeds {
-				pg.seedEditors.editors[index+1].Edit.Editor.Focus()
-			}
+	if index != -1 {
+		for i, b := range pg.seedMenu {
+			for pg.seedMenu[i].button.Clicked() {
+				pg.seedEditors.editors[index].Edit.Editor.SetText(b.text)
+				pg.seedEditors.editors[index].Edit.Editor.MoveCaret(len(b.text), 0)
+				pg.seedClicked = true
+				if index != numberOfSeeds {
+					pg.seedEditors.editors[index+1].Edit.Editor.Focus()
+				}
 
-			if index == numberOfSeeds {
-				pg.isLastEditor = true
+				if index == numberOfSeeds {
+					pg.isLastEditor = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Resolves #919 
This PR ensures that operations in the OnSuggestionsSeedsClicked function do not get executed if the seed editor focus index is equal to -1 thereby fixing the "invalid memory location" error.