### PR TITLE
Fix overflow when navigation is collapsed

### DIFF
--- a/ui/page/components/nav_drawer.go
+++ b/ui/page/components/nav_drawer.go
@@ -39,6 +39,7 @@ type NavDrawer struct {
 	MinimizeNavDrawerButton decredmaterial.IconButton
 	MaximizeNavDrawerButton decredmaterial.IconButton
 	activeDrawerBtn         decredmaterial.IconButton
+	IsNavExpanded           bool
 }
 
 func (nd *NavDrawer) LayoutNavDrawer(gtx layout.Context) layout.Dimensions {
@@ -76,17 +77,21 @@ func (nd *NavDrawer) LayoutNavDrawer(gtx layout.Context) layout.Dimensions {
 						return img.Layout24dp(gtx)
 					}),
 					layout.Rigid(func(gtx C) D {
-						return layout.Inset{
-							Left: nd.leftInset,
-						}.Layout(gtx, func(gtx C) D {
-							textColor := nd.Theme.Color.GrayText1
-							if nd.DrawerNavItems[i].PageID == nd.CurrentPage {
-								textColor = nd.Theme.Color.DeepBlue
-							}
-							txt := nd.Theme.Label(nd.textSize, nd.DrawerNavItems[i].Title)
-							txt.Color = textColor
-							return txt.Layout(gtx)
-						})
+						if !nd.IsNavExpanded {
+							return layout.Inset{
+								Left: nd.leftInset,
+							}.Layout(gtx, func(gtx C) D {
+								textColor := nd.Theme.Color.GrayText1
+								if nd.DrawerNavItems[i].PageID == nd.CurrentPage {
+									textColor = nd.Theme.Color.DeepBlue
+								}
+								txt := nd.Theme.Label(nd.textSize, nd.DrawerNavItems[i].Title)
+								txt.Color = textColor
+								return txt.Layout(gtx)
+							})
+						}
+
+						return D{}
 					}),
 				)
 			})

--- a/ui/page/components/nav_drawer.go
+++ b/ui/page/components/nav_drawer.go
@@ -149,7 +149,6 @@ func (nd *NavDrawer) LayoutTopBar(gtx layout.Context) layout.Dimensions {
 func (nd *NavDrawer) DrawerToggled(min bool) {
 	if min {
 		nd.axis = layout.Vertical
-		nd.textSize = values.TextSize12
 		nd.leftInset = values.MarginPadding0
 		nd.width = navDrawerMinimizedWidth
 		nd.activeDrawerBtn = nd.MaximizeNavDrawerButton

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -86,7 +86,6 @@ type MainPage struct {
 	usdExchangeSet         bool
 	isFetchingExchangeRate bool
 	isBalanceHidden        bool
-	isNavExpanded          bool
 
 	setNavExpanded  func()
 	totalBalanceUSD string
@@ -120,7 +119,7 @@ func NewMainPage(l *load.Load) *MainPage {
 	mp.refreshExchangeRateBtn = mp.Theme.NewClickable(true)
 
 	mp.setNavExpanded = func() {
-		mp.drawerNav.DrawerToggled(mp.isNavExpanded)
+		mp.drawerNav.DrawerToggled(mp.drawerNav.IsNavExpanded)
 	}
 
 	mp.bottomNavigationBar.OnViewCreated()
@@ -470,12 +469,12 @@ func (mp *MainPage) HandleUserInteractions() {
 	mp.floatingActionButton.CurrentPage = mp.CurrentPageID()
 
 	for mp.drawerNav.MinimizeNavDrawerButton.Button.Clicked() {
-		mp.isNavExpanded = true
+		mp.drawerNav.IsNavExpanded = true
 		mp.setNavExpanded()
 	}
 
 	for mp.drawerNav.MaximizeNavDrawerButton.Button.Clicked() {
-		mp.isNavExpanded = false
+		mp.drawerNav.IsNavExpanded = false
 		mp.setNavExpanded()
 	}
 


### PR DESCRIPTION
Closes #1004 
This PR removes the text from navigation items when they are collapsed.

![image](https://user-images.githubusercontent.com/66803475/186538459-2c6613c6-7fa6-412e-999e-22cbd49d58d1.png)

