### PR TITLE
fix governance click bug

### DIFF
--- a/ui/page/components/votebar_widget.go
+++ b/ui/page/components/votebar_widget.go
@@ -260,12 +260,13 @@ func (v *VoteBar) layoutIconAndText(gtx C, lbl decredmaterial.Label, count int, 
 				return lbl.Layout(gtx)
 			}),
 			layout.Rigid(func(gtx C) D {
-				percentage := (count / v.totalVotes) * 100
+				count := float64(count)
+				percentage := (count / float64(v.totalVotes)) * 100
 				if percentage < 0 {
 					percentage = 0
 				}
-				percentageStr := strconv.FormatFloat(float64(percentage), 'f', 1, 64) + "%"
-				countStr := strconv.FormatFloat(float64(count), 'f', 0, 64)
+				percentageStr := strconv.FormatFloat(percentage, 'f', 1, 64) + "%"
+				countStr := strconv.FormatFloat(count, 'f', 0, 64)
 
 				return v.Theme.Body1(fmt.Sprintf("%s (%s)", countStr, percentageStr)).Layout(gtx)
 			}),

--- a/ui/page/governance/governance_page.go
+++ b/ui/page/governance/governance_page.go
@@ -79,6 +79,10 @@ func (pg *Page) OnNavigatedFrom() {
 }
 
 func (pg *Page) HandleUserInteractions() {
+	if activeTab := pg.CurrentPage(); activeTab != nil {
+		activeTab.HandleUserInteractions()
+	}
+
 	for pg.splashScreenInfoButton.Button.Clicked() {
 		pg.showInfoModal()
 	}


### PR DESCRIPTION
fix #997 

Previously, the user interaction on the governance sub pages were not being handled by the master page(Governance page), so all click events were ignored. The solution was to initialize the `HandleUserInteractions()` method of the sub pages from the governance page.


Fix app crash when the reject dropdown option is selected. This was as a result of integer from the error. 0/0 = infinity converting this to floating points 
