### PR TITLE
account for user interaction on governance sub pages

### DIFF
--- a/ui/page/governance/governance_page.go
+++ b/ui/page/governance/governance_page.go
@@ -96,6 +96,12 @@ func (pg *Page) HandleUserInteractions() {
 			pg.Display(NewConsensusPage(pg.Load))
 		}
 	}
+
+	// Handle individual page user interactions.
+	if activeTab := pg.CurrentPage(); activeTab != nil {
+		activeTab.HandleUserInteractions()
+	}
+
 }
 
 func (pg *Page) Layout(gtx C) D {


### PR DESCRIPTION
Resolves #997 

Previously, the user interaction on the governance sub pages were not being handled by the master page(Governance page), so all click events were ignored.

the solution was to initialize the `HandleUserInteractions()` method of the sub pages from the governance page