### PR TITLE
Prevent Command Prompt from opening with godcr on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ See [CONTRIBUTING.md](https://github.com/planetdecred/godcr/blob/master/.github/
 
 ## Other
 
-Earlier experimental work with other user interface toolkits can be found at [godcr-old](https://github.com/planetdecred/godcr-old).
+Earlier experimental work with other user interface toolkits can be found at [godcr-old](https://github.com/raedahgroup/godcr-old).

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 # This how we want to name the binary output
-BINARY=godcrtest
+BINARY=godcr
 
 VERSION="1.7.0"
 BUILD=`date -u +"%Y-%m-%dT%H:%M:%SZ"`

--- a/makefile
+++ b/makefile
@@ -31,3 +31,4 @@ windows:
 clean:
 	-rm -f ${BINARY}-*
 
+.PHONY: clean darwin windows linux freebsd

--- a/makefile
+++ b/makefile
@@ -9,21 +9,24 @@ BuildEnv="prod"
 LDFLAGS=-ldflags "-w -s -X main.Version=${VERSION} -X main.BuildDate=${BUILD} -X main.BuildEnv=${BuildEnv}"
 # LDFLAGSWIN adds the -H=windowsgui flag to windows build to prevent cli from starting alongside godcr
 LDFLAGSWIN= -ldflags "-H=windowsgui -w -s -X main.Version=${VERSION} -X main.BuildDate=${BUILD} -X main.BuildEnv=${BuildEnv}"
-export GOARCH=amd64
 
-all: clean darwin windows
+all: clean macos windows linux freebsd
 
 freebsd:
-	GOOS=freebsd go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
+	GOOS=freebsd GOARCH=amd64 go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
+	GOOS=freebsd GOARCH=arm64 go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
 
-darwin:
-	GOOS=darwin go build -trimpath ${LDFLAGS} -o ${BINARY}-darwin-${GOARCH}
+linux:
+	GOOS=linux GOARCH=amd64 go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
+	GOOS=freebsd GOARCH=arm64 go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
+
+macos:
+	GOOS=darwin GOARCH=amd64 go build -trimpath ${LDFLAGS} -o ${BINARY}-darwin-${GOARCH}
 
 windows:
-	GOOS=windows go build -trimpath ${LDFLAGSWIN} -o ${BINARY}-windows-${GOARCH}.exe
+	GOOS=windows GOARCH=amd64 go build -trimpath ${LDFLAGSWIN} -o ${BINARY}-windows-${GOARCH}.exe
  
 # Cleans our project: deletes old binaries
 clean:
 	-rm -f ${BINARY}-*
 
-.PHONY: clean darwin windows

--- a/makefile
+++ b/makefile
@@ -7,6 +7,7 @@ BUILD=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 BuildEnv="prod" 
 
 LDFLAGS=-ldflags "-w -s -X main.Version=${VERSION} -X main.BuildDate=${BUILD} -X main.BuildEnv=${BuildEnv}"
+# LDFLAGSWIN adds the -H=windowsgui flag to windows build to prevent cli from starting alongside godcr
 LDFLAGSWIN= -ldflags "-H=windowsgui -w -s -X main.Version=${VERSION} -X main.BuildDate=${BUILD} -X main.BuildEnv=${BuildEnv}"
 export GOARCH=amd64
 

--- a/makefile
+++ b/makefile
@@ -1,5 +1,5 @@
 # This how we want to name the binary output
-BINARY=godcr
+BINARY=godcrtest
 
 VERSION="1.7.0"
 BUILD=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
@@ -7,7 +7,7 @@ BUILD=`date -u +"%Y-%m-%dT%H:%M:%SZ"`
 BuildEnv="prod" 
 
 LDFLAGS=-ldflags "-w -s -X main.Version=${VERSION} -X main.BuildDate=${BUILD} -X main.BuildEnv=${BuildEnv}"
-
+LDFLAGSWIN= -ldflags "-H=windowsgui -w -s -X main.Version=${VERSION} -X main.BuildDate=${BUILD} -X main.BuildEnv=${BuildEnv}"
 export GOARCH=amd64
 
 all: clean darwin windows
@@ -19,7 +19,7 @@ darwin:
 	GOOS=darwin go build -trimpath ${LDFLAGS} -o ${BINARY}-darwin-${GOARCH}
 
 windows:
-	GOOS=windows go build -trimpath ${LDFLAGS} -o ${BINARY}-windows-${GOARCH}.exe
+	GOOS=windows go build -trimpath ${LDFLAGSWIN} -o ${BINARY}-windows-${GOARCH}.exe
  
 # Cleans our project: deletes old binaries
 clean:

--- a/makefile
+++ b/makefile
@@ -22,6 +22,7 @@ linux:
 
 macos:
 	GOOS=darwin GOARCH=amd64 go build -trimpath ${LDFLAGS} -o ${BINARY}-darwin-${GOARCH}
+	GOOS=darwin GOARCH=arm64 go build -trimpath ${LDFLAGS} -o ${BINARY}-darwin-${GOARCH}
 
 windows:
 	GOOS=windows GOARCH=amd64 go build -trimpath ${LDFLAGSWIN} -o ${BINARY}-windows-${GOARCH}.exe

--- a/makefile
+++ b/makefile
@@ -18,7 +18,7 @@ freebsd:
 
 linux:
 	GOOS=linux GOARCH=amd64 go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
-	GOOS=freebsd GOARCH=arm64 go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
+	GOOS=linux GOARCH=arm64 go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
 
 macos:
 	GOOS=darwin GOARCH=amd64 go build -trimpath ${LDFLAGS} -o ${BINARY}-darwin-${GOARCH}

--- a/makefile
+++ b/makefile
@@ -17,8 +17,8 @@ freebsd:
 	GOOS=freebsd GOARCH=arm64 go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
 
 linux:
-	GOOS=linux GOARCH=amd64 go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
-	GOOS=linux GOARCH=arm64 go build -trimpath ${LDFLAGS} -o ${BINARY}-freebsd-${GOARCH}
+	GOOS=linux GOARCH=amd64 go build -trimpath ${LDFLAGS} -o ${BINARY}-linux-${GOARCH}
+	GOOS=linux GOARCH=arm64 go build -trimpath ${LDFLAGS} -o ${BINARY}-linux-${GOARCH}
 
 macos:
 	GOOS=darwin GOARCH=amd64 go build -trimpath ${LDFLAGS} -o ${BINARY}-darwin-${GOARCH}


### PR DESCRIPTION
Closes #968 

This PR modifies the build process for windows to prevent the Command Prompt from opening with godcr on windows

The fix implemented was adding the `-H=windowsgui` flag to the windows build command. The tag hides the terminal and uses only the GUI.

This PR also updates the makefile and modifies incorrect links in the readme file 