### PR TITLE
fix `golangci-lint: command not found` error

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Install linter
-        run: "curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.35.2"
+        run: "curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.35.2"
 
       - name: Install dependencies
         if: steps.cache.outputs.cache-hit != 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang 
 
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(go env GOPATH)/bin v1.19.1
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.35.2
 
 ENV GO111MODULE on
 


### PR DESCRIPTION
`golangci-lint` has been failing on more recent PRs, with the error `golangci-lint: command not found`

the install section of the official `golangci-lint` website(https://golangci-lint.run/usage/install/) shows there's a new URL used to install the `golangci-lint` binary which is `https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh` the godcr workflow was attempting to use `https://install.goreleaser.com/github.com/golangci/golangci-lint.sh`, which is an old method of installing the binary and no longer works.

The fix was to replace the outdated URL with the one recommended from the `golangci-lint` website