### PR TITLE
Watch-only wallet delete bug

### DIFF
--- a/ui/load/load.go
+++ b/ui/load/load.go
@@ -7,6 +7,7 @@ package load
 
 import (
 	"golang.org/x/text/message"
+	"sync"
 
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/assets"
@@ -28,6 +29,7 @@ type Load struct {
 	CurrentAppWidth int
 
 	Toast *notification.Toast
+	UiMu  sync.Mutex // Mutex to sync concurrent access to UI components.
 
 	SelectedUTXO map[int]map[int32]map[string]*wallet.UnspentOutput
 

--- a/ui/load/load.go
+++ b/ui/load/load.go
@@ -6,8 +6,9 @@
 package load
 
 import (
-	"golang.org/x/text/message"
 	"sync"
+
+	"golang.org/x/text/message"
 
 	"github.com/planetdecred/dcrlibwallet"
 	"github.com/planetdecred/godcr/ui/assets"
@@ -29,7 +30,7 @@ type Load struct {
 	CurrentAppWidth int
 
 	Toast *notification.Toast
-	UiMu  sync.Mutex // Mutex to sync concurrent access to UI components.
+	UIMu  sync.Mutex // Mutex to sync concurrent access to UI components.
 
 	SelectedUTXO map[int]map[int32]map[string]*wallet.UnspentOutput
 

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -105,9 +105,9 @@ func (in *InfoModal) CheckBox(checkbox decredmaterial.CheckBoxStyle, mustBeCheck
 	return in
 }
 
-func (pm *InfoModal) SetLoading(loading bool) {
-	pm.isLoading = loading
-	pm.modal.SetDisabled(loading)
+func (in *InfoModal) SetLoading(loading bool) {
+	in.isLoading = loading
+	in.modal.SetDisabled(loading)
 }
 
 func (in *InfoModal) Title(title string) *InfoModal {

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -180,7 +180,7 @@ func (in *InfoModal) HandleKeyEvent(evt *key.Event) {
 }
 
 func (in *InfoModal) Handle() {
-	for in.btnPositve.Clicked() {
+	if in.btnPositve.Clicked() {
 		if in.isLoading {
 			return
 		}
@@ -195,7 +195,7 @@ func (in *InfoModal) Handle() {
 		}
 	}
 
-	for in.btnNegative.Clicked() {
+	if in.btnNegative.Clicked() {
 		if !in.isLoading {
 			in.DismissModal(in)
 			in.negativeButtonClicked()

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -30,7 +30,7 @@ type InfoModal struct {
 	customWidget   layout.Widget
 
 	positiveButtonText    string
-	positiveButtonClicked func(isChecked bool)
+	positiveButtonClicked func(isChecked bool) bool
 	btnPositve            decredmaterial.Button
 
 	negativeButtonText    string
@@ -120,7 +120,7 @@ func (in *InfoModal) Body(subtitle string) *InfoModal {
 	return in
 }
 
-func (in *InfoModal) PositiveButton(text string, clicked func(isChecked bool)) *InfoModal {
+func (in *InfoModal) PositiveButton(text string, clicked func(isChecked bool) bool) *InfoModal {
 	in.positiveButtonText = text
 	in.positiveButtonClicked = clicked
 	return in
@@ -181,13 +181,15 @@ func (in *InfoModal) HandleKeyEvent(evt *key.Event) {
 
 func (in *InfoModal) Handle() {
 	for in.btnPositve.Clicked() {
+		if in.isLoading {
+			return
+		}
 		isChecked := false
 		if in.checkbox.CheckBox != nil {
 			isChecked = in.checkbox.CheckBox.Value
 		}
 
-		in.positiveButtonClicked(isChecked)
-		if !in.isLoading {
+		if in.positiveButtonClicked(isChecked) {
 			in.DismissModal(in)
 		}
 	}

--- a/ui/modal/info_modal.go
+++ b/ui/modal/info_modal.go
@@ -180,10 +180,7 @@ func (in *InfoModal) HandleKeyEvent(evt *key.Event) {
 }
 
 func (in *InfoModal) Handle() {
-	if in.btnPositve.Clicked() {
-		if in.isLoading {
-			return
-		}
+	for in.btnPositve.Clicked() {
 		isChecked := false
 		if in.checkbox.CheckBox != nil {
 			isChecked = in.checkbox.CheckBox.Value
@@ -195,7 +192,7 @@ func (in *InfoModal) Handle() {
 		}
 	}
 
-	if in.btnNegative.Clicked() {
+	for in.btnNegative.Clicked() {
 		if !in.isLoading {
 			in.DismissModal(in)
 			in.negativeButtonClicked()

--- a/ui/page/components/sub_page.go
+++ b/ui/page/components/sub_page.go
@@ -134,7 +134,9 @@ func (sp *SubPage) EventHandler() {
 				Title(sp.Title).
 				SetupWithTemplate(sp.InfoTemplate).
 				SetCancelable(true).
-				PositiveButton(values.String(values.StrGotIt), func(isChecked bool) {}).Show()
+				PositiveButton(values.String(values.StrGotIt), func(isChecked bool) bool {
+					return true
+				}).Show()
 		}
 	}
 

--- a/ui/page/components/votebar_widget.go
+++ b/ui/page/components/votebar_widget.go
@@ -240,7 +240,9 @@ func (v *VoteBar) infoButtonModal() {
 		Title(values.String(values.StrProposalVoteDetails)).
 		Body(bodyText).
 		SetCancelable(true).
-		PositiveButton(values.String(values.StrGotIt), func(bool) {}).Show()
+		PositiveButton(values.String(values.StrGotIt), func(bool) bool {
+			return true
+		}).Show()
 }
 
 func (v *VoteBar) layoutIconAndText(gtx C, lbl decredmaterial.Label, count int, col color.NRGBA) D {

--- a/ui/page/debug_page.go
+++ b/ui/page/debug_page.go
@@ -170,12 +170,13 @@ func (pg *DebugPage) resetDexData() {
 		Title(values.String(values.StrConfirmDexReset)).
 		Body(values.String(values.StrDexResetInfo)).
 		NegativeButton(values.String(values.StrCancel), func() {}).
-		PositiveButton(values.String(values.StrResetDexClient), func(isChecked bool) {
+		PositiveButton(values.String(values.StrResetDexClient), func(isChecked bool) bool {
 			if pg.Dexc().Reset() {
 				pg.Toast.Notify("DEX client data reset complete.")
 			} else {
 				pg.Toast.NotifyError("DEX client data reset failed. Check the logs.")
 			}
+			return true
 		})
 	pg.ShowModal(confirmModal)
 }

--- a/ui/page/governance/consensus_page.go
+++ b/ui/page/governance/consensus_page.go
@@ -117,7 +117,9 @@ func (pg *ConsensusPage) HandleUserInteractions() {
 			Title(values.String(values.StrConsensusChange)).
 			Body(values.String(values.StrOnChainVote)).
 			SetCancelable(true).
-			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) {}).Show()
+			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) bool {
+				return true
+			}).Show()
 	}
 
 	for pg.viewVotingDashboard.Clicked() {
@@ -167,7 +169,9 @@ func (pg *ConsensusPage) HandleUserInteractions() {
 					}),
 				)
 			}).
-			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) {})
+			PositiveButton("Got it", func(isChecked bool) bool {
+				return true
+			})
 		pg.ShowModal(info)
 	}
 

--- a/ui/page/governance/proposal_details_page.go
+++ b/ui/page/governance/proposal_details_page.go
@@ -178,7 +178,9 @@ func (pg *ProposalDetails) HandleUserInteractions() {
 					}),
 				)
 			}).
-			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) {})
+			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) bool {
+				return true
+			})
 		pg.ShowModal(info)
 	}
 }

--- a/ui/page/governance/proposals_page.go
+++ b/ui/page/governance/proposals_page.go
@@ -183,7 +183,9 @@ func (pg *ProposalsPage) HandleUserInteractions() {
 			Title(values.String(values.StrProposal)).
 			Body(values.String(values.StrOffChainVote)).
 			SetCancelable(true).
-			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) {}).Show()
+			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) bool {
+				return true
+			}).Show()
 	}
 
 	if pg.syncCompleted {

--- a/ui/page/governance/splash_screen.go
+++ b/ui/page/governance/splash_screen.go
@@ -65,6 +65,8 @@ func (pg *Page) showInfoModal() {
 	info := modal.NewInfoModal(pg.Load).
 		Title(values.String(values.StrGovernance)).
 		Body(values.String(values.StrProposalInfo)).
-		PositiveButton(values.String(values.StrGotIt), func(isChecked bool) {})
+		PositiveButton(values.String(values.StrGotIt), func(isChecked bool) bool {
+			return true
+		})
 	pg.ShowModal(info)
 }

--- a/ui/page/help_page.go
+++ b/ui/page/help_page.go
@@ -165,7 +165,9 @@ func (pg *HelpPage) HandleUserInteractions() {
 					}),
 				)
 			}).
-			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) {})
+			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) bool {
+				return true
+			})
 		pg.ShowModal(info)
 	}
 }

--- a/ui/page/overview/overview_layout.go
+++ b/ui/page/overview/overview_layout.go
@@ -235,9 +235,10 @@ func (pg *AppOverviewPage) showBackupInfo() {
 			pg.WL.MultiWallet.SaveUserConfigValue(load.SeedBackupNotificationConfigKey, true)
 		}).
 		PositiveButtonStyle(pg.Load.Theme.Color.Primary, pg.Load.Theme.Color.InvText).
-		PositiveButton(values.String(values.StrBackupNow), func(isChecked bool) {
+		PositiveButton(values.String(values.StrBackupNow), func(isChecked bool) bool {
 			pg.WL.MultiWallet.SaveUserConfigValue(load.SeedBackupNotificationConfigKey, true)
 			pg.ChangeFragment(wPage.NewWalletPage(pg.Load))
+			return true
 		}).Show()
 }
 

--- a/ui/page/privacy/account_mixer_page.go
+++ b/ui/page/privacy/account_mixer_page.go
@@ -243,9 +243,10 @@ func (pg *AccountMixerPage) HandleUserInteractions() {
 				Title("Cancel mixer?").
 				Body("Are you sure you want to cancel mixer action?").
 				NegativeButton("No", func() {}).
-				PositiveButton("Yes", func(isChecked bool) {
+				PositiveButton("Yes", func(isChecked bool) bool {
 					pg.toggleMixer.SetChecked(false)
 					go pg.WL.MultiWallet.StopAccountMixer(pg.wallet.ID)
+					return true
 				})
 			pg.ShowModal(info)
 		}

--- a/ui/page/privacy/shared_modals.go
+++ b/ui/page/privacy/shared_modals.go
@@ -32,7 +32,9 @@ func showInfoModal(conf *sharedModalConf, title, body, btnText string, isError, 
 		Icon(icon).
 		Title(title).
 		Body(body).
-		PositiveButton(btnText, func(isChecked bool) {})
+		PositiveButton(btnText, func(isChecked bool) bool {
+			return true
+		})
 
 	if alignCenter {
 		align := layout.Center
@@ -48,8 +50,9 @@ func showModalSetupMixerInfo(conf *sharedModalConf) {
 		SetupWithTemplate(modal.SetupMixerInfoTemplate).
 		CheckBox(conf.checkBox, false).
 		NegativeButton(values.String(values.StrCancel), func() {}).
-		PositiveButton("Begin setup", func(movefundsChecked bool) {
+		PositiveButton("Begin setup", func(movefundsChecked bool) bool {
 			showModalSetupMixerAcct(conf, movefundsChecked)
+			return true
 		})
 	conf.ShowModal(info)
 }
@@ -65,8 +68,9 @@ func showModalSetupMixerAcct(conf *sharedModalConf, movefundsChecked bool) {
 				Icon(alert).
 				Title("Account name is taken").
 				Body(txt).
-				PositiveButton("Go back & rename", func(movefundsChecked bool) {
+				PositiveButton("Go back & rename", func(movefundsChecked bool) bool {
 					conf.PopFragment()
+					return true
 				})
 			conf.ShowModal(info)
 			return

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -462,7 +462,9 @@ func (pg *ReceivePage) HandleUserInteractions() {
 		info := modal.NewInfoModal(pg.Load).
 			Title(values.String(values.StrReceive)+" DCR").
 			Body(values.String(values.StrReceiveInfo)).
-			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) {})
+			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) bool {
+				return true
+			})
 		pg.ShowModal(info)
 	}
 

--- a/ui/page/seedbackup/backup_instructions.go
+++ b/ui/page/seedbackup/backup_instructions.go
@@ -93,8 +93,9 @@ func promptToExit(load *load.Load) {
 		Title("Exit?").
 		Body("Are you sure you want to exit the seed backup process?").
 		NegativeButton("No", func() {}).
-		PositiveButton("Yes", func(isChecked bool) {
+		PositiveButton("Yes", func(isChecked bool) bool {
 			load.PopToFragment(components.WalletsPageID)
+			return true
 		}).
 		Show()
 }

--- a/ui/page/send/page.go
+++ b/ui/page/send/page.go
@@ -362,7 +362,9 @@ func (pg *Page) HandleUserInteractions() {
 		info := modal.NewInfoModal(pg.Load).
 			Title(values.String(values.StrSend)+" DCR").
 			Body(values.String(values.StrSendInfo)).
-			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) {})
+			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) bool {
+				return true
+			})
 		pg.ShowModal(info)
 	}
 

--- a/ui/page/settings_page.go
+++ b/ui/page/settings_page.go
@@ -381,8 +381,9 @@ func (pg *SettingsPage) showWarningModalDialog(title, msg, key string) {
 		Body(msg).
 		NegativeButton(values.String(values.StrCancel), func() {}).
 		PositiveButtonStyle(pg.Theme.Color.Surface, pg.Theme.Color.Danger).
-		PositiveButton(values.String(values.StrRemove), func(isChecked bool) {
+		PositiveButton(values.String(values.StrRemove), func(isChecked bool) bool {
 			pg.WL.MultiWallet.DeleteUserConfigValueForKey(key)
+			return true
 		})
 	pg.ShowModal(info)
 }
@@ -434,13 +435,14 @@ func (pg *SettingsPage) HandleUserInteractions() {
 				Body(values.String(values.StrGovernanceSettingsInfo)).
 				NegativeButton(values.String(values.StrCancel), func() {}).
 				PositiveButtonStyle(pg.Theme.Color.Surface, pg.Theme.Color.Danger).
-				PositiveButton(values.String(values.StrDisable), func(isChecked bool) {
+				PositiveButton(values.String(values.StrDisable), func(isChecked bool) bool {
 					if pg.WL.MultiWallet.Politeia.IsSyncing() {
 						go pg.WL.MultiWallet.Politeia.StopSync()
 					}
 					pg.WL.MultiWallet.SaveUserConfigValue(load.FetchProposalConfigKey, !pg.governance.IsChecked())
 					pg.WL.MultiWallet.Politeia.ClearSavedProposals()
 					pg.Toast.Notify(values.StringF(values.StrPropFetching, values.String(values.StrDisabled)))
+					return true
 				})
 			pg.ShowModal(info)
 		}
@@ -472,7 +474,9 @@ func (pg *SettingsPage) HandleUserInteractions() {
 		info := modal.NewInfoModal(pg.Load).
 			Title(values.String(values.StrSetupStartupPassword)).
 			Body(values.String(values.StrStartupPasswordInfo)).
-			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) {})
+			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) bool {
+				return true
+			})
 		pg.ShowModal(info)
 	}
 

--- a/ui/page/staking/overview.go
+++ b/ui/page/staking/overview.go
@@ -252,7 +252,9 @@ func (pg *Page) HandleUserInteractions() {
 					Icon(successIcon).
 					Title(values.String(values.StrTicketConfirmed)).
 					SetContentAlignment(align, align).
-					PositiveButton(values.String(values.StrBackStaking), func(isChecked bool) {})
+					PositiveButton(values.String(values.StrBackStaking), func(isChecked bool) bool {
+						return true
+					})
 				pg.ShowModal(info)
 				pg.loadPageData()
 			}).Show()

--- a/ui/page/transaction/transaction_details_page.go
+++ b/ui/page/transaction/transaction_details_page.go
@@ -770,7 +770,9 @@ func (pg *TxDetailsPage) HandleUserInteractions() {
 					}),
 				)
 			}).
-			PositiveButton("Got it", func(isChecked bool) {})
+			PositiveButton("Got it", func(isChecked bool) bool {
+				return true
+			})
 		pg.ShowModal(info)
 	}
 

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -1245,7 +1245,7 @@ func (pg *WalletPage) deleteBadWallet(badWalletID int) {
 		Body(values.String(values.StrWalletRestoreMsg)).
 		NegativeButton(values.String(values.StrCancel), func() {}).
 		PositiveButtonStyle(pg.Load.Theme.Color.Surface, pg.Load.Theme.Color.Danger).
-		PositiveButton(values.String(values.StrRemove), func(isChecked bool) {
+		PositiveButton(values.String(values.StrRemove), func(isChecked bool) bool {
 			go func() {
 				err := pg.WL.MultiWallet.DeleteBadWallet(badWalletID)
 				if err != nil {
@@ -1256,6 +1256,7 @@ func (pg *WalletPage) deleteBadWallet(badWalletID int) {
 				pg.loadBadWallets() // refresh bad wallets list
 				pg.RefreshWindow()
 			}()
+			return true
 		}).Show()
 }
 

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -160,6 +160,8 @@ func (pg *WalletPage) OnNavigatedTo() {
 	pg.ctx, pg.ctxCancel = context.WithCancel(context.TODO())
 
 	pg.listenForTxNotifications()
+
+	pg.hasWatchOnly = false
 	pg.loadWalletAndAccounts()
 }
 

--- a/ui/page/wallets/wallet_settings_page.go
+++ b/ui/page/wallets/wallet_settings_page.go
@@ -276,25 +276,25 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 						}
 					}()
 					return
-				} else {
-					modal.NewPasswordModal(pg.Load).
-						Title(values.String(values.StrConfirmToRemove)).
-						NegativeButton(values.String(values.StrCancel), func() {}).
-						PositiveButton(values.String(values.StrConfirm), func(password string, pm *modal.PasswordModal) bool {
-							go func() {
-								err := pg.WL.MultiWallet.DeleteWallet(pg.wallet.ID, []byte(password))
-								if err != nil {
-									pm.SetError(err.Error())
-									pm.SetLoading(false)
-									return
-								}
-
-								walletDeleted()
-								pm.Dismiss() // calls RefreshWindow.
-							}()
-							return false
-						}).Show()
 				}
+
+				modal.NewPasswordModal(pg.Load).
+					Title(values.String(values.StrConfirmToRemove)).
+					NegativeButton(values.String(values.StrCancel), func() {}).
+					PositiveButton(values.String(values.StrConfirm), func(password string, pm *modal.PasswordModal) bool {
+						go func() {
+							err := pg.WL.MultiWallet.DeleteWallet(pg.wallet.ID, []byte(password))
+							if err != nil {
+								pm.SetError(err.Error())
+								pm.SetLoading(false)
+								return
+							}
+
+							walletDeleted()
+							pm.Dismiss() // calls RefreshWindow.
+						}()
+						return false
+					}).Show()
 
 			}).Show()
 	}

--- a/ui/page/wallets/wallet_settings_page.go
+++ b/ui/page/wallets/wallet_settings_page.go
@@ -223,18 +223,19 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 				Body("Rescanning may help resolve some balance errors. This will take some time, as it scans the entire"+
 					" blockchain for transactions").
 				NegativeButton(values.String(values.StrCancel), func() {}).
-				PositiveButton(values.String(values.StrRescan), func(isChecked bool) {
+				PositiveButton(values.String(values.StrRescan), func(isChecked bool) bool {
 					err := pg.WL.MultiWallet.RescanBlocks(pg.wallet.ID)
 					if err != nil {
 						if err.Error() == dcrlibwallet.ErrNotConnected {
 							pg.Toast.NotifyError(values.String(values.StrNotConnected))
-							return
+							return true
 						}
 						pg.Toast.NotifyError(err.Error())
-						return
+						return true
 					}
 					msg := values.String(values.StrRescanProgressNotification)
 					pg.Toast.Notify(msg)
+					return true
 				})
 
 			pg.ShowModal(info)
@@ -252,7 +253,7 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 			Body(warningMsg).
 			NegativeButton(values.String(values.StrCancel), func() {}).
 			PositiveButtonStyle(pg.Load.Theme.Color.Surface, pg.Load.Theme.Color.Danger).
-			PositiveButton(values.String(values.StrRemove), func(isChecked bool) {
+			PositiveButton(values.String(values.StrRemove), func(isChecked bool) bool {
 				walletDeleted := func() {
 					if pg.WL.MultiWallet.LoadedWalletsCount() > 0 {
 						pg.Toast.Notify("Wallet removed")
@@ -275,7 +276,7 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 							infoModal.Dismiss()
 						}
 					}()
-					return
+					return false
 				}
 
 				modal.NewPasswordModal(pg.Load).
@@ -295,15 +296,17 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 						}()
 						return false
 					}).Show()
-
+				return false
 			}).Show()
 	}
 
 	if pg.infoButton.Button.Clicked() {
 		info := modal.NewInfoModal(pg.Load).
-			Title("Spending password").
-			Body("A spending password helps secure your wallet transactions.").
-			PositiveButton("Got it", func(isChecked bool) {})
+			Title(values.String(values.StrSpendingPassword)).
+			Body(values.String(values.StrSpendingPasswordInfo)).
+			PositiveButton(values.String(values.StrGotIt), func(isChecked bool) bool {
+				return true
+			})
 		pg.ShowModal(info)
 	}
 }

--- a/ui/page/wallets/wallet_settings_page.go
+++ b/ui/page/wallets/wallet_settings_page.go
@@ -263,33 +263,35 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 				}
 
 				if pg.wallet.IsWatchingOnlyWallet() {
-					// no password is required for watching only wallets.
-					err := pg.WL.MultiWallet.DeleteWallet(pg.wallet.ID, nil)
-					if err != nil {
-						pg.Toast.NotifyError(err.Error())
-					} else {
-						go walletDeleted()
-					}
-					return
-				}
-
-				modal.NewPasswordModal(pg.Load).
-					Title(values.String(values.StrConfirmToRemove)).
-					NegativeButton(values.String(values.StrCancel), func() {}).
-					PositiveButton(values.String(values.StrConfirm), func(password string, pm *modal.PasswordModal) bool {
-						go func() {
-							err := pg.WL.MultiWallet.DeleteWallet(pg.wallet.ID, []byte(password))
-							if err != nil {
-								pm.SetError(err.Error())
-								pm.SetLoading(false)
-								return
-							}
-
+					go func() {
+						// no password is required for watching only wallets.
+						err := pg.WL.MultiWallet.DeleteWallet(pg.wallet.ID, nil)
+						if err != nil {
+							pg.Toast.NotifyError(err.Error())
+						} else {
 							walletDeleted()
-							pm.Dismiss() // calls RefreshWindow.
-						}()
-						return false
-					}).Show()
+						}
+					}()
+					return
+				} else {
+					modal.NewPasswordModal(pg.Load).
+						Title(values.String(values.StrConfirmToRemove)).
+						NegativeButton(values.String(values.StrCancel), func() {}).
+						PositiveButton(values.String(values.StrConfirm), func(password string, pm *modal.PasswordModal) bool {
+							go func() {
+								err := pg.WL.MultiWallet.DeleteWallet(pg.wallet.ID, []byte(password))
+								if err != nil {
+									pm.SetError(err.Error())
+									pm.SetLoading(false)
+									return
+								}
+
+								walletDeleted()
+								pm.Dismiss() // calls RefreshWindow.
+							}()
+							return false
+						}).Show()
+				}
 
 			}).Show()
 	}

--- a/ui/page/wallets/wallet_settings_page.go
+++ b/ui/page/wallets/wallet_settings_page.go
@@ -247,8 +247,8 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 		if pg.wallet.IsWatchingOnlyWallet() {
 			warningMsg = "The watch-only wallet will be removed from your app"
 		}
-		modal.NewInfoModal(pg.Load).
-			Title(values.String(values.StrRemoveWallet)).
+		infoModal := modal.NewInfoModal(pg.Load)
+		infoModal.Title(values.String(values.StrRemoveWallet)).
 			Body(warningMsg).
 			NegativeButton(values.String(values.StrCancel), func() {}).
 			PositiveButtonStyle(pg.Load.Theme.Color.Surface, pg.Load.Theme.Color.Danger).
@@ -263,13 +263,16 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 				}
 
 				if pg.wallet.IsWatchingOnlyWallet() {
+					infoModal.SetLoading(true)
 					go func() {
 						// no password is required for watching only wallets.
 						err := pg.WL.MultiWallet.DeleteWallet(pg.wallet.ID, nil)
 						if err != nil {
 							pg.Toast.NotifyError(err.Error())
+							infoModal.SetLoading(false)
 						} else {
 							walletDeleted()
+							infoModal.Dismiss()
 						}
 					}()
 					return

--- a/ui/page/wallets/wallet_settings_page.go
+++ b/ui/page/wallets/wallet_settings_page.go
@@ -268,7 +268,7 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 					if err != nil {
 						pg.Toast.NotifyError(err.Error())
 					} else {
-						walletDeleted()
+						go walletDeleted()
 					}
 					return
 				}

--- a/ui/window.go
+++ b/ui/window.go
@@ -113,6 +113,8 @@ func (win *Window) NewLoad() (*load.Load, error) {
 	// app window. When the next FrameEvent is received,
 	// a new StartPage will be initialized and displayed.
 	l.ReloadApp = func() {
+		l.UiMu.Lock()
+		defer l.UiMu.Unlock()
 		if win.currentPage != nil {
 			win.currentPage.OnNavigatedFrom()
 			win.currentPage = nil
@@ -179,6 +181,8 @@ func (win *Window) HandleEvents() {
 // elements. This ensures that the proper interface is displayed to the user
 // based on their last performed action where applicable.
 func (win *Window) displayWindow(evt system.FrameEvent) {
+	win.load.UiMu.Lock()
+	defer win.load.UiMu.Unlock()
 	// Set up the StartPage the first time a FrameEvent is received.
 	if win.currentPage == nil {
 		win.currentPage = page.NewStartPage(win.load)

--- a/ui/window.go
+++ b/ui/window.go
@@ -113,8 +113,8 @@ func (win *Window) NewLoad() (*load.Load, error) {
 	// app window. When the next FrameEvent is received,
 	// a new StartPage will be initialized and displayed.
 	l.ReloadApp = func() {
-		l.UiMu.Lock()
-		defer l.UiMu.Unlock()
+		l.UIMu.Lock()
+		defer l.UIMu.Unlock()
 		if win.currentPage != nil {
 			win.currentPage.OnNavigatedFrom()
 			win.currentPage = nil
@@ -181,8 +181,8 @@ func (win *Window) HandleEvents() {
 // elements. This ensures that the proper interface is displayed to the user
 // based on their last performed action where applicable.
 func (win *Window) displayWindow(evt system.FrameEvent) {
-	win.load.UiMu.Lock()
-	defer win.load.UiMu.Unlock()
+	win.load.UIMu.Lock()
+	defer win.load.UIMu.Unlock()
 	// Set up the StartPage the first time a FrameEvent is received.
 	if win.currentPage == nil {
 		win.currentPage = page.NewStartPage(win.load)


### PR DESCRIPTION
This PR fixes the watch-only wallet crash delete bug. Hides watch-only wallet layout after the last watch-only wallet is deleted and shows loader widget to indicate that a process is going on when a watch-only wallet is being deleted.  Closes #942 and #941.


https://user-images.githubusercontent.com/4796738/170577854-4c6324ad-9b1d-4320-ac71-b4b2685bcf58.mp4

