### PR TITLE
reset auto ticket buyer wallet cofig if mixer is set

### DIFF
--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -493,9 +493,9 @@ func (mp *MainPage) HandleUserInteractions() {
 			if mp.WL.MultiWallet.IsSynced() {
 				mp.Display(pg)
 			} else if mp.WL.MultiWallet.IsSyncing() {
-				mp.Toast.NotifyError(values.String(values.StrNotConnected))
-			} else {
 				mp.Toast.NotifyError(values.String(values.StrWalletSyncing))
+			} else {
+				mp.Toast.NotifyError(values.String(values.StrNotConnected))
 			}
 		}
 	}
@@ -581,9 +581,9 @@ func (mp *MainPage) HandleUserInteractions() {
 			if mp.WL.MultiWallet.IsSynced() {
 				mp.Display(pg)
 			} else if mp.WL.MultiWallet.IsSyncing() {
-				mp.Toast.NotifyError("Wallet is syncing, please wait")
+				mp.Toast.NotifyError(values.String(values.StrWalletSyncing))
 			} else {
-				mp.Toast.NotifyError("Not connected to the Decred network")
+				mp.Toast.NotifyError(values.String(values.StrNotConnected))
 			}
 		}
 	}

--- a/ui/page/staking/auto_ticket_modal.go
+++ b/ui/page/staking/auto_ticket_modal.go
@@ -84,9 +84,19 @@ func (tb *ticketBuyerModal) OnResume() {
 				tb.Toast.NotifyError(err.Error())
 			}
 
+			if wal.ReadBoolConfigValueForKey(dcrlibwallet.AccountMixerConfigSet, false) &&
+				!wal.ReadBoolConfigValueForKey(load.SpendUnmixedFundsKey, false) &&
+				(tbConfig.PurchaseAccount == wal.MixedAccountNumber()) {
+				tb.accountSelector.SetSelectedAccount(acct)
+			} else {
+				err := tb.accountSelector.SelectFirstWalletValidAccount(nil)
+				if err != nil {
+					tb.Toast.NotifyError(err.Error())
+				}
+			}
+
 			tb.vspSelector.SelectVSP(tbConfig.VspHost)
 			tb.balToMaintainEditor.Editor.SetText(strconv.FormatFloat(dcrlibwallet.AmountCoin(tbConfig.BalanceToMaintain), 'f', 0, 64))
-			tb.accountSelector.SetSelectedAccount(acct)
 			break
 		}
 	}


### PR DESCRIPTION
Fix #945

This PR allows selecting of only mixed accounts when mixer is set.
It also prevents using of already saved config as possible options when they are not mixed account both on the purchase modal and config modal.