### PR TITLE
Don't clear mixer config when spend from unmixed accounts is enabled.

### DIFF
--- a/ui/load/utils.go
+++ b/ui/load/utils.go
@@ -13,4 +13,5 @@ const (
 	SeedBackupNotificationConfigKey  = "seed_backup_notification"
 	ProposalNotificationConfigKey    = "proposal_notification_key"
 	TransactionNotificationConfigKey = "transaction_notification_key"
+	SpendUnmixedFundsKey             = "spend_unmixed_funds"
 )

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -70,11 +70,8 @@ func (pg *AccountMixerPage) OnNavigatedTo() {
 	pg.listenForMixerNotifications()
 	pg.toggleMixer.SetChecked(pg.wallet.IsAccountMixerActive())
 
-	if pg.wallet.AccountMixerConfigIsSet() {
-		pg.allowUnspendUnmixedAcct.SetChecked(false)
-	} else {
-		pg.allowUnspendUnmixedAcct.SetChecked(true)
-	}
+	isSpendUnmixedFunds := pg.wallet.ReadBoolConfigValueForKey(load.SpendUnmixedFundsKey, false)
+	pg.allowUnspendUnmixedAcct.SetChecked(isSpendUnmixedFunds)
 }
 
 // Layout draws the page UI components into the provided layout context
@@ -271,7 +268,7 @@ func (pg *AccountMixerPage) HandleUserInteractions() {
 						tim.SetError("confirmation text is incorrect")
 						tim.SetLoading(false)
 					} else {
-						pg.wallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, false)
+						pg.wallet.SetBoolConfigValueForKey(load.SpendUnmixedFundsKey, true)
 						tim.Dismiss()
 					}
 					return false
@@ -284,7 +281,7 @@ func (pg *AccountMixerPage) HandleUserInteractions() {
 			textModal.Show()
 
 		} else {
-			pg.wallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
+			pg.wallet.SetBoolConfigValueForKey(load.SpendUnmixedFundsKey, false)
 		}
 
 		if pg.dangerZoneCollapsible.IsExpanded() {

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -107,8 +107,8 @@ func NewSendPage(l *load.Load) *Page {
 			// Imported and watch only wallet accounts are invalid for sending
 			accountIsValid := account.Number != load.MaxInt32 && !wal.IsWatchingOnlyWallet()
 
-			if wal.ReadBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, false) {
-				// privacy is enabled for selected wallet
+			if !wal.ReadBoolConfigValueForKey(load.SpendUnmixedFundsKey, false) {
+				// Spending unmixed fund isn't permitted for the selected wallet
 
 				// only mixed accounts can send to address for wallet with privacy setup
 				if pg.sendDestination.accountSwitch.SelectedIndex() == 1 {

--- a/ui/page/staking/auto_ticket_modal.go
+++ b/ui/page/staking/auto_ticket_modal.go
@@ -184,8 +184,8 @@ func (tb *ticketBuyerModal) initializeAccountSelector() {
 			// Imported and watch only wallet accounts are invalid for sending
 			accountIsValid := account.Number != dcrlibwallet.ImportedAccountNumber && !wal.IsWatchingOnlyWallet()
 
-			if wal.ReadBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, false) {
-				// privacy is enabled for selected wallet
+			if !wal.ReadBoolConfigValueForKey(load.SpendUnmixedFundsKey, false) {
+				// Spending from unmixed accounts is disabled for the selected wallet
 				accountIsValid = account.Number == wal.MixedAccountNumber()
 			}
 			return accountIsValid

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -313,8 +313,8 @@ func (tp *stakingModal) initializeAccountSelector() {
 			// Imported and watch only wallet accounts are invalid for sending
 			accountIsValid := account.Number != dcrlibwallet.ImportedAccountNumber && !wal.IsWatchingOnlyWallet()
 
-			if wal.ReadBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, false) {
-				// privacy is enabled for selected wallet
+			if wal.ReadBoolConfigValueForKey(load.SpendUnmixedFundsKey, false) {
+				// Spending from unmixed accounts is disabled for wallet
 
 				accountIsValid = account.Number == wal.MixedAccountNumber()
 			}

--- a/ui/page/staking/purchase_modal.go
+++ b/ui/page/staking/purchase_modal.go
@@ -313,7 +313,7 @@ func (tp *stakingModal) initializeAccountSelector() {
 			// Imported and watch only wallet accounts are invalid for sending
 			accountIsValid := account.Number != dcrlibwallet.ImportedAccountNumber && !wal.IsWatchingOnlyWallet()
 
-			if wal.ReadBoolConfigValueForKey(load.SpendUnmixedFundsKey, false) {
+			if !wal.ReadBoolConfigValueForKey(load.SpendUnmixedFundsKey, false) {
 				// Spending from unmixed accounts is disabled for wallet
 
 				accountIsValid = account.Number == wal.MixedAccountNumber()


### PR DESCRIPTION
This PR Keeps the stake shuffle configs when spend from unmixed accounts is enabled. Closes #926.