### PR TITLE
enhance usability for mobile layouts

### DIFF
--- a/ui/load/load.go
+++ b/ui/load/load.go
@@ -22,9 +22,10 @@ type DCRUSDTBittrex struct {
 type Load struct {
 	Theme *decredmaterial.Theme
 
-	WL      *WalletLoad
-	Printer *message.Printer
-	Network string
+	WL              *WalletLoad
+	Printer         *message.Printer
+	Network         string
+	CurrentAppWidth int
 
 	Toast *notification.Toast
 

--- a/ui/load/utils.go
+++ b/ui/load/utils.go
@@ -15,3 +15,13 @@ const (
 	TransactionNotificationConfigKey = "transaction_notification_key"
 	SpendUnmixedFundsKey             = "spend_unmixed_funds"
 )
+
+// SetCurrentAppWidth stores the current width of the app's window.
+func (l *Load) SetCurrentAppWidth(appWidth int) {
+	l.CurrentAppWidth = appWidth
+}
+
+// GetCurrentAppWidth returns the current width of the app's window.
+func (l *Load) GetCurrentAppWidth() int {
+	return l.CurrentAppWidth
+}

--- a/ui/page/components/bottom_nav.go
+++ b/ui/page/components/bottom_nav.go
@@ -37,6 +37,7 @@ type BottomNavigationBar struct {
 }
 
 func (bottomNavigationbar *BottomNavigationBar) LayoutBottomNavigationBar(gtx layout.Context) layout.Dimensions {
+	currentScreenWidth := gtx.Constraints.Max.X
 	return layout.Stack{Alignment: layout.S}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
 			return decredmaterial.LinearLayout{
@@ -55,7 +56,7 @@ func (bottomNavigationbar *BottomNavigationBar) LayoutBottomNavigationBar(gtx la
 						}
 						return decredmaterial.LinearLayout{
 							Orientation: bottomNavigationbar.axis,
-							Width:       (gtx.Px(values.AppWidth) * 100 / len(bottomNavigationbar.BottomNaigationItems)) / 100, // Divide each cell equally
+							Width:       (currentScreenWidth * 100 / len(bottomNavigationbar.BottomNaigationItems)) / 100, // Divide each cell equally
 							Height:      decredmaterial.WrapContent,
 							Padding:     layout.UniformInset(values.MarginPadding15),
 							Alignment:   bottomNavigationbar.alignment,

--- a/ui/page/components/bottom_nav.go
+++ b/ui/page/components/bottom_nav.go
@@ -95,97 +95,100 @@ func (bottomNavigationbar *BottomNavigationBar) LayoutBottomNavigationBar(gtx la
 
 func (bottomNavigationbar *BottomNavigationBar) LayoutSendReceive(gtx layout.Context) layout.Dimensions {
 	gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
-	return layout.S.Layout(gtx, func(gtx C) D {
-		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-			layout.Rigid(func(gtx C) D {
-				gtx.Constraints.Min.X = gtx.Constraints.Max.X
-				return layout.Center.Layout(gtx, func(gtx C) D {
-					return decredmaterial.LinearLayout{
-						Width:       decredmaterial.WrapContent,
-						Height:      decredmaterial.WrapContent,
-						Orientation: layout.Horizontal,
-						Background:  bottomNavigationbar.Theme.Color.DefualtThemeColors().Primary,
-						Border:      decredmaterial.Border{Radius: decredmaterial.Radius(20)},
-						Padding:     layout.UniformInset(values.MarginPadding8),
-					}.Layout(gtx,
-						layout.Rigid(func(gtx C) D {
-							return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
-								layout.Rigid(func(gtx C) D {
-									return decredmaterial.LinearLayout{
-										Width:       decredmaterial.WrapContent,
-										Height:      decredmaterial.WrapContent,
-										Orientation: layout.Horizontal,
-										Padding: layout.Inset{
-											Right: values.MarginPadding16,
-											Left:  values.MarginPadding16,
-										},
-										Clickable: bottomNavigationbar.FloatingActionButton[0].Clickable,
-									}.Layout(gtx,
-										layout.Rigid(func(gtx C) D {
-											return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
-												func(gtx C) D {
+	if bottomNavigationbar.CurrentPage == "Overview" || bottomNavigationbar.CurrentPage == "Transactions" {
+		return layout.S.Layout(gtx, func(gtx C) D {
+			return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+				layout.Rigid(func(gtx C) D {
+					gtx.Constraints.Min.X = gtx.Constraints.Max.X
+					return layout.Center.Layout(gtx, func(gtx C) D {
+						return decredmaterial.LinearLayout{
+							Width:       decredmaterial.WrapContent,
+							Height:      decredmaterial.WrapContent,
+							Orientation: layout.Horizontal,
+							Background:  bottomNavigationbar.Theme.Color.DefualtThemeColors().Primary,
+							Border:      decredmaterial.Border{Radius: decredmaterial.Radius(20)},
+							Padding:     layout.UniformInset(values.MarginPadding8),
+						}.Layout(gtx,
+							layout.Rigid(func(gtx C) D {
+								return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+									layout.Rigid(func(gtx C) D {
+										return decredmaterial.LinearLayout{
+											Width:       decredmaterial.WrapContent,
+											Height:      decredmaterial.WrapContent,
+											Orientation: layout.Horizontal,
+											Padding: layout.Inset{
+												Right: values.MarginPadding16,
+												Left:  values.MarginPadding16,
+											},
+											Clickable: bottomNavigationbar.FloatingActionButton[0].Clickable,
+										}.Layout(gtx,
+											layout.Rigid(func(gtx C) D {
+												return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
+													func(gtx C) D {
+														return layout.Center.Layout(gtx, func(gtx C) D {
+															return bottomNavigationbar.FloatingActionButton[0].Image.Layout24dp(gtx)
+														})
+													})
+											}),
+											layout.Rigid(func(gtx C) D {
+												return layout.Inset{
+													Left: values.MarginPadding0,
+												}.Layout(gtx, func(gtx C) D {
 													return layout.Center.Layout(gtx, func(gtx C) D {
-														return bottomNavigationbar.FloatingActionButton[0].Image.Layout24dp(gtx)
+														txt := bottomNavigationbar.Theme.Label(values.MarginPadding16, bottomNavigationbar.FloatingActionButton[0].Title)
+														txt.Color = bottomNavigationbar.Theme.Color.DefualtThemeColors().White
+														return txt.Layout(gtx)
 													})
 												})
-										}),
-										layout.Rigid(func(gtx C) D {
-											return layout.Inset{
-												Left: values.MarginPadding0,
-											}.Layout(gtx, func(gtx C) D {
-												return layout.Center.Layout(gtx, func(gtx C) D {
-													txt := bottomNavigationbar.Theme.Label(values.MarginPadding16, bottomNavigationbar.FloatingActionButton[0].Title)
-													txt.Color = bottomNavigationbar.Theme.Color.DefualtThemeColors().White
-													return txt.Layout(gtx)
-												})
-											})
-										}),
-									)
-								}),
-								layout.Rigid(func(gtx C) D {
-									verticalSeparator := bottomNavigationbar.Theme.SeparatorVertical(50, 1)
-									verticalSeparator.Color = bottomNavigationbar.Theme.Color.DefualtThemeColors().White
-									return verticalSeparator.Layout(gtx)
-								}),
-								layout.Rigid(func(gtx C) D {
-									return decredmaterial.LinearLayout{
-										Width:       decredmaterial.WrapContent,
-										Height:      decredmaterial.WrapContent,
-										Orientation: layout.Horizontal,
-										Padding: layout.Inset{
-											Right: values.MarginPadding16,
-											Left:  values.MarginPadding16,
-										},
-										Clickable: bottomNavigationbar.FloatingActionButton[1].Clickable,
-									}.Layout(gtx,
-										layout.Rigid(func(gtx C) D {
-											return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
-												func(gtx C) D {
+											}),
+										)
+									}),
+									layout.Rigid(func(gtx C) D {
+										verticalSeparator := bottomNavigationbar.Theme.SeparatorVertical(50, 1)
+										verticalSeparator.Color = bottomNavigationbar.Theme.Color.DefualtThemeColors().White
+										return verticalSeparator.Layout(gtx)
+									}),
+									layout.Rigid(func(gtx C) D {
+										return decredmaterial.LinearLayout{
+											Width:       decredmaterial.WrapContent,
+											Height:      decredmaterial.WrapContent,
+											Orientation: layout.Horizontal,
+											Padding: layout.Inset{
+												Right: values.MarginPadding16,
+												Left:  values.MarginPadding16,
+											},
+											Clickable: bottomNavigationbar.FloatingActionButton[1].Clickable,
+										}.Layout(gtx,
+											layout.Rigid(func(gtx C) D {
+												return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
+													func(gtx C) D {
+														return layout.Center.Layout(gtx, func(gtx C) D {
+															return bottomNavigationbar.FloatingActionButton[1].Image.Layout24dp(gtx)
+														})
+													})
+											}),
+											layout.Rigid(func(gtx C) D {
+												return layout.Inset{
+													Left: values.MarginPadding0,
+												}.Layout(gtx, func(gtx C) D {
 													return layout.Center.Layout(gtx, func(gtx C) D {
-														return bottomNavigationbar.FloatingActionButton[1].Image.Layout24dp(gtx)
+														txt := bottomNavigationbar.Theme.Label(values.MarginPadding16, bottomNavigationbar.FloatingActionButton[1].Title)
+														txt.Color = bottomNavigationbar.Theme.Color.DefualtThemeColors().White
+														return txt.Layout(gtx)
 													})
 												})
-										}),
-										layout.Rigid(func(gtx C) D {
-											return layout.Inset{
-												Left: values.MarginPadding0,
-											}.Layout(gtx, func(gtx C) D {
-												return layout.Center.Layout(gtx, func(gtx C) D {
-													txt := bottomNavigationbar.Theme.Label(values.MarginPadding16, bottomNavigationbar.FloatingActionButton[1].Title)
-													txt.Color = bottomNavigationbar.Theme.Color.DefualtThemeColors().White
-													return txt.Layout(gtx)
-												})
-											})
-										}),
-									)
-								}),
-							)
-						}),
-					)
-				})
-			}),
-		)
-	})
+											}),
+										)
+									}),
+								)
+							}),
+						)
+					})
+				}),
+			)
+		})
+	}
+	return D{}
 }
 
 func (bottomNavigationbar *BottomNavigationBar) OnViewCreated() {

--- a/ui/page/components/bottom_nav.go
+++ b/ui/page/components/bottom_nav.go
@@ -37,7 +37,6 @@ type BottomNavigationBar struct {
 }
 
 func (bottomNavigationbar *BottomNavigationBar) LayoutBottomNavigationBar(gtx layout.Context) layout.Dimensions {
-	currentScreenWidth := gtx.Constraints.Max.X
 	return layout.Stack{Alignment: layout.S}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
 			return decredmaterial.LinearLayout{
@@ -56,7 +55,7 @@ func (bottomNavigationbar *BottomNavigationBar) LayoutBottomNavigationBar(gtx la
 						}
 						return decredmaterial.LinearLayout{
 							Orientation: bottomNavigationbar.axis,
-							Width:       (currentScreenWidth * 100 / len(bottomNavigationbar.BottomNaigationItems)) / 100, // Divide each cell equally
+							Width:       (bottomNavigationbar.Load.GetCurrentAppWidth() * 100 / len(bottomNavigationbar.BottomNaigationItems)) / 100, // Divide each cell equally
 							Height:      decredmaterial.WrapContent,
 							Padding:     layout.UniformInset(values.MarginPadding15),
 							Alignment:   bottomNavigationbar.alignment,

--- a/ui/page/components/bottom_nav.go
+++ b/ui/page/components/bottom_nav.go
@@ -24,6 +24,7 @@ type BottomNavigationBarHandler struct {
 type BottomNavigationBar struct {
 	*load.Load
 
+	FloatingActionButton []BottomNavigationBarHandler
 	BottomNaigationItems []BottomNavigationBarHandler
 	CurrentPage          string
 
@@ -90,6 +91,101 @@ func (bottomNavigationbar *BottomNavigationBar) LayoutBottomNavigationBar(gtx la
 			)
 		}),
 	)
+}
+
+func (bottomNavigationbar *BottomNavigationBar) LayoutSendReceive(gtx layout.Context) layout.Dimensions {
+	gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
+	return layout.S.Layout(gtx, func(gtx C) D {
+		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
+			layout.Rigid(func(gtx C) D {
+				gtx.Constraints.Min.X = gtx.Constraints.Max.X
+				return layout.Center.Layout(gtx, func(gtx C) D {
+					return decredmaterial.LinearLayout{
+						Width:       decredmaterial.WrapContent,
+						Height:      decredmaterial.WrapContent,
+						Orientation: layout.Horizontal,
+						Background:  bottomNavigationbar.Theme.Color.DefualtThemeColors().Primary,
+						Border:      decredmaterial.Border{Radius: decredmaterial.Radius(20)},
+						Padding:     layout.UniformInset(values.MarginPadding8),
+					}.Layout(gtx,
+						layout.Rigid(func(gtx C) D {
+							return layout.Flex{Axis: layout.Horizontal}.Layout(gtx,
+								layout.Rigid(func(gtx C) D {
+									return decredmaterial.LinearLayout{
+										Width:       decredmaterial.WrapContent,
+										Height:      decredmaterial.WrapContent,
+										Orientation: layout.Horizontal,
+										Padding: layout.Inset{
+											Right: values.MarginPadding16,
+											Left:  values.MarginPadding16,
+										},
+										Clickable: bottomNavigationbar.FloatingActionButton[0].Clickable,
+									}.Layout(gtx,
+										layout.Rigid(func(gtx C) D {
+											return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
+												func(gtx C) D {
+													return layout.Center.Layout(gtx, func(gtx C) D {
+														return bottomNavigationbar.FloatingActionButton[0].Image.Layout24dp(gtx)
+													})
+												})
+										}),
+										layout.Rigid(func(gtx C) D {
+											return layout.Inset{
+												Left: values.MarginPadding0,
+											}.Layout(gtx, func(gtx C) D {
+												return layout.Center.Layout(gtx, func(gtx C) D {
+													txt := bottomNavigationbar.Theme.Label(values.MarginPadding16, bottomNavigationbar.FloatingActionButton[0].Title)
+													txt.Color = bottomNavigationbar.Theme.Color.DefualtThemeColors().White
+													return txt.Layout(gtx)
+												})
+											})
+										}),
+									)
+								}),
+								layout.Rigid(func(gtx C) D {
+									verticalSeparator := bottomNavigationbar.Theme.SeparatorVertical(50, 1)
+									verticalSeparator.Color = bottomNavigationbar.Theme.Color.DefualtThemeColors().White
+									return verticalSeparator.Layout(gtx)
+								}),
+								layout.Rigid(func(gtx C) D {
+									return decredmaterial.LinearLayout{
+										Width:       decredmaterial.WrapContent,
+										Height:      decredmaterial.WrapContent,
+										Orientation: layout.Horizontal,
+										Padding: layout.Inset{
+											Right: values.MarginPadding16,
+											Left:  values.MarginPadding16,
+										},
+										Clickable: bottomNavigationbar.FloatingActionButton[1].Clickable,
+									}.Layout(gtx,
+										layout.Rigid(func(gtx C) D {
+											return layout.Inset{Right: values.MarginPadding8}.Layout(gtx,
+												func(gtx C) D {
+													return layout.Center.Layout(gtx, func(gtx C) D {
+														return bottomNavigationbar.FloatingActionButton[1].Image.Layout24dp(gtx)
+													})
+												})
+										}),
+										layout.Rigid(func(gtx C) D {
+											return layout.Inset{
+												Left: values.MarginPadding0,
+											}.Layout(gtx, func(gtx C) D {
+												return layout.Center.Layout(gtx, func(gtx C) D {
+													txt := bottomNavigationbar.Theme.Label(values.MarginPadding16, bottomNavigationbar.FloatingActionButton[1].Title)
+													txt.Color = bottomNavigationbar.Theme.Color.DefualtThemeColors().White
+													return txt.Layout(gtx)
+												})
+											})
+										}),
+									)
+								}),
+							)
+						}),
+					)
+				})
+			}),
+		)
+	})
 }
 
 func (bottomNavigationbar *BottomNavigationBar) OnViewCreated() {

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -239,6 +239,13 @@ func (mp *MainPage) initNavItems() {
 			},
 			{
 				Clickable:     mp.Theme.NewClickable(true),
+				Image:         mp.Theme.Icons.StakeIcon,
+				ImageInactive: mp.Theme.Icons.StakeIconInactive,
+				Title:         values.String(values.StrStaking),
+				PageID:        staking.OverviewPageID,
+			},
+			{
+				Clickable:     mp.Theme.NewClickable(true),
 				Image:         mp.Theme.Icons.WalletIcon,
 				ImageInactive: mp.Theme.Icons.WalletIconInactive,
 				Title:         values.String(values.StrWallets),
@@ -533,6 +540,8 @@ func (mp *MainPage) HandleUserInteractions() {
 				pg = overview.NewOverviewPage(mp.Load)
 			case transaction.TransactionsPageID:
 				pg = transaction.NewTransactionsPage(mp.Load)
+			case staking.OverviewPageID:
+				pg = staking.NewStakingPage(mp.Load)
 			case wallets.WalletPageID:
 				pg = wallets.NewWalletPage(mp.Load)
 			case MorePageID:

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -706,7 +706,8 @@ func (mp *MainPage) popToFragment(pageID string) {
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
-	if gtx.Constraints.Max.X <= gtx.Px(values.StartMobileView) {
+	mp.Load.SetCurrentAppWidth(gtx.Constraints.Max.X)
+	if mp.Load.GetCurrentAppWidth() <= gtx.Px(values.StartMobileView) {
 		return mp.layoutMobile(gtx)
 	}
 	return mp.layoutDesktop(gtx)
@@ -820,7 +821,6 @@ func (mp *MainPage) totalDCRBalance(gtx C) D {
 }
 
 func (mp *MainPage) LayoutTopBar(gtx layout.Context) layout.Dimensions {
-	screenWidth := gtx.Constraints.Max.X
 	return decredmaterial.LinearLayout{
 		Width:       decredmaterial.MatchParent,
 		Height:      decredmaterial.WrapContent,
@@ -878,7 +878,7 @@ func (mp *MainPage) LayoutTopBar(gtx layout.Context) layout.Dimensions {
 				}),
 				layout.Rigid(func(gtx C) D {
 					gtx.Constraints.Min.X = gtx.Constraints.Max.X
-					if screenWidth <= gtx.Px(values.StartMobileView) {
+					if mp.Load.GetCurrentAppWidth() <= gtx.Px(values.StartMobileView) {
 						return D{}
 					}
 					return mp.appBarNav.LayoutTopBar(gtx)

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -279,6 +279,8 @@ func (mp *MainPage) initNavItems() {
 			},
 		},
 	}
+	mp.floatingActionButton.FloatingActionButton[0].Clickable.Hoverable = false
+	mp.floatingActionButton.FloatingActionButton[1].Clickable.Hoverable = false
 }
 
 // OnNavigatedTo is called when the page is about to be displayed and

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -548,6 +548,35 @@ func (mp *MainPage) HandleUserInteractions() {
 		}
 	}
 
+	for i, item := range mp.floatingActionButton.FloatingActionButton {
+		for item.Clickable.Clicked() {
+			var pg load.Page
+			if i == 0 {
+				if mp.sendPage == nil {
+					mp.sendPage = send.NewSendPage(mp.Load)
+				}
+				pg = mp.sendPage
+			} else {
+				if mp.receivePage == nil {
+					mp.receivePage = NewReceivePage(mp.Load)
+				}
+				pg = mp.receivePage
+			}
+
+			if pg.ID() == mp.currentPageID() {
+				continue
+			}
+
+			if mp.WL.MultiWallet.IsSynced() {
+				mp.ChangeFragment(pg)
+			} else if mp.WL.MultiWallet.IsSyncing() {
+				mp.Toast.NotifyError("Wallet is syncing, please wait")
+			} else {
+				mp.Toast.NotifyError("Not connected to the Decred network")
+			}
+		}
+	}
+
 	mp.isBalanceHidden = mp.WL.MultiWallet.ReadBoolConfigValueForKey(load.HideBalanceConfigKey, false)
 	for mp.hideBalanceItem.hideBalanceButton.Button.Clicked() {
 		mp.isBalanceHidden = !mp.isBalanceHidden

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -706,7 +706,7 @@ func (mp *MainPage) popToFragment(pageID string) {
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
-	if gtx.Constraints.Max.X <= gtx.Px(values.MobileAppWidth) {
+	if gtx.Constraints.Max.X <= gtx.Px(values.StartMobileView) {
 		return mp.layoutMobile(gtx)
 	}
 	return mp.layoutDesktop(gtx)
@@ -819,7 +819,8 @@ func (mp *MainPage) totalDCRBalance(gtx C) D {
 	return components.LayoutBalance(gtx, mp.Load, mp.totalBalance.String())
 }
 
-func (mp *MainPage) LayoutTopBar(gtx C) D {
+func (mp *MainPage) LayoutTopBar(gtx layout.Context) layout.Dimensions {
+	screenWidth := gtx.Constraints.Max.X
 	return decredmaterial.LinearLayout{
 		Width:       decredmaterial.MatchParent,
 		Height:      decredmaterial.WrapContent,
@@ -877,7 +878,7 @@ func (mp *MainPage) LayoutTopBar(gtx C) D {
 				}),
 				layout.Rigid(func(gtx C) D {
 					gtx.Constraints.Min.X = gtx.Constraints.Max.X
-					if gtx.Constraints.Max.X <= gtx.Px(values.MobileAppWidth) {
+					if screenWidth <= gtx.Px(values.StartMobileView) {
 						return D{}
 					}
 					return mp.appBarNav.LayoutTopBar(gtx)

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -745,7 +745,7 @@ func (mp *MainPage) layoutMobile(gtx layout.Context) layout.Dimensions {
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 		layout.Flexed(0.08, mp.LayoutTopBar),
 		layout.Flexed(0.795, func(gtx C) D {
-			return layout.Stack{Alignment: layout.SE}.Layout(gtx,
+			return layout.Stack{Alignment: layout.N}.Layout(gtx,
 				layout.Expanded(func(gtx C) D {
 					if mp.currentPage == nil {
 						return layout.Dimensions{}

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -684,8 +684,8 @@ func (mp *MainPage) layoutDesktop(gtx layout.Context) layout.Dimensions {
 
 func (mp *MainPage) layoutMobile(gtx layout.Context) layout.Dimensions {
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
-		layout.Flexed(0.125, mp.LayoutTopBar),
-		layout.Flexed(0.75, func(gtx C) D {
+		layout.Flexed(0.08, mp.LayoutTopBar),
+		layout.Flexed(0.795, func(gtx C) D {
 			if mp.currentPage == nil {
 				return layout.Dimensions{}
 			}

--- a/ui/page/more_page.go
+++ b/ui/page/more_page.go
@@ -204,7 +204,7 @@ func (pg *MorePage) OnNavigatedFrom() {}
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (pg *MorePage) Layout(gtx layout.Context) layout.Dimensions {
-	if gtx.Constraints.Max.X <= gtx.Px(values.StartMobileView) {
+	if pg.Load.GetCurrentAppWidth() <= gtx.Px(values.StartMobileView) {
 		container := func(gtx C) D {
 			pg.layoutMoreItemsMobile(gtx)
 			return layout.Dimensions{Size: gtx.Constraints.Max}

--- a/ui/page/more_page.go
+++ b/ui/page/more_page.go
@@ -204,7 +204,7 @@ func (pg *MorePage) OnNavigatedFrom() {}
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
 func (pg *MorePage) Layout(gtx layout.Context) layout.Dimensions {
-	if gtx.Constraints.Max.X <= gtx.Px(values.MobileAppWidth) {
+	if gtx.Constraints.Max.X <= gtx.Px(values.StartMobileView) {
 		container := func(gtx C) D {
 			pg.layoutMoreItemsMobile(gtx)
 			return layout.Dimensions{Size: gtx.Constraints.Max}

--- a/ui/page/receive_page.go
+++ b/ui/page/receive_page.go
@@ -185,7 +185,7 @@ func (pg *ReceivePage) Layout(gtx C) D {
 	pg.handleCopyEvent(gtx)
 	pg.pageBackdropLayout(gtx)
 
-	if gtx.Constraints.Max.X <= gtx.Px(values.StartMobileView) {
+	if pg.Load.GetCurrentAppWidth() <= gtx.Px(values.StartMobileView) {
 		return pg.layoutMobile(gtx)
 	}
 	return pg.layoutDesktop(gtx)

--- a/ui/page/start_page.go
+++ b/ui/page/start_page.go
@@ -243,8 +243,8 @@ func (sp *startPage) buttonSection(gtx C) D {
 	return layout.Stack{Alignment: layout.S}.Layout(gtx,
 		layout.Stacked(func(gtx C) D {
 			return layout.Flex{Alignment: layout.Middle, Axis: layout.Vertical}.Layout(gtx,
-				layout.Rigid(func(gtx C) D {
-					gtx.Constraints.Max.X = gtx.Px(values.AppWidth) // set button with to app width
+				layout.Rigid(func(gtx layout.Context) layout.Dimensions {
+					gtx.Constraints.Max.X = gtx.Px(values.AppWidth) // set button width to app width
 					gtx.Constraints.Min.X = gtx.Constraints.Max.X
 					return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 						layout.Rigid(func(gtx C) D {

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -90,11 +90,8 @@ var (
 	TextSize34   = unit.Sp(34)
 	TextSize32   = unit.Sp(32)
 
-	// AppWidth  = unit.Sp(800)
-	// AppHeight = unit.Sp(600)
-
-	AppWidth  = unit.Sp(360)
-	AppHeight = unit.Sp(740)
+	AppWidth  = unit.Sp(800)
+	AppHeight = unit.Sp(600)
 
 	// These define the dimensions at which we consider the user to be using a
 	// mobile device. The dimensions specified are the default viewport for

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -90,9 +90,19 @@ var (
 	TextSize34   = unit.Sp(34)
 	TextSize32   = unit.Sp(32)
 
-	// AppWidth  = unit.Sp(800)
-	// AppHeight = unit.Sp(600)
+	AppWidth  = unit.Sp(800)
+	AppHeight = unit.Sp(600)
 
-	AppWidth  = unit.Sp(428)
-	AppHeight = unit.Sp(740)
+	// AppWidth  = unit.Sp(360)
+	// AppHeight = unit.Sp(740)
+
+	// This defines the dimensions at which we consider the user to be using a
+	// mobile device. The dimensions specified are the default viewport for
+	// iPhone 12 Pro Max (428 x 926).
+	// TODO: The mobile app width should consider larger screens. Browsers considers mobile
+	// devices starting from 600px below. While tablets and large phones are considered to be
+	// between 600px and 768px. While Landscape tablets are considered to be between
+	// 768px and 992px.
+	MobileAppWidth  = unit.Sp(360)
+	MobileAppHeight = unit.Sp(780)
 )

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -96,7 +96,7 @@ var (
 	AppWidth  = unit.Sp(360)
 	AppHeight = unit.Sp(740)
 
-	// This defines the dimensions at which we consider the user to be using a
+	// These define the dimensions at which we consider the user to be using a
 	// mobile device. The dimensions specified are the default viewport for
 	// iPhone 12 Pro Max (428 x 926).
 	// TODO: The mobile app width should consider larger screens. Browsers considers mobile
@@ -105,4 +105,6 @@ var (
 	// 768px and 992px.
 	MobileAppWidth  = unit.Sp(360)
 	MobileAppHeight = unit.Sp(780)
+
+	StartMobileView = unit.Sp(600)
 )

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -90,6 +90,9 @@ var (
 	TextSize34   = unit.Sp(34)
 	TextSize32   = unit.Sp(32)
 
-	AppWidth  = unit.Sp(800)
-	AppHeight = unit.Sp(600)
+	// AppWidth  = unit.Sp(800)
+	// AppHeight = unit.Sp(600)
+
+	AppWidth  = unit.Sp(428)
+	AppHeight = unit.Sp(740)
 )

--- a/ui/values/dimensions.go
+++ b/ui/values/dimensions.go
@@ -90,11 +90,11 @@ var (
 	TextSize34   = unit.Sp(34)
 	TextSize32   = unit.Sp(32)
 
-	AppWidth  = unit.Sp(800)
-	AppHeight = unit.Sp(600)
+	// AppWidth  = unit.Sp(800)
+	// AppHeight = unit.Sp(600)
 
-	// AppWidth  = unit.Sp(360)
-	// AppHeight = unit.Sp(740)
+	AppWidth  = unit.Sp(360)
+	AppHeight = unit.Sp(740)
 
 	// This defines the dimensions at which we consider the user to be using a
 	// mobile device. The dimensions specified are the default viewport for


### PR DESCRIPTION
This PR is a continuation of https://github.com/planetdecred/godcr/pull/948.

Changes Include

- [x] Add floating action button (FAB) to access send and receive page
- [x] Add staking to the bottom navigation bar
- [x] Add governance and staking to the more page(permanent staking location yet to be decided)
- [x] Hide the send and receive buttons from the top bar
- [x] Fix excess top space in the flex layout, just below the topbar
- [x] Fix security tools pages(Security tools, Verify Message & Validate Address) layout
- [x] Fix help page layout
- [x] Fix about page layout
- [x] Fix receive page layout
- [x] Fix restore seed page layout
- [x] Fix transactions page layout

**Screenshots**

| <img src="https://user-images.githubusercontent.com/25265396/171178678-07e5bdd8-73e3-4f1b-a424-744928741373.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/171178724-15d3337b-0b05-4b82-84e8-a82e91ee646e.png" height="500"> |
|-|-|

| <img src="https://user-images.githubusercontent.com/25265396/171178678-07e5bdd8-73e3-4f1b-a424-744928741373.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/171178940-b06ed7c7-a825-48a1-aa89-50120f8936af.png" height="500"> |
|-|-|

| <img src="https://user-images.githubusercontent.com/25265396/171180307-d8820105-b67c-4aac-80ac-5c638e498421.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/171180860-6418722d-a9a9-4daf-bcfb-9b62fcabf88e.png" height="500"> |
|-|-|

| <img src="https://user-images.githubusercontent.com/25265396/171497063-8f9ed48d-6f0f-403b-b5c4-23dc5ef7bce5.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/171497565-a0b6aef0-a9d8-45c4-94b2-a1bfbbb58d40.png" height="500"> |
|-|-|

| <img src="https://user-images.githubusercontent.com/25265396/171497830-229f36cd-3b8d-42d0-b6c5-d59f70c40ccc.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/171498505-8fbd8819-b86a-4224-acad-024847dbe97d.png" height="500"> |
|-|-|

| <img src="https://user-images.githubusercontent.com/25265396/171528361-d500ab0b-3a58-4457-b363-67fc82b6de6b.png" height="500">|<img src="https://user-images.githubusercontent.com/25265396/171528992-16b6a0ac-3ab2-471e-aaf9-ab36c0a15163.png" height="500"> |
|-|-|
