### PR TITLE
switch to bottom nav, when on mobile devices

### DIFF
--- a/ui/page/components/bottom_nav.go
+++ b/ui/page/components/bottom_nav.go
@@ -1,0 +1,146 @@
+package components
+
+import (
+	"gioui.org/layout"
+	"gioui.org/unit"
+
+	"github.com/planetdecred/godcr/ui/decredmaterial"
+	"github.com/planetdecred/godcr/ui/load"
+	"github.com/planetdecred/godcr/ui/values"
+)
+
+var (
+	bottomNavigationBarHeight = values.MarginPadding100
+)
+
+type BottomNavigationBarHandler struct {
+	Clickable     *decredmaterial.Clickable
+	Image         *decredmaterial.Image
+	ImageInactive *decredmaterial.Image
+	Title         string
+	PageID        string
+}
+
+type BottomNavigationBar struct {
+	*load.Load
+
+	AppBarNavItems       []BottomNavigationBarHandler
+	BottomNaigationItems []BottomNavigationBarHandler
+	CurrentPage          string
+
+	axis        layout.Axis
+	textSize    unit.Value
+	bottomInset unit.Value
+	height      unit.Value
+	alignment   layout.Alignment
+	direction   layout.Direction
+}
+
+func (bottomNavigationbar *BottomNavigationBar) LayoutBottomNavigationBar(gtx layout.Context) layout.Dimensions {
+	return layout.Stack{Alignment: layout.S}.Layout(gtx,
+		layout.Expanded(func(gtx C) D {
+			return UniformPadding(gtx, func(gtx C) D {
+				return decredmaterial.LinearLayout{
+					Width:       decredmaterial.WrapContent,
+					Height:      decredmaterial.WrapContent,
+					Orientation: layout.Horizontal,
+					Background:  bottomNavigationbar.Theme.Color.Surface,
+				}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						list := layout.List{Axis: layout.Horizontal}
+						return list.Layout(gtx, len(bottomNavigationbar.BottomNaigationItems), func(gtx C, i int) D {
+
+							background := bottomNavigationbar.Theme.Color.Surface
+							if bottomNavigationbar.BottomNaigationItems[i].PageID == bottomNavigationbar.CurrentPage {
+								background = bottomNavigationbar.Theme.Color.Gray5
+							}
+							return decredmaterial.LinearLayout{
+								Orientation: bottomNavigationbar.axis,
+								Width:       (gtx.Px(values.AppWidth) * 100 / len(bottomNavigationbar.BottomNaigationItems)) / 100, // Divide each cell equally
+								Height:      decredmaterial.WrapContent,
+								Padding:     layout.UniformInset(values.MarginPadding15),
+								Alignment:   bottomNavigationbar.alignment,
+								Direction:   bottomNavigationbar.direction,
+								Background:  background,
+								Clickable:   bottomNavigationbar.BottomNaigationItems[i].Clickable,
+							}.Layout(gtx,
+								layout.Rigid(func(gtx C) D {
+									img := bottomNavigationbar.BottomNaigationItems[i].ImageInactive
+
+									if bottomNavigationbar.BottomNaigationItems[i].PageID == bottomNavigationbar.CurrentPage {
+										img = bottomNavigationbar.BottomNaigationItems[i].Image
+									}
+
+									return img.Layout24dp(gtx)
+								}),
+								layout.Rigid(func(gtx C) D {
+									return layout.Inset{
+										Bottom: bottomNavigationbar.bottomInset,
+									}.Layout(gtx, func(gtx C) D {
+										textColor := bottomNavigationbar.Theme.Color.GrayText1
+										if bottomNavigationbar.BottomNaigationItems[i].PageID == bottomNavigationbar.CurrentPage {
+											textColor = bottomNavigationbar.Theme.Color.DeepBlue
+										}
+										txt := bottomNavigationbar.Theme.Label(bottomNavigationbar.textSize, bottomNavigationbar.BottomNaigationItems[i].Title)
+										txt.Color = textColor
+										return txt.Layout(gtx)
+									})
+								}),
+							)
+						})
+					}),
+				)
+			})
+		}),
+	)
+}
+
+// func (bottomNavigationbar *BottomNavigationBar) LayoutTopBar(gtx layout.Context) layout.Dimensions {
+// 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
+// 	return layout.E.Layout(gtx, func(gtx C) D {
+// 		return layout.Inset{Right: values.MarginPadding8}.Layout(gtx, func(gtx C) D {
+// 			list := layout.List{Axis: layout.Horizontal}
+// 			return list.Layout(gtx, len(bottomNavigationbar.AppBarNavItems), func(gtx C, i int) D {
+// 				background := bottomNavigationbar.Theme.Color.Surface
+// 				if bottomNavigationbar.AppBarNavItems[i].PageID == bottomNavigationbar.CurrentPage {
+// 					background = bottomNavigationbar.Theme.Color.Gray5
+// 				}
+// 				return decredmaterial.LinearLayout{
+// 					Width:       decredmaterial.WrapContent,
+// 					Height:      decredmaterial.WrapContent,
+// 					Orientation: layout.Horizontal,
+// 					Background:  background,
+// 					Padding:     layout.UniformInset(values.MarginPadding16),
+// 					Clickable:   bottomNavigationbar.AppBarNavItems[i].Clickable,
+// 				}.Layout(gtx,
+// 					layout.Rigid(func(gtx C) D {
+// 						return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
+// 							func(gtx C) D {
+// 								return layout.Center.Layout(gtx, func(gtx C) D {
+// 									return bottomNavigationbar.AppBarNavItems[i].Image.Layout24dp(gtx)
+// 								})
+// 							})
+// 					}),
+// 					layout.Rigid(func(gtx C) D {
+// 						return layout.Inset{
+// 							Left: values.MarginPadding0,
+// 						}.Layout(gtx, func(gtx C) D {
+// 							return layout.Center.Layout(gtx, func(gtx C) D {
+// 								return bottomNavigationbar.Theme.Body1(bottomNavigationbar.AppBarNavItems[i].Title).Layout(gtx)
+// 							})
+// 						})
+// 					}),
+// 				)
+// 			})
+// 		})
+// 	})
+// }
+
+func (bottomNavigationbar *BottomNavigationBar) OnViewCreated() {
+	bottomNavigationbar.axis = layout.Vertical
+	bottomNavigationbar.textSize = values.TextSize12
+	bottomNavigationbar.bottomInset = values.MarginPadding0
+	bottomNavigationbar.height = bottomNavigationBarHeight
+	bottomNavigationbar.alignment = layout.Middle
+	bottomNavigationbar.direction = layout.Center
+}

--- a/ui/page/components/bottom_nav.go
+++ b/ui/page/components/bottom_nav.go
@@ -24,7 +24,6 @@ type BottomNavigationBarHandler struct {
 type BottomNavigationBar struct {
 	*load.Load
 
-	AppBarNavItems       []BottomNavigationBarHandler
 	BottomNaigationItems []BottomNavigationBarHandler
 	CurrentPage          string
 
@@ -92,47 +91,6 @@ func (bottomNavigationbar *BottomNavigationBar) LayoutBottomNavigationBar(gtx la
 		}),
 	)
 }
-
-// func (bottomNavigationbar *BottomNavigationBar) LayoutTopBar(gtx layout.Context) layout.Dimensions {
-// 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
-// 	return layout.E.Layout(gtx, func(gtx C) D {
-// 		return layout.Inset{Right: values.MarginPadding8}.Layout(gtx, func(gtx C) D {
-// 			list := layout.List{Axis: layout.Horizontal}
-// 			return list.Layout(gtx, len(bottomNavigationbar.AppBarNavItems), func(gtx C, i int) D {
-// 				background := bottomNavigationbar.Theme.Color.Surface
-// 				if bottomNavigationbar.AppBarNavItems[i].PageID == bottomNavigationbar.CurrentPage {
-// 					background = bottomNavigationbar.Theme.Color.Gray5
-// 				}
-// 				return decredmaterial.LinearLayout{
-// 					Width:       decredmaterial.WrapContent,
-// 					Height:      decredmaterial.WrapContent,
-// 					Orientation: layout.Horizontal,
-// 					Background:  background,
-// 					Padding:     layout.UniformInset(values.MarginPadding16),
-// 					Clickable:   bottomNavigationbar.AppBarNavItems[i].Clickable,
-// 				}.Layout(gtx,
-// 					layout.Rigid(func(gtx C) D {
-// 						return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
-// 							func(gtx C) D {
-// 								return layout.Center.Layout(gtx, func(gtx C) D {
-// 									return bottomNavigationbar.AppBarNavItems[i].Image.Layout24dp(gtx)
-// 								})
-// 							})
-// 					}),
-// 					layout.Rigid(func(gtx C) D {
-// 						return layout.Inset{
-// 							Left: values.MarginPadding0,
-// 						}.Layout(gtx, func(gtx C) D {
-// 							return layout.Center.Layout(gtx, func(gtx C) D {
-// 								return bottomNavigationbar.Theme.Body1(bottomNavigationbar.AppBarNavItems[i].Title).Layout(gtx)
-// 							})
-// 						})
-// 					}),
-// 				)
-// 			})
-// 		})
-// 	})
-// }
 
 func (bottomNavigationbar *BottomNavigationBar) OnViewCreated() {
 	bottomNavigationbar.axis = layout.Vertical

--- a/ui/page/components/bottom_nav.go
+++ b/ui/page/components/bottom_nav.go
@@ -39,58 +39,56 @@ type BottomNavigationBar struct {
 func (bottomNavigationbar *BottomNavigationBar) LayoutBottomNavigationBar(gtx layout.Context) layout.Dimensions {
 	return layout.Stack{Alignment: layout.S}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
-			return UniformPadding(gtx, func(gtx C) D {
-				return decredmaterial.LinearLayout{
-					Width:       decredmaterial.WrapContent,
-					Height:      decredmaterial.WrapContent,
-					Orientation: layout.Horizontal,
-					Background:  bottomNavigationbar.Theme.Color.Surface,
-				}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
-						list := layout.List{Axis: layout.Horizontal}
-						return list.Layout(gtx, len(bottomNavigationbar.BottomNaigationItems), func(gtx C, i int) D {
+			return decredmaterial.LinearLayout{
+				Width:       decredmaterial.WrapContent,
+				Height:      decredmaterial.WrapContent,
+				Orientation: layout.Horizontal,
+				Background:  bottomNavigationbar.Theme.Color.Surface,
+			}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					list := layout.List{Axis: layout.Horizontal}
+					return list.Layout(gtx, len(bottomNavigationbar.BottomNaigationItems), func(gtx C, i int) D {
 
-							background := bottomNavigationbar.Theme.Color.Surface
-							if bottomNavigationbar.BottomNaigationItems[i].PageID == bottomNavigationbar.CurrentPage {
-								background = bottomNavigationbar.Theme.Color.Gray5
-							}
-							return decredmaterial.LinearLayout{
-								Orientation: bottomNavigationbar.axis,
-								Width:       (gtx.Px(values.AppWidth) * 100 / len(bottomNavigationbar.BottomNaigationItems)) / 100, // Divide each cell equally
-								Height:      decredmaterial.WrapContent,
-								Padding:     layout.UniformInset(values.MarginPadding15),
-								Alignment:   bottomNavigationbar.alignment,
-								Direction:   bottomNavigationbar.direction,
-								Background:  background,
-								Clickable:   bottomNavigationbar.BottomNaigationItems[i].Clickable,
-							}.Layout(gtx,
-								layout.Rigid(func(gtx C) D {
-									img := bottomNavigationbar.BottomNaigationItems[i].ImageInactive
+						background := bottomNavigationbar.Theme.Color.Surface
+						if bottomNavigationbar.BottomNaigationItems[i].PageID == bottomNavigationbar.CurrentPage {
+							background = bottomNavigationbar.Theme.Color.Gray5
+						}
+						return decredmaterial.LinearLayout{
+							Orientation: bottomNavigationbar.axis,
+							Width:       (gtx.Px(values.AppWidth) * 100 / len(bottomNavigationbar.BottomNaigationItems)) / 100, // Divide each cell equally
+							Height:      decredmaterial.WrapContent,
+							Padding:     layout.UniformInset(values.MarginPadding15),
+							Alignment:   bottomNavigationbar.alignment,
+							Direction:   bottomNavigationbar.direction,
+							Background:  background,
+							Clickable:   bottomNavigationbar.BottomNaigationItems[i].Clickable,
+						}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								img := bottomNavigationbar.BottomNaigationItems[i].ImageInactive
 
+								if bottomNavigationbar.BottomNaigationItems[i].PageID == bottomNavigationbar.CurrentPage {
+									img = bottomNavigationbar.BottomNaigationItems[i].Image
+								}
+
+								return img.Layout24dp(gtx)
+							}),
+							layout.Rigid(func(gtx C) D {
+								return layout.Inset{
+									Bottom: bottomNavigationbar.bottomInset,
+								}.Layout(gtx, func(gtx C) D {
+									textColor := bottomNavigationbar.Theme.Color.GrayText1
 									if bottomNavigationbar.BottomNaigationItems[i].PageID == bottomNavigationbar.CurrentPage {
-										img = bottomNavigationbar.BottomNaigationItems[i].Image
+										textColor = bottomNavigationbar.Theme.Color.DeepBlue
 									}
-
-									return img.Layout24dp(gtx)
-								}),
-								layout.Rigid(func(gtx C) D {
-									return layout.Inset{
-										Bottom: bottomNavigationbar.bottomInset,
-									}.Layout(gtx, func(gtx C) D {
-										textColor := bottomNavigationbar.Theme.Color.GrayText1
-										if bottomNavigationbar.BottomNaigationItems[i].PageID == bottomNavigationbar.CurrentPage {
-											textColor = bottomNavigationbar.Theme.Color.DeepBlue
-										}
-										txt := bottomNavigationbar.Theme.Label(bottomNavigationbar.textSize, bottomNavigationbar.BottomNaigationItems[i].Title)
-										txt.Color = textColor
-										return txt.Layout(gtx)
-									})
-								}),
-							)
-						})
-					}),
-				)
-			})
+									txt := bottomNavigationbar.Theme.Label(bottomNavigationbar.textSize, bottomNavigationbar.BottomNaigationItems[i].Title)
+									txt.Color = textColor
+									return txt.Layout(gtx)
+								})
+							}),
+						)
+					})
+				}),
+			)
 		}),
 	)
 }

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -707,18 +707,14 @@ func (mp *MainPage) layoutDesktop(gtx layout.Context) layout.Dimensions {
 
 func (mp *MainPage) layoutMobile(gtx layout.Context) layout.Dimensions {
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-		layout.Flexed(0.125, func(gtx C) D {
-			return mp.LayoutTopBar(gtx)
-		}),
+		layout.Flexed(0.125, mp.LayoutTopBar),
 		layout.Flexed(0.75, func(gtx C) D {
 			if mp.currentPage == nil {
 				return layout.Dimensions{}
 			}
 			return mp.currentPage.Layout(gtx)
 		}),
-		layout.Flexed(0.125, func(gtx C) D {
-			return mp.bottomNavigationBar.LayoutBottomNavigationBar(gtx)
-		}),
+		layout.Flexed(0.125, mp.bottomNavigationBar.LayoutBottomNavigationBar),
 	)
 }
 
@@ -795,7 +791,7 @@ func (mp *MainPage) LayoutTopBar(gtx layout.Context) layout.Dimensions {
 				Orientation: layout.Horizontal,
 			}.Layout(gtx,
 				layout.Rigid(func(gtx C) D {
-					return layout.S.Layout(gtx, func(gtx C) D {
+					return layout.W.Layout(gtx, func(gtx C) D {
 						h := values.MarginPadding24
 						v := values.MarginPadding14
 						// Balance container

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -706,22 +706,18 @@ func (mp *MainPage) layoutDesktop(gtx layout.Context) layout.Dimensions {
 }
 
 func (mp *MainPage) layoutMobile(gtx layout.Context) layout.Dimensions {
-	return layout.Stack{}.Layout(gtx,
-		layout.Expanded(func(gtx C) D {
-			return decredmaterial.LinearLayout{
-				Width:       decredmaterial.MatchParent,
-				Height:      decredmaterial.MatchParent,
-				Orientation: layout.Vertical,
-			}.Layout(gtx,
-				layout.Rigid(mp.LayoutTopBar),
-				layout.Rigid(func(gtx C) D {
-					if mp.currentPage == nil {
-						return layout.Dimensions{}
-					}
-					return mp.currentPage.Layout(gtx)
-				}),
-				layout.Rigid(mp.bottomNavigationBar.LayoutBottomNavigationBar),
-			)
+	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+		layout.Flexed(0.125, func(gtx C) D {
+			return mp.LayoutTopBar(gtx)
+		}),
+		layout.Flexed(0.75, func(gtx C) D {
+			if mp.currentPage == nil {
+				return layout.Dimensions{}
+			}
+			return mp.currentPage.Layout(gtx)
+		}),
+		layout.Flexed(0.125, func(gtx C) D {
+			return mp.bottomNavigationBar.LayoutBottomNavigationBar(gtx)
 		}),
 	)
 }
@@ -785,76 +781,74 @@ func (mp *MainPage) totalDCRBalance(gtx layout.Context) layout.Dimensions {
 }
 
 func (mp *MainPage) LayoutTopBar(gtx layout.Context) layout.Dimensions {
-	return components.UniformPadding(gtx, func(gtx C) D {
-		return decredmaterial.LinearLayout{
-			Width:       decredmaterial.MatchParent,
-			Height:      decredmaterial.WrapContent,
-			Background:  mp.Theme.Color.Surface,
-			Orientation: layout.Vertical,
-		}.Layout(gtx,
-			layout.Rigid(func(gtx C) D {
-				return decredmaterial.LinearLayout{
-					Width:       decredmaterial.MatchParent,
-					Height:      decredmaterial.WrapContent,
-					Background:  mp.Theme.Color.Surface,
-					Orientation: layout.Horizontal,
-				}.Layout(gtx,
-					layout.Rigid(func(gtx C) D {
-						return layout.S.Layout(gtx, func(gtx C) D {
-							h := values.MarginPadding24
-							v := values.MarginPadding14
-							// Balance container
-							return components.Container{Padding: layout.Inset{Right: h, Left: h, Top: v, Bottom: v}}.Layout(gtx,
-								func(gtx C) D {
-									return decredmaterial.LinearLayout{
-										Width:       decredmaterial.WrapContent,
-										Height:      decredmaterial.WrapContent,
-										Background:  mp.Theme.Color.Surface,
-										Orientation: layout.Horizontal,
-									}.Layout(gtx,
-										layout.Rigid(func(gtx C) D {
-											return layout.Inset{Right: values.MarginPadding16}.Layout(gtx,
-												func(gtx C) D {
-													return mp.Theme.Icons.Logo.Layout24dp(gtx)
-												})
-										}),
-										layout.Rigid(func(gtx C) D {
-											return mp.totalDCRBalance(gtx)
-										}),
-										layout.Rigid(func(gtx C) D {
-											if !mp.isBalanceHidden {
-												return mp.LayoutUSDBalance(gtx)
-											}
-											return layout.Dimensions{}
-										}),
-										layout.Rigid(func(gtx C) D {
-											mp.hideBalanceItem.tooltipLabel = mp.Theme.Caption("Hide Balance")
-											mp.hideBalanceItem.hideBalanceButton.Icon = mp.Theme.Icons.RevealIcon
-											if mp.isBalanceHidden {
-												mp.hideBalanceItem.tooltipLabel.Text = "Show Balance"
-												mp.hideBalanceItem.hideBalanceButton.Icon = mp.Theme.Icons.ConcealIcon
-											}
-											return layout.Inset{
-												Top:  values.MarginPadding1,
-												Left: values.MarginPadding9,
-											}.Layout(gtx, mp.hideBalanceItem.hideBalanceButton.Layout)
-										}),
-									)
-								})
-						})
-					}),
-					layout.Rigid(func(gtx C) D {
-						gtx.Constraints.Min.X = gtx.Constraints.Max.X
-						return mp.appBarNav.LayoutTopBar(gtx)
-					}),
-				)
-			}),
-			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
-				gtx.Constraints.Min.X = gtx.Constraints.Max.X
-				return mp.Theme.Separator().Layout(gtx)
-			}),
-		)
-	})
+	return decredmaterial.LinearLayout{
+		Width:       decredmaterial.MatchParent,
+		Height:      decredmaterial.WrapContent,
+		Background:  mp.Theme.Color.Surface,
+		Orientation: layout.Vertical,
+	}.Layout(gtx,
+		layout.Rigid(func(gtx C) D {
+			return decredmaterial.LinearLayout{
+				Width:       decredmaterial.MatchParent,
+				Height:      decredmaterial.WrapContent,
+				Background:  mp.Theme.Color.Surface,
+				Orientation: layout.Horizontal,
+			}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					return layout.S.Layout(gtx, func(gtx C) D {
+						h := values.MarginPadding24
+						v := values.MarginPadding14
+						// Balance container
+						return components.Container{Padding: layout.Inset{Right: h, Left: h, Top: v, Bottom: v}}.Layout(gtx,
+							func(gtx C) D {
+								return decredmaterial.LinearLayout{
+									Width:       decredmaterial.WrapContent,
+									Height:      decredmaterial.WrapContent,
+									Background:  mp.Theme.Color.Surface,
+									Orientation: layout.Horizontal,
+								}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										return layout.Inset{Right: values.MarginPadding16}.Layout(gtx,
+											func(gtx C) D {
+												return mp.Theme.Icons.Logo.Layout24dp(gtx)
+											})
+									}),
+									layout.Rigid(func(gtx C) D {
+										return mp.totalDCRBalance(gtx)
+									}),
+									layout.Rigid(func(gtx C) D {
+										if !mp.isBalanceHidden {
+											return mp.LayoutUSDBalance(gtx)
+										}
+										return layout.Dimensions{}
+									}),
+									layout.Rigid(func(gtx C) D {
+										mp.hideBalanceItem.tooltipLabel = mp.Theme.Caption("Hide Balance")
+										mp.hideBalanceItem.hideBalanceButton.Icon = mp.Theme.Icons.RevealIcon
+										if mp.isBalanceHidden {
+											mp.hideBalanceItem.tooltipLabel.Text = "Show Balance"
+											mp.hideBalanceItem.hideBalanceButton.Icon = mp.Theme.Icons.ConcealIcon
+										}
+										return layout.Inset{
+											Top:  values.MarginPadding1,
+											Left: values.MarginPadding9,
+										}.Layout(gtx, mp.hideBalanceItem.hideBalanceButton.Layout)
+									}),
+								)
+							})
+					})
+				}),
+				layout.Rigid(func(gtx C) D {
+					gtx.Constraints.Min.X = gtx.Constraints.Max.X
+					return mp.appBarNav.LayoutTopBar(gtx)
+				}),
+			)
+		}),
+		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+			gtx.Constraints.Min.X = gtx.Constraints.Max.X
+			return mp.Theme.Separator().Layout(gtx)
+		}),
+	)
 }
 
 // postDdesktopNotification posts notifications to the desktop.

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -60,10 +60,11 @@ type MainPage struct {
 	*listeners.SyncProgressListener
 	*listeners.TxAndBlockNotificationListener
 	*listeners.ProposalNotificationListener
-	ctx       context.Context
-	ctxCancel context.CancelFunc
-	appBarNav components.NavDrawer
-	drawerNav components.NavDrawer
+	ctx                 context.Context
+	ctxCancel           context.CancelFunc
+	appBarNav           components.NavDrawer
+	drawerNav           components.NavDrawer
+	bottomNavigationBar components.BottomNavigationBar
 
 	hideBalanceItem HideBalanceItem
 
@@ -121,6 +122,8 @@ func NewMainPage(l *load.Load) *MainPage {
 	mp.setNavExpanded = func() {
 		mp.drawerNav.DrawerToggled(mp.isNavExpanded)
 	}
+
+	mp.bottomNavigationBar.OnViewCreated()
 
 	return mp
 }
@@ -209,6 +212,41 @@ func (mp *MainPage) initNavItems() {
 		},
 		MinimizeNavDrawerButton: mp.Theme.IconButton(mp.Theme.Icons.NavigationArrowBack),
 		MaximizeNavDrawerButton: mp.Theme.IconButton(mp.Theme.Icons.NavigationArrowForward),
+	}
+
+	mp.bottomNavigationBar = components.BottomNavigationBar{
+		Load:        mp.Load,
+		CurrentPage: mp.currentPageID(),
+		BottomNaigationItems: []components.BottomNavigationBarHandler{
+			{
+				Clickable:     mp.Theme.NewClickable(true),
+				Image:         mp.Theme.Icons.OverviewIcon,
+				ImageInactive: mp.Theme.Icons.OverviewIconInactive,
+				Title:         values.String(values.StrOverview),
+				PageID:        overview.OverviewPageID,
+			},
+			{
+				Clickable:     mp.Theme.NewClickable(true),
+				Image:         mp.Theme.Icons.TransactionsIcon,
+				ImageInactive: mp.Theme.Icons.TransactionsIconInactive,
+				Title:         values.String(values.StrTransactions),
+				PageID:        transaction.TransactionsPageID,
+			},
+			{
+				Clickable:     mp.Theme.NewClickable(true),
+				Image:         mp.Theme.Icons.WalletIcon,
+				ImageInactive: mp.Theme.Icons.WalletIconInactive,
+				Title:         values.String(values.StrWallets),
+				PageID:        wallets.WalletPageID,
+			},
+			{
+				Clickable:     mp.Theme.NewClickable(true),
+				Image:         mp.Theme.Icons.MoreIcon,
+				ImageInactive: mp.Theme.Icons.MoreIconInactive,
+				Title:         values.String(values.StrMore),
+				PageID:        MorePageID,
+			},
+		},
 	}
 }
 
@@ -386,6 +424,7 @@ func (mp *MainPage) HandleUserInteractions() {
 	}
 
 	mp.drawerNav.CurrentPage = mp.currentPageID()
+	mp.bottomNavigationBar.CurrentPage = mp.currentPageID()
 	mp.appBarNav.CurrentPage = mp.currentPageID()
 
 	for mp.drawerNav.MinimizeNavDrawerButton.Button.Clicked() {
@@ -448,6 +487,29 @@ func (mp *MainPage) HandleUserInteractions() {
 				} else {
 					pg = dexclient.NewMarketPage(mp.Load)
 				}
+			case MorePageID:
+				pg = NewMorePage(mp.Load)
+			}
+
+			if pg == nil || pg.ID() == mp.currentPageID() {
+				continue
+			}
+
+			// clear stack
+			mp.changeFragment(pg)
+		}
+	}
+
+	for _, item := range mp.bottomNavigationBar.BottomNaigationItems {
+		for item.Clickable.Clicked() {
+			var pg load.Page
+			switch item.PageID {
+			case overview.OverviewPageID:
+				pg = overview.NewOverviewPage(mp.Load)
+			case transaction.TransactionsPageID:
+				pg = transaction.NewTransactionsPage(mp.Load)
+			case wallets.WalletPageID:
+				pg = wallets.NewWalletPage(mp.Load)
 			case MorePageID:
 				pg = NewMorePage(mp.Load)
 			}
@@ -581,6 +643,13 @@ func (mp *MainPage) popToFragment(pageID string) {
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
+	if gtx.Constraints.Max.X <= gtx.Px(unit.Sp(400)) {
+		return mp.layoutMobile(gtx)
+	}
+	return mp.layoutDesktop(gtx)
+}
+
+func (mp *MainPage) layoutDesktop(gtx layout.Context) layout.Dimensions {
 	return layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
 			return decredmaterial.LinearLayout{
@@ -632,6 +701,27 @@ func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
 			//TODO: show toasts here
 			return D{}
 
+		}),
+	)
+}
+
+func (mp *MainPage) layoutMobile(gtx layout.Context) layout.Dimensions {
+	return layout.Stack{}.Layout(gtx,
+		layout.Expanded(func(gtx C) D {
+			return decredmaterial.LinearLayout{
+				Width:       decredmaterial.MatchParent,
+				Height:      decredmaterial.MatchParent,
+				Orientation: layout.Vertical,
+			}.Layout(gtx,
+				layout.Rigid(mp.LayoutTopBar),
+				layout.Rigid(func(gtx C) D {
+					if mp.currentPage == nil {
+						return layout.Dimensions{}
+					}
+					return mp.currentPage.Layout(gtx)
+				}),
+				layout.Rigid(mp.bottomNavigationBar.LayoutBottomNavigationBar),
+			)
 		}),
 	)
 }
@@ -695,74 +785,76 @@ func (mp *MainPage) totalDCRBalance(gtx layout.Context) layout.Dimensions {
 }
 
 func (mp *MainPage) LayoutTopBar(gtx layout.Context) layout.Dimensions {
-	return decredmaterial.LinearLayout{
-		Width:       decredmaterial.MatchParent,
-		Height:      decredmaterial.WrapContent,
-		Background:  mp.Theme.Color.Surface,
-		Orientation: layout.Vertical,
-	}.Layout(gtx,
-		layout.Rigid(func(gtx C) D {
-			return decredmaterial.LinearLayout{
-				Width:       decredmaterial.MatchParent,
-				Height:      decredmaterial.WrapContent,
-				Background:  mp.Theme.Color.Surface,
-				Orientation: layout.Horizontal,
-			}.Layout(gtx,
-				layout.Rigid(func(gtx C) D {
-					return layout.W.Layout(gtx, func(gtx C) D {
-						h := values.MarginPadding24
-						v := values.MarginPadding14
-						// Balance container
-						return components.Container{Padding: layout.Inset{Right: h, Left: h, Top: v, Bottom: v}}.Layout(gtx,
-							func(gtx C) D {
-								return decredmaterial.LinearLayout{
-									Width:       decredmaterial.WrapContent,
-									Height:      decredmaterial.WrapContent,
-									Background:  mp.Theme.Color.Surface,
-									Orientation: layout.Horizontal,
-								}.Layout(gtx,
-									layout.Rigid(func(gtx C) D {
-										return layout.Inset{Right: values.MarginPadding16}.Layout(gtx,
-											func(gtx C) D {
-												return mp.Theme.Icons.Logo.Layout24dp(gtx)
-											})
-									}),
-									layout.Rigid(func(gtx C) D {
-										return mp.totalDCRBalance(gtx)
-									}),
-									layout.Rigid(func(gtx C) D {
-										if !mp.isBalanceHidden {
-											return mp.LayoutUSDBalance(gtx)
-										}
-										return layout.Dimensions{}
-									}),
-									layout.Rigid(func(gtx C) D {
-										mp.hideBalanceItem.tooltipLabel = mp.Theme.Caption("Hide Balance")
-										mp.hideBalanceItem.hideBalanceButton.Icon = mp.Theme.Icons.RevealIcon
-										if mp.isBalanceHidden {
-											mp.hideBalanceItem.tooltipLabel.Text = "Show Balance"
-											mp.hideBalanceItem.hideBalanceButton.Icon = mp.Theme.Icons.ConcealIcon
-										}
-										return layout.Inset{
-											Top:  values.MarginPadding1,
-											Left: values.MarginPadding9,
-										}.Layout(gtx, mp.hideBalanceItem.hideBalanceButton.Layout)
-									}),
-								)
-							})
-					})
-				}),
-				layout.Rigid(func(gtx C) D {
-					gtx.Constraints.Min.X = gtx.Constraints.Max.X
-					return mp.appBarNav.LayoutTopBar(gtx)
-				}),
-			)
-		}),
-		layout.Rigid(func(gtx layout.Context) layout.Dimensions {
-			gtx.Constraints.Min.X = gtx.Constraints.Max.X
-			return mp.Theme.Separator().Layout(gtx)
-		}),
-	)
+	return components.UniformPadding(gtx, func(gtx C) D {
+		return decredmaterial.LinearLayout{
+			Width:       decredmaterial.MatchParent,
+			Height:      decredmaterial.WrapContent,
+			Background:  mp.Theme.Color.Surface,
+			Orientation: layout.Vertical,
+		}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				return decredmaterial.LinearLayout{
+					Width:       decredmaterial.MatchParent,
+					Height:      decredmaterial.WrapContent,
+					Background:  mp.Theme.Color.Surface,
+					Orientation: layout.Horizontal,
+				}.Layout(gtx,
+					layout.Rigid(func(gtx C) D {
+						return layout.S.Layout(gtx, func(gtx C) D {
+							h := values.MarginPadding24
+							v := values.MarginPadding14
+							// Balance container
+							return components.Container{Padding: layout.Inset{Right: h, Left: h, Top: v, Bottom: v}}.Layout(gtx,
+								func(gtx C) D {
+									return decredmaterial.LinearLayout{
+										Width:       decredmaterial.WrapContent,
+										Height:      decredmaterial.WrapContent,
+										Background:  mp.Theme.Color.Surface,
+										Orientation: layout.Horizontal,
+									}.Layout(gtx,
+										layout.Rigid(func(gtx C) D {
+											return layout.Inset{Right: values.MarginPadding16}.Layout(gtx,
+												func(gtx C) D {
+													return mp.Theme.Icons.Logo.Layout24dp(gtx)
+												})
+										}),
+										layout.Rigid(func(gtx C) D {
+											return mp.totalDCRBalance(gtx)
+										}),
+										layout.Rigid(func(gtx C) D {
+											if !mp.isBalanceHidden {
+												return mp.LayoutUSDBalance(gtx)
+											}
+											return layout.Dimensions{}
+										}),
+										layout.Rigid(func(gtx C) D {
+											mp.hideBalanceItem.tooltipLabel = mp.Theme.Caption("Hide Balance")
+											mp.hideBalanceItem.hideBalanceButton.Icon = mp.Theme.Icons.RevealIcon
+											if mp.isBalanceHidden {
+												mp.hideBalanceItem.tooltipLabel.Text = "Show Balance"
+												mp.hideBalanceItem.hideBalanceButton.Icon = mp.Theme.Icons.ConcealIcon
+											}
+											return layout.Inset{
+												Top:  values.MarginPadding1,
+												Left: values.MarginPadding9,
+											}.Layout(gtx, mp.hideBalanceItem.hideBalanceButton.Layout)
+										}),
+									)
+								})
+						})
+					}),
+					layout.Rigid(func(gtx C) D {
+						gtx.Constraints.Min.X = gtx.Constraints.Max.X
+						return mp.appBarNav.LayoutTopBar(gtx)
+					}),
+				)
+			}),
+			layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+				gtx.Constraints.Min.X = gtx.Constraints.Max.X
+				return mp.Theme.Separator().Layout(gtx)
+			}),
+		)
+	})
 }
 
 // postDdesktopNotification posts notifications to the desktop.

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -643,7 +643,7 @@ func (mp *MainPage) popToFragment(pageID string) {
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
-	if gtx.Constraints.Max.X <= gtx.Px(unit.Sp(400)) {
+	if gtx.Constraints.Max.X <= gtx.Px(unit.Sp(428)) {
 		return mp.layoutMobile(gtx)
 	}
 	return mp.layoutDesktop(gtx)

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -91,5 +91,5 @@ var (
 	TextSize32   = unit.Sp(32)
 
 	AppWidth  = unit.Sp(428)
-	AppHeight = unit.Sp(926)
+	AppHeight = unit.Sp(740)
 )

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -90,6 +90,6 @@ var (
 	TextSize34   = unit.Sp(34)
 	TextSize32   = unit.Sp(32)
 
-	AppWidth  = unit.Sp(800)
-	AppHeight = unit.Sp(600)
+	AppWidth  = unit.Sp(400)
+	AppHeight = unit.Sp(740)
 )

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -90,6 +90,6 @@ var (
 	TextSize34   = unit.Sp(34)
 	TextSize32   = unit.Sp(32)
 
-	AppWidth  = unit.Sp(400)
-	AppHeight = unit.Sp(740)
+	AppWidth  = unit.Sp(428)
+	AppHeight = unit.Sp(926)
 )

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -90,6 +90,6 @@ var (
 	TextSize34   = unit.Sp(34)
 	TextSize32   = unit.Sp(32)
 
-	AppWidth  = unit.Sp(428)
-	AppHeight = unit.Sp(740)
+	AppWidth  = unit.Sp(800)
+	AppHeight = unit.Sp(600)
 )


### PR DESCRIPTION
When on devices with screen width below `479px`, we can safely assume the user is on a mobile device and rearrange the layout.

This PR replaces the side bar with a bottom navigation bar when on screen-sizes below `479px`

**How can we achieve multiple layouts?**

Each page has a `Layout(gtx layout.Context) D {}` method, we can create 2 further layout to address mobile and desktop view(based on the current app width, we can say tablets are accounted for, although tests would still be carried out for such purposes).

The 2 layouts that need to be created are `layoutDesktop(gtx layout.Context) layout.Dimensions {}` and `layoutMobile(gtx layout.Context) layout.Dimensions {}`

**How do we decide which layout to show?**

We can check if the max screen width is below or equals the chosen mobile pixels (`479px`) e.g `if gtx.Constraints.Max.X <= gtx.Px(unit.Sp(400)) {}`

So for a full layout method, we should have;
```
func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
	if gtx.Constraints.Max.X <= gtx.Px(unit.Sp(479)) {
		return mp.layoutMobile(gtx)
	}
	return mp.layoutDesktop(gtx)
}
```

**How can we compile for Mobile devices?**

**Android**
From the [Gioui Docs for building Android](https://gioui.org/doc/install/android)

`gogio -target android .`

This would generate a `godcr.apk`

**iOS**
From the [Gioui Docs for building iOS](https://gioui.org/doc/install/ios)

`gogio -o godcr.app -target ios .`

This would generate a `godcr.app`

**Screenshots**
![ezgif com-optimize](https://user-images.githubusercontent.com/25265396/169873617-f3caa07a-cc63-45c8-8f80-6d480f989112.gif)
