### PR TITLE
add option to import watch only wallet from the splash screen

### DIFF
--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -375,6 +375,7 @@ func (pg *WalletPage) showAddWalletModal(l *load.Load) {
 
 func (pg *WalletPage) showImportWatchOnlyWalletModal(l *load.Load) {
 	modal.NewCreateWatchOnlyModal(l).
+		EnableName(true).
 		WatchOnlyCreated(func(walletName, extPubKey string, m *modal.CreateWatchOnlyModal) bool {
 			go func() {
 				_, err := pg.multiWallet.CreateWatchOnlyWallet(walletName, extPubKey)


### PR DESCRIPTION
Resolves #938 

This PR adds the option to import a watch only wallet from the splash screen.

**Screenshots**
![Screenshot from 2022-05-22 22-43-44](https://user-images.githubusercontent.com/25265396/169717276-617d0991-0742-46e3-a48d-fb5f85a5133d.png)
![Screenshot from 2022-05-22 22-43-55](https://user-images.githubusercontent.com/25265396/169717281-3f6e279a-189c-4f3d-8907-1947264202c4.png)
