### PR TITLE
Fixes hidden watch only menu

### DIFF
--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -411,19 +411,19 @@ func (pg *WalletPage) showImportWatchOnlyWalletModal(l *load.Load) {
 // moreOptionPositionEvent tracks the position of the click event on the page
 // determines the position of options menu
 func (pg *WalletPage) moreOptionPositionEvent(gtx layout.Context) {
-	setUnitValue := func(){}
-	
-	if ok, err := pg.multiWallet.AllWalletsAreWatchOnly(); ok{
-		if err == nil{
+	setUnitValue := func() {}
+
+	if ok, err := pg.multiWallet.AllWalletsAreWatchOnly(); ok {
+		if err == nil {
 			setUnitValue = func() {
 				pg.mt = unit.Dp(25)
 			}
 		}
-		}else{
-			setUnitValue = func() {
-				pg.mt = unit.Dp(-220)
-			}
+	} else {
+		setUnitValue = func() {
+			pg.mt = unit.Dp(-220)
 		}
+	}
 
 	for _, e := range pg.click.Events(gtx) {
 		switch e.Type {
@@ -457,22 +457,21 @@ func (pg *WalletPage) Layout(gtx layout.Context) layout.Dimensions {
 
 	pageContent := []func(gtx C) D{}
 
-	if ok, err := pg.multiWallet.AllWalletsAreWatchOnly(); ok{
-		if err == nil{
+	if ok, err := pg.multiWallet.AllWalletsAreWatchOnly(); ok {
+		if err == nil {
 			pageContent = []func(gtx C) D{
 				pg.watchOnlyWalletSection,
-			}			
+			}
 		}
-		}else{
-			pageContent = []func(gtx C) D{
-				pg.walletSection,
-			}
-			
-			if pg.hasWatchOnly {
-				pageContent = append(pageContent, pg.watchOnlyWalletSection)
-				}	
-			}
+	} else {
+		pageContent = []func(gtx C) D{
+			pg.walletSection,
+		}
 
+		if pg.hasWatchOnly {
+			pageContent = append(pageContent, pg.watchOnlyWalletSection)
+		}
+	}
 
 	if len(pg.badWalletsList) != 0 {
 		pageContent = append(pageContent, pg.badWalletsSection)

--- a/ui/page/wallets/wallet_page.go
+++ b/ui/page/wallets/wallet_page.go
@@ -409,10 +409,21 @@ func (pg *WalletPage) showImportWatchOnlyWalletModal(l *load.Load) {
 }
 
 // moreOptionPositionEvent tracks the position of the click event on the page
+// determines the position of options menu
 func (pg *WalletPage) moreOptionPositionEvent(gtx layout.Context) {
-	setUnitValue := func() {
-		pg.mt = unit.Dp(-220)
-	}
+	setUnitValue := func(){}
+	
+	if ok, err := pg.multiWallet.AllWalletsAreWatchOnly(); ok{
+		if err == nil{
+			setUnitValue = func() {
+				pg.mt = unit.Dp(25)
+			}
+		}
+		}else{
+			setUnitValue = func() {
+				pg.mt = unit.Dp(-220)
+			}
+		}
 
 	for _, e := range pg.click.Events(gtx) {
 		switch e.Type {
@@ -443,13 +454,25 @@ func (pg *WalletPage) moreOptionPositionEvent(gtx layout.Context) {
 // Layout lays out the widgets for the main wallets pg.
 func (pg *WalletPage) Layout(gtx layout.Context) layout.Dimensions {
 	pg.moreOptionPositionEvent(gtx)
-	pageContent := []func(gtx C) D{
-		pg.walletSection,
-	}
 
-	if pg.hasWatchOnly {
-		pageContent = append(pageContent, pg.watchOnlyWalletSection)
-	}
+	pageContent := []func(gtx C) D{}
+
+	if ok, err := pg.multiWallet.AllWalletsAreWatchOnly(); ok{
+		if err == nil{
+			pageContent = []func(gtx C) D{
+				pg.watchOnlyWalletSection,
+			}			
+		}
+		}else{
+			pageContent = []func(gtx C) D{
+				pg.walletSection,
+			}
+			
+			if pg.hasWatchOnly {
+				pageContent = append(pageContent, pg.watchOnlyWalletSection)
+				}	
+			}
+
 
 	if len(pg.badWalletsList) != 0 {
 		pageContent = append(pageContent, pg.badWalletsSection)
@@ -496,6 +519,7 @@ func (pg *WalletPage) Layout(gtx layout.Context) layout.Dimensions {
 	)
 }
 
+//Sets up layout of options menu
 func (pg *WalletPage) layoutOptionsMenu(gtx layout.Context, optionsMenuIndex int, listItem *walletListItem) {
 	if pg.openPopupIndex != optionsMenuIndex {
 		return
@@ -653,6 +677,7 @@ func (pg *WalletPage) walletSection(gtx layout.Context) layout.Dimensions {
 	})
 }
 
+//Sets up layout of watch only wallet section
 func (pg *WalletPage) watchOnlyWalletSection(gtx layout.Context) layout.Dimensions {
 	if !pg.hasWatchOnly {
 		return D{}
@@ -679,6 +704,7 @@ func (pg *WalletPage) watchOnlyWalletSection(gtx layout.Context) layout.Dimensio
 	})
 }
 
+// Sets up layout of watch only section items
 func (pg *WalletPage) layoutWatchOnlyWallets(gtx layout.Context) D {
 	pg.listLock.Lock()
 	listItems := pg.listItems


### PR DESCRIPTION
This resolves #940 

This makes it such that there is no more scroll bar on the side of the wallet page when there is only one thing on it. It also makes the options menu visible when its only a watch only wallet on the wallet list


![image](https://user-images.githubusercontent.com/54014025/171176745-6fbf2aaa-3c30-4ddc-b5da-a2503936adaa.png)
