### PR TITLE
Enable privacy by default when new wallet is created

### DIFF
--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -23,7 +23,6 @@ import (
 	"github.com/planetdecred/godcr/ui/page/dexclient"
 	"github.com/planetdecred/godcr/ui/page/governance"
 	"github.com/planetdecred/godcr/ui/page/overview"
-	"github.com/planetdecred/godcr/ui/page/privacy"
 	"github.com/planetdecred/godcr/ui/page/send"
 	"github.com/planetdecred/godcr/ui/page/staking"
 	"github.com/planetdecred/godcr/ui/page/transaction"
@@ -121,49 +120,6 @@ func NewMainPage(l *load.Load) *MainPage {
 	mp.setNavExpanded = func() {
 		mp.drawerNav.DrawerToggled(mp.isNavExpanded)
 	}
-
-	return mp
-}
-
-//Creates new main page after startup wallet creation
-//Switches to automatic privacy setup
-func NewMainPageAfterWalC(l *load.Load, wal *dcrlibwallet.Wallet) *MainPage {
-	mp := &MainPage{
-		Load: l,
-	}
-
-	mp.hideBalanceItem.hideBalanceButton = mp.Theme.IconButton(mp.Theme.Icons.ConcealIcon)
-	mp.hideBalanceItem.hideBalanceButton.Size = unit.Dp(19)
-	mp.hideBalanceItem.hideBalanceButton.Inset = layout.UniformInset(values.MarginPadding4)
-	mp.hideBalanceItem.tooltip = mp.Theme.Tooltip()
-
-	// init shared page functions
-	toggleSync := func() {
-		if mp.WL.MultiWallet.IsConnectedToDecredNetwork() {
-			mp.WL.MultiWallet.CancelSync()
-		} else {
-			mp.StartSyncing()
-		}
-	}
-	l.ToggleSync = toggleSync
-	l.ChangeFragment = mp.changeFragment
-	l.PopFragment = mp.popFragment
-	l.PopToFragment = mp.popToFragment
-
-	mp.setLanguageSetting()
-
-	mp.initNavItems()
-
-	mp.refreshExchangeRateBtn = mp.Theme.NewClickable(true)
-
-	// Show a seed backup prompt if necessary.
-	mp.WL.MultiWallet.SaveUserConfigValue(load.SeedBackupNotificationConfigKey, false)
-
-	mp.setNavExpanded = func() {
-		mp.drawerNav.DrawerToggled(mp.isNavExpanded)
-	}
-
-	defer mp.ChangeFragment(privacy.NewSetupPrivacyPage(mp.Load, wal))
 
 	return mp
 }

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -23,6 +23,7 @@ import (
 	"github.com/planetdecred/godcr/ui/page/dexclient"
 	"github.com/planetdecred/godcr/ui/page/governance"
 	"github.com/planetdecred/godcr/ui/page/overview"
+	"github.com/planetdecred/godcr/ui/page/privacy"
 	"github.com/planetdecred/godcr/ui/page/send"
 	"github.com/planetdecred/godcr/ui/page/staking"
 	"github.com/planetdecred/godcr/ui/page/transaction"
@@ -120,6 +121,49 @@ func NewMainPage(l *load.Load) *MainPage {
 	mp.setNavExpanded = func() {
 		mp.drawerNav.DrawerToggled(mp.isNavExpanded)
 	}
+
+	return mp
+}
+
+//Creates new main page after startup wallet creation
+//Switches to automatic privacy setup
+func NewMainPageAfterWalC(l *load.Load, wal *dcrlibwallet.Wallet) *MainPage {
+	mp := &MainPage{
+		Load: l,
+	}
+
+	mp.hideBalanceItem.hideBalanceButton = mp.Theme.IconButton(mp.Theme.Icons.ConcealIcon)
+	mp.hideBalanceItem.hideBalanceButton.Size = unit.Dp(19)
+	mp.hideBalanceItem.hideBalanceButton.Inset = layout.UniformInset(values.MarginPadding4)
+	mp.hideBalanceItem.tooltip = mp.Theme.Tooltip()
+
+	// init shared page functions
+	toggleSync := func() {
+		if mp.WL.MultiWallet.IsConnectedToDecredNetwork() {
+			mp.WL.MultiWallet.CancelSync()
+		} else {
+			mp.StartSyncing()
+		}
+	}
+	l.ToggleSync = toggleSync
+	l.ChangeFragment = mp.changeFragment
+	l.PopFragment = mp.popFragment
+	l.PopToFragment = mp.popToFragment
+
+	mp.setLanguageSetting()
+
+	mp.initNavItems()
+
+	mp.refreshExchangeRateBtn = mp.Theme.NewClickable(true)
+
+	// Show a seed backup prompt if necessary.
+	mp.WL.MultiWallet.SaveUserConfigValue(load.SeedBackupNotificationConfigKey, false)
+
+	mp.setNavExpanded = func() {
+		mp.drawerNav.DrawerToggled(mp.isNavExpanded)
+	}
+
+	defer mp.ChangeFragment(privacy.NewSetupPrivacyPage(mp.Load, wal))
 
 	return mp
 }

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -118,8 +118,8 @@ func (sp *startPage) HandleUserInteractions() {
 						m.SetLoading(false)
 						return
 					}
-					crErr := wal.CreateMixerAccounts("mixed", "unmixed", password)
-					if crErr != nil {
+					err = wal.CreateMixerAccounts("mixed", "unmixed", password)
+					if err != nil {
 						m.SetError(err.Error())
 						m.SetLoading(false)
 						return

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -10,9 +10,9 @@ import (
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
 	"github.com/planetdecred/godcr/ui/modal"
+	"github.com/planetdecred/godcr/ui/page/privacy"
 	"github.com/planetdecred/godcr/ui/page/wallets"
 	"github.com/planetdecred/godcr/ui/values"
-	"github.com/planetdecred/godcr/ui/page/privacy"
 )
 
 const StartPageID = "start_page"

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -118,7 +118,7 @@ func (sp *startPage) HandleUserInteractions() {
 						m.SetLoading(false)
 						return
 					}
-					crErr := wal.CreateMixerAccounts("mixed", "unmixed", password)
+					err = wal.CreateMixerAccounts("mixed", "unmixed", password)
 					if crErr != nil {
 						m.SetError(err.Error())
 						m.SetLoading(false)

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -118,9 +118,16 @@ func (sp *startPage) HandleUserInteractions() {
 						m.SetLoading(false)
 						return
 					}
+					crErr := wal.CreateMixerAccounts("mixed", "unmixed", password)
+					if crErr != nil {
+						m.SetError(err.Error())
+						m.SetLoading(false)
+						return
+					}
+					sp.WL.MultiWallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
 					m.Dismiss()
 
-					sp.ChangeWindowPage(NewMainPageAfterWalC(sp.Load, wal), false)
+					sp.ChangeWindowPage(NewMainPage(sp.Load), false)
 				}()
 				return false
 			}).Show()

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -10,7 +10,6 @@ import (
 	"github.com/planetdecred/godcr/ui/decredmaterial"
 	"github.com/planetdecred/godcr/ui/load"
 	"github.com/planetdecred/godcr/ui/modal"
-	"github.com/planetdecred/godcr/ui/page/privacy"
 	"github.com/planetdecred/godcr/ui/page/wallets"
 	"github.com/planetdecred/godcr/ui/values"
 )
@@ -121,8 +120,7 @@ func (sp *startPage) HandleUserInteractions() {
 					}
 					m.Dismiss()
 
-					sp.ChangeWindowPage(NewMainPage(sp.Load), false)
-					sp.ChangeFragment(privacy.NewSetupPrivacyPage(sp.Load, wal))
+					sp.ChangeWindowPage(NewMainPageAfterWalC(sp.Load, wal), false)
 				}()
 				return false
 			}).Show()

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -12,6 +12,7 @@ import (
 	"github.com/planetdecred/godcr/ui/modal"
 	"github.com/planetdecred/godcr/ui/page/wallets"
 	"github.com/planetdecred/godcr/ui/values"
+	"github.com/planetdecred/godcr/ui/page/privacy"
 )
 
 const StartPageID = "start_page"
@@ -112,7 +113,7 @@ func (sp *startPage) HandleUserInteractions() {
 			Title("Create new wallet").
 			PasswordCreated(func(_, password string, m *modal.CreatePasswordModal) bool {
 				go func() {
-					_, err := sp.WL.MultiWallet.CreateNewWallet("mywallet", password, dcrlibwallet.PassphraseTypePass)
+					wal, err := sp.WL.MultiWallet.CreateNewWallet("mywallet", password, dcrlibwallet.PassphraseTypePass)
 					if err != nil {
 						m.SetError(err.Error())
 						m.SetLoading(false)
@@ -121,6 +122,7 @@ func (sp *startPage) HandleUserInteractions() {
 					m.Dismiss()
 
 					sp.ChangeWindowPage(NewMainPage(sp.Load), false)
+					sp.ChangeFragment(privacy.NewSetupPrivacyPage(sp.Load, wal))
 				}()
 				return false
 			}).Show()

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -365,10 +365,16 @@ func (pg *WalletPage) showAddWalletModal(l *load.Load) {
 					m.SetLoading(false)
 					return
 				}
+				crErr := wal.CreateMixerAccounts("mixed", "unmixed", password)
+				if crErr != nil {
+					m.SetError(err.Error())
+					m.SetLoading(false)
+					return
+				}
+				pg.WL.MultiWallet.SetBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, true)
 				pg.loadWalletAndAccounts()
 				pg.Toast.Notify("Wallet created")
 				m.Dismiss()
-				pg.ChangeFragment(privacy.NewSetupPrivacyPage(pg.Load, wal))
 			}()
 			return false
 		}).Show()

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -365,8 +365,8 @@ func (pg *WalletPage) showAddWalletModal(l *load.Load) {
 					m.SetLoading(false)
 					return
 				}
-				crErr := wal.CreateMixerAccounts("mixed", "unmixed", password)
-				if crErr != nil {
+				err = wal.CreateMixerAccounts("mixed", "unmixed", password)
+				if err != nil {
 					m.SetError(err.Error())
 					m.SetLoading(false)
 					return

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -359,7 +359,7 @@ func (pg *WalletPage) showAddWalletModal(l *load.Load) {
 		ShowWalletInfoTip(true).
 		PasswordCreated(func(walletName, password string, m *modal.CreatePasswordModal) bool {
 			go func() {
-				_, err := pg.multiWallet.CreateNewWallet(walletName, password, dcrlibwallet.PassphraseTypePass)
+				wal, err := pg.multiWallet.CreateNewWallet(walletName, password, dcrlibwallet.PassphraseTypePass)
 				if err != nil {
 					m.SetError(err.Error())
 					m.SetLoading(false)
@@ -368,6 +368,7 @@ func (pg *WalletPage) showAddWalletModal(l *load.Load) {
 				pg.loadWalletAndAccounts()
 				pg.Toast.Notify("Wallet created")
 				m.Dismiss()
+				pg.ChangeFragment(privacy.NewSetupPrivacyPage(pg.Load, wal))
 			}()
 			return false
 		}).Show()

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -365,7 +365,7 @@ func (pg *WalletPage) showAddWalletModal(l *load.Load) {
 					m.SetLoading(false)
 					return
 				}
-				crErr := wal.CreateMixerAccounts("mixed", "unmixed", password)
+				err = wal.CreateMixerAccounts("mixed", "unmixed", password)
 				if crErr != nil {
 					m.SetError(err.Error())
 					m.SetLoading(false)


### PR DESCRIPTION
Resolves #933 

This PR makes it such that as soon as a new wallet is created, privacy is enabled by default.