### PR TITLE
Fix UI lag on transactions page

### DIFF
--- a/ui/decredmaterial/clickable_list.go
+++ b/ui/decredmaterial/clickable_list.go
@@ -8,7 +8,7 @@ import (
 type ClickableList struct {
 	layout.List
 	theme           *Theme
-	clickables      []*Clickable
+	Clickables      []*Clickable
 	Radius          CornerRadius // this radius is used by the clickable
 	selectedItem    int
 	DividerHeight   unit.Dp
@@ -37,16 +37,16 @@ func (cl *ClickableList) ItemClicked() (bool, int) {
 }
 
 func (cl *ClickableList) handleClickables(count int) {
-	if len(cl.clickables) != count {
+	if len(cl.Clickables) != count {
 
-		cl.clickables = make([]*Clickable, count)
+		cl.Clickables = make([]*Clickable, count)
 		for i := 0; i < count; i++ {
 			clickable := cl.theme.NewClickable(cl.IsHoverable)
-			cl.clickables[i] = clickable
+			cl.Clickables[i] = clickable
 		}
 	}
 
-	for index, clickable := range cl.clickables {
+	for index, clickable := range cl.Clickables {
 		for clickable.Clicked() {
 			cl.selectedItem = index
 		}
@@ -56,7 +56,7 @@ func (cl *ClickableList) handleClickables(count int) {
 func (cl *ClickableList) Layout(gtx layout.Context, count int, w layout.ListElement) layout.Dimensions {
 	cl.handleClickables(count)
 	return cl.List.Layout(gtx, count, func(gtx C, i int) D {
-		if cl.IsShadowEnabled && cl.clickables[i].button.Hovered() {
+		if cl.IsShadowEnabled && cl.Clickables[i].button.Hovered() {
 			shadow := cl.theme.Shadow()
 			shadow.SetShadowRadius(14)
 			shadow.SetShadowElevation(5)
@@ -70,14 +70,14 @@ func (cl *ClickableList) Layout(gtx layout.Context, count int, w layout.ListElem
 
 func (cl *ClickableList) row(gtx layout.Context, count int, i int, w layout.ListElement) layout.Dimensions {
 	if i == 0 { // first item
-		cl.clickables[i].Radius.TopLeft = cl.Radius.TopLeft
-		cl.clickables[i].Radius.TopRight = cl.Radius.TopRight
+		cl.Clickables[i].Radius.TopLeft = cl.Radius.TopLeft
+		cl.Clickables[i].Radius.TopRight = cl.Radius.TopRight
 	}
 	if i == count-1 { // last item
-		cl.clickables[i].Radius.BottomLeft = cl.Radius.BottomLeft
-		cl.clickables[i].Radius.BottomRight = cl.Radius.BottomRight
+		cl.Clickables[i].Radius.BottomLeft = cl.Radius.BottomLeft
+		cl.Clickables[i].Radius.BottomRight = cl.Radius.BottomRight
 	}
-	row := cl.clickables[i].Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+	row := cl.Clickables[i].Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 		return w(gtx, i)
 	})
 

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -50,6 +50,10 @@ type TransactionsPage struct {
 	container       *widget.List
 	transactions    []dcrlibwallet.Transaction
 	wallets         []*dcrlibwallet.Wallet
+	paginatedTxns   [][]dcrlibwallet.Transaction
+	currentPage     int
+	paginated       bool
+	pageEnd         bool
 }
 
 func NewTransactionsPage(l *load.Load) *TransactionsPage {
@@ -110,6 +114,7 @@ func (pg *TransactionsPage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 
 	pg.listenForTxNotifications()
+	pg.paginated = false
 	pg.loadTransactions(pg.walletDropDown.SelectedIndex())
 }
 
@@ -132,10 +137,19 @@ func (pg *TransactionsPage) loadTransactions(selectedWalletIndex int) {
 	}
 
 	wallTxs, err := selectedWallet.GetTransactionsRaw(0, 0, txFilter, newestFirst) //TODO
+	pg.currentPage = 0
 	if err != nil {
 		// log.Error("Error loading transactions:", err)
 	} else {
-		pg.transactions = wallTxs
+		if len(wallTxs) > 20 {
+			pg.paginatedTxns = pg.splitTxns(wallTxs)
+			pg.transactions = pg.paginatedTxns[0]
+			pg.paginated = true
+		} else {
+			pg.paginated = false
+			pg.paginatedTxns = nil
+			pg.transactions = wallTxs
+		}
 	}
 }
 
@@ -177,6 +191,16 @@ func (pg *TransactionsPage) layoutDesktop(gtx layout.Context) layout.Dimensions 
 										Transaction: wallTxs[index],
 										Index:       index,
 										ShowBadge:   false,
+									}
+									offsetNum := []int{1, 2, 3, 4, 5}
+									if pg.paginated {
+										for _, offset := range offsetNum {
+											if pg.transactionList.Clickables[len(pg.transactions)-offset].IsHovered() {
+												pg.pageEnd = true
+											} else {
+												pg.pageEnd = false
+											}
+										}
 									}
 
 									return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
@@ -370,6 +394,13 @@ func (pg *TransactionsPage) HandleUserInteractions() {
 
 		pg.loadTransactions(pg.selectedCategoryIndex)
 		pg.changed = false
+	}
+
+	if pg.pageEnd && pg.currentPage != len(pg.paginatedTxns)-1 {
+		pg.currentPage = pg.currentPage + 1
+		for i := 0; i < len(pg.paginatedTxns[pg.currentPage]); i++ {
+			pg.transactions = append(pg.transactions, pg.paginatedTxns[pg.currentPage][i])
+		}
 	}
 }
 

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -156,54 +156,73 @@ func (pg *TransactionsPage) layoutDesktop(gtx layout.Context) layout.Dimensions 
 		wallTxs := pg.splitTxns()[0]
 		return layout.Stack{Alignment: layout.N}.Layout(gtx,
 			layout.Expanded(func(gtx C) D {
-				return layout.Inset{
-					Top:    values.MarginPadding60,
-					Bottom: values.MarginPadding80,
-				}.Layout(gtx, func(gtx C) D {
-					return pg.Theme.List(pg.container).Layout(gtx, 1, func(gtx C, i int) D {
-						return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
-							return pg.Theme.Card().Layout(gtx, func(gtx C) D {
-								// return "No transactions yet" text if there are no transactions
-								if len(wallTxs) == 0 {
-									padding := values.MarginPadding16
-									txt := pg.Theme.Body1(values.String(values.StrNoTransactions))
-									txt.Color = pg.Theme.Color.GrayText3
-									gtx.Constraints.Min.X = gtx.Constraints.Max.X
-									return layout.Center.Layout(gtx, func(gtx C) D {
-										return layout.Inset{Top: padding, Bottom: padding}.Layout(gtx, txt.Layout)
-									})
-								}
-
-								return pg.transactionList.Layout(gtx, len(wallTxs), func(gtx C, index int) D {
-									var row = components.TransactionRow{
-										Transaction: wallTxs[index],
-										Index:       index,
-										ShowBadge:   false,
-									}
-
+				return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return layout.Inset{
+							Top:    values.MarginPadding60,
+							Bottom: values.MarginPadding60,
+						}.Layout(gtx, func(gtx C) D {
+							return pg.Theme.List(pg.container).Layout(gtx, 1, func(gtx C, i int) D {
+								return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 									return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 										layout.Rigid(func(gtx C) D {
-											return components.LayoutTransactionRow(gtx, pg.Load, row)
+											return pg.Theme.Card().Layout(gtx, func(gtx C) D {
+												// return "No transactions yet" text if there are no transactions
+												if len(wallTxs) == 0 {
+													padding := values.MarginPadding16
+													txt := pg.Theme.Body1(values.String(values.StrNoTransactions))
+													txt.Color = pg.Theme.Color.GrayText3
+													gtx.Constraints.Min.X = gtx.Constraints.Max.X
+													return layout.Center.Layout(gtx, func(gtx C) D {
+														return layout.Inset{Top: padding, Bottom: padding}.Layout(gtx, txt.Layout)
+													})
+												}
+
+												return pg.transactionList.Layout(gtx, len(wallTxs), func(gtx C, index int) D {
+													var row = components.TransactionRow{
+														Transaction: wallTxs[index],
+														Index:       index,
+														ShowBadge:   false,
+													}
+
+													return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+														layout.Rigid(func(gtx C) D {
+															return components.LayoutTransactionRow(gtx, pg.Load, row)
+														}),
+														layout.Rigid(func(gtx C) D {
+															// No divider for last row
+															if row.Index == len(wallTxs)-1 {
+																return layout.Dimensions{}
+															}
+
+															gtx.Constraints.Min.X = gtx.Constraints.Max.X
+															separator := pg.Theme.Separator()
+															return layout.E.Layout(gtx, func(gtx C) D {
+																// Show bottom divider for all rows except last
+																return layout.Inset{Left: values.MarginPadding56}.Layout(gtx, separator.Layout)
+															})
+														}),
+													)
+												})
+											})
 										}),
 										layout.Rigid(func(gtx C) D {
-											// No divider for last row
-											if row.Index == len(wallTxs)-1 {
-												return layout.Dimensions{}
-											}
-
-											gtx.Constraints.Min.X = gtx.Constraints.Max.X
-											separator := pg.Theme.Separator()
-											return layout.E.Layout(gtx, func(gtx C) D {
-												// Show bottom divider for all rows except last
-												return layout.Inset{Left: values.MarginPadding56}.Layout(gtx, separator.Layout)
+											gtx.Constraints.Max.X = 110
+											return layout.S.Layout(gtx, func(gtx C) D {
+												return layout.Inset{
+													Top: values.MarginPadding20,
+												}.Layout(gtx, func(gtx C) D {
+													return pg.viewMoreButton.Layout(gtx)
+												})
 											})
 										}),
 									)
 								})
 							})
 						})
-					})
-				})
+					}),
+				)
+
 			}),
 			layout.Expanded(func(gtx C) D {
 				return pg.walletDropDown.Layout(gtx, 0, false)
@@ -213,15 +232,6 @@ func (pg *TransactionsPage) layoutDesktop(gtx layout.Context) layout.Dimensions 
 			}),
 			layout.Expanded(func(gtx C) D {
 				return pg.txTypeDropDown.Layout(gtx, pg.orderDropDown.Width-4, true)
-			}),
-			layout.Expanded(func(gtx C) D {
-				gtx.Constraints.Max.X = 150
-				gtx.Constraints.Max.Y = 50
-				return layout.Inset{
-					Top: values.MarginPadding100,
-				}.Layout(gtx, func(gtx C) D {
-					return pg.viewMoreButton.Layout(gtx)
-				})
 			}),
 		)
 	}

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -158,11 +158,11 @@ func (pg *TransactionsPage) checkForPagination(txns []dcrlibwallet.Transaction) 
 		pg.paginatedTxns = pg.splitTxns(txns)
 		pg.transactions = pg.paginatedTxns[pg.currentPageIndex]
 		return true
-	} else {
-		pg.currentPageIndex = 0
-		pg.paginatedTxns = nil
-		pg.transactions = txns
 	}
+
+	pg.currentPageIndex = 0
+	pg.paginatedTxns = nil
+	pg.transactions = txns
 
 	return false
 }

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -417,3 +417,21 @@ func (pg *TransactionsPage) listenForTxNotifications() {
 func (pg *TransactionsPage) OnNavigatedFrom() {
 	pg.ctxCancel()
 }
+
+func (pg *TransactionsPage) splitTxns() [][]dcrlibwallet.Transaction {
+	currentView := make([][]dcrlibwallet.Transaction, 0)
+	tempTxnsArr := make([]dcrlibwallet.Transaction, 0)
+
+	for i := 0; i < len(pg.transactions); i++ {
+		tempTxnsArr = append(tempTxnsArr, pg.transactions[i])
+		if ((i + 1) % 20) == 0 {
+			currentView = append(currentView, tempTxnsArr)
+			tempTxnsArr = nil
+		} else if i == len(pg.transactions)-1 {
+			currentView = append(currentView, tempTxnsArr)
+			tempTxnsArr = nil
+		}
+	}
+
+	return currentView
+}

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -43,15 +43,6 @@ type TransactionsPage struct {
 	walletTabTitles       []string
 	changed               bool
 
-	orderDropDown   *decredmaterial.DropDown
-	txTypeDropDown  *decredmaterial.DropDown
-	walletDropDown  *decredmaterial.DropDown
-	transactionList *decredmaterial.ClickableList
-	container       *widget.List
-	transactions    []dcrlibwallet.Transaction
-	wallets         []*dcrlibwallet.Wallet
-	viewMoreButton  decredmaterial.Button
-	paginatedTxns   [][]dcrlibwallet.Transaction
 	orderDropDown    *decredmaterial.DropDown
 	txTypeDropDown   *decredmaterial.DropDown
 	walletDropDown   *decredmaterial.DropDown
@@ -421,15 +412,16 @@ func (pg *TransactionsPage) HandleUserInteractions() {
 
 		pg.loadTransactions(pg.selectedCategoryIndex)
 		pg.changed = false
-	if pg.viewMoreButton.Clicked() {
-		pg.currentPageIndex = pg.currentPageIndex + 1
-		for i := 0; i < len(pg.paginatedTxns[pg.currentPageIndex]); i++ {
-			pg.transactions = append(pg.transactions, pg.paginatedTxns[pg.currentPageIndex][i])
+		if pg.viewMoreButton.Clicked() {
+			pg.currentPageIndex = pg.currentPageIndex + 1
+			for i := 0; i < len(pg.paginatedTxns[pg.currentPageIndex]); i++ {
+				pg.transactions = append(pg.transactions, pg.paginatedTxns[pg.currentPageIndex][i])
+			}
 		}
-	}
 
-	if pg.currentPageIndex == len(pg.paginatedTxns)-1 {
-		pg.paginatedTxns = nil
+		if pg.currentPageIndex == len(pg.paginatedTxns)-1 {
+			pg.paginatedTxns = nil
+		}
 	}
 }
 

--- a/ui/page/transaction/transactions_page.go
+++ b/ui/page/transaction/transactions_page.go
@@ -50,6 +50,7 @@ type TransactionsPage struct {
 	container       *widget.List
 	transactions    []dcrlibwallet.Transaction
 	wallets         []*dcrlibwallet.Wallet
+	viewMoreButton  decredmaterial.Button
 }
 
 func NewTransactionsPage(l *load.Load) *TransactionsPage {
@@ -62,6 +63,7 @@ func NewTransactionsPage(l *load.Load) *TransactionsPage {
 		separator:       l.Theme.Separator(),
 		transactionList: l.Theme.NewClickableList(layout.Vertical),
 		walletTabList:   l.Theme.NewClickableList(layout.Horizontal),
+		viewMoreButton:  l.Theme.Button("View more"),
 	}
 
 	pg.walletTabList.IsHoverable = false
@@ -151,16 +153,16 @@ func (pg *TransactionsPage) Layout(gtx layout.Context) layout.Dimensions {
 
 func (pg *TransactionsPage) layoutDesktop(gtx layout.Context) layout.Dimensions {
 	container := func(gtx C) D {
-		wallTxs := pg.transactions
+		wallTxs := pg.splitTxns()[0]
 		return layout.Stack{Alignment: layout.N}.Layout(gtx,
 			layout.Expanded(func(gtx C) D {
 				return layout.Inset{
-					Top: values.MarginPadding60,
+					Top:    values.MarginPadding60,
+					Bottom: values.MarginPadding80,
 				}.Layout(gtx, func(gtx C) D {
 					return pg.Theme.List(pg.container).Layout(gtx, 1, func(gtx C, i int) D {
 						return layout.Inset{Right: values.MarginPadding2}.Layout(gtx, func(gtx C) D {
 							return pg.Theme.Card().Layout(gtx, func(gtx C) D {
-
 								// return "No transactions yet" text if there are no transactions
 								if len(wallTxs) == 0 {
 									padding := values.MarginPadding16
@@ -211,6 +213,15 @@ func (pg *TransactionsPage) layoutDesktop(gtx layout.Context) layout.Dimensions 
 			}),
 			layout.Expanded(func(gtx C) D {
 				return pg.txTypeDropDown.Layout(gtx, pg.orderDropDown.Width-4, true)
+			}),
+			layout.Expanded(func(gtx C) D {
+				gtx.Constraints.Max.X = 150
+				gtx.Constraints.Max.Y = 50
+				return layout.Inset{
+					Top: values.MarginPadding100,
+				}.Layout(gtx, func(gtx C) D {
+					return pg.viewMoreButton.Layout(gtx)
+				})
 			}),
 		)
 	}


### PR DESCRIPTION
Closes #757 

This PR implements the pagination of transactions on the transactions page. The following were implemented:
- Adds a `view more` button if the number of transactions is more than 20
- Appends transactions in scores when the `view more` button is clicked until all transactions are displayed
- Hides the `view more` button when all transactions are displayed 