### PR TITLE
Disable receive, send and mixer navigation option for watch only wallet.

### DIFF
--- a/ui/modal/create_password_modal.go
+++ b/ui/modal/create_password_modal.go
@@ -103,6 +103,11 @@ func (cm *CreatePasswordModal) EnableConfirmPassword(enable bool) *CreatePasswor
 	return cm
 }
 
+func (cm *CreatePasswordModal) NameHint(hint string) *CreatePasswordModal {
+	cm.walletName.Hint = hint
+	return cm
+}
+
 func (cm *CreatePasswordModal) PasswordHint(hint string) *CreatePasswordModal {
 	cm.passwordEditor.Hint = hint
 	return cm

--- a/ui/page/components/nav_drawer.go
+++ b/ui/page/components/nav_drawer.go
@@ -51,8 +51,16 @@ func (nd *NavDrawer) LayoutNavDrawer(gtx layout.Context) layout.Dimensions {
 		layout.Rigid(func(gtx C) D {
 			list := layout.List{Axis: layout.Vertical}
 			return list.Layout(gtx, len(nd.DrawerNavItems), func(gtx C, i int) D {
-
+				mGtx := gtx
 				background := nd.Theme.Color.Surface
+
+				if nd.WL.SelectedWallet.Wallet.IsWatchingOnlyWallet() && (nd.DrawerNavItems[i].PageID == values.String(values.StrSend) ||
+					nd.DrawerNavItems[i].PageID == values.String(values.StrReceive) ||
+					nd.DrawerNavItems[i].PageID == values.String(values.StrAccountMixer)) {
+					background = decredmaterial.Disabled(nd.Theme.Color.Gray5)
+					mGtx = gtx.Disabled()
+				}
+
 				if nd.DrawerNavItems[i].PageID == nd.CurrentPage {
 					background = nd.Theme.Color.Gray5
 				}
@@ -65,7 +73,7 @@ func (nd *NavDrawer) LayoutNavDrawer(gtx layout.Context) layout.Dimensions {
 					Direction:   nd.direction,
 					Background:  background,
 					Clickable:   nd.DrawerNavItems[i].Clickable,
-				}.Layout(gtx,
+				}.Layout(mGtx,
 					layout.Rigid(func(gtx C) D {
 						img := nd.DrawerNavItems[i].ImageInactive
 

--- a/ui/page/main_page.go
+++ b/ui/page/main_page.go
@@ -640,7 +640,7 @@ func (mp *MainPage) OnNavigatedFrom() {
 // Layout draws the page UI components into the provided layout context
 // to be eventually drawn on screen.
 // Part of the load.Page interface.
-func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
+func (mp *MainPage) Layout(gtx C) D {
 	mp.Load.SetCurrentAppWidth(gtx.Constraints.Max.X)
 	if mp.Load.GetCurrentAppWidth() <= gtx.Dp(values.StartMobileView) {
 		return mp.layoutMobile(gtx)
@@ -648,7 +648,7 @@ func (mp *MainPage) Layout(gtx layout.Context) layout.Dimensions {
 	return mp.layoutDesktop(gtx)
 }
 
-func (mp *MainPage) layoutDesktop(gtx layout.Context) layout.Dimensions {
+func (mp *MainPage) layoutDesktop(gtx C) D {
 	return layout.Stack{}.Layout(gtx,
 		layout.Expanded(func(gtx C) D {
 			return decredmaterial.LinearLayout{
@@ -677,7 +677,7 @@ func (mp *MainPage) layoutDesktop(gtx layout.Context) layout.Dimensions {
 	)
 }
 
-func (mp *MainPage) layoutMobile(gtx layout.Context) layout.Dimensions {
+func (mp *MainPage) layoutMobile(gtx C) D {
 	return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 		layout.Rigid(mp.LayoutTopBar),
 		layout.Flexed(1, func(gtx C) D {
@@ -685,7 +685,7 @@ func (mp *MainPage) layoutMobile(gtx layout.Context) layout.Dimensions {
 				layout.Expanded(func(gtx C) D {
 					currentPage := mp.CurrentPage()
 					if currentPage == nil {
-						return layout.Dimensions{}
+						return D{}
 					}
 					return currentPage.Layout(gtx)
 				}),
@@ -698,7 +698,7 @@ func (mp *MainPage) layoutMobile(gtx layout.Context) layout.Dimensions {
 	)
 }
 
-func (mp *MainPage) LayoutUSDBalance(gtx layout.Context) layout.Dimensions {
+func (mp *MainPage) LayoutUSDBalance(gtx C) D {
 	if !mp.usdExchangeSet {
 		return D{}
 	}
@@ -747,7 +747,7 @@ func (mp *MainPage) totalDCRBalance(gtx C) D {
 	return components.LayoutBalanceWithUnit(gtx, mp.Load, mp.totalBalance.String())
 }
 
-func (mp *MainPage) LayoutTopBar(gtx layout.Context) layout.Dimensions {
+func (mp *MainPage) LayoutTopBar(gtx C) D {
 	return decredmaterial.LinearLayout{
 		Width:       decredmaterial.MatchParent,
 		Height:      decredmaterial.WrapContent,

--- a/ui/page/settings_page.go
+++ b/ui/page/settings_page.go
@@ -104,7 +104,7 @@ func (pg *SettingsPage) Layout(gtx C) D {
 	return pg.layoutDesktop(gtx)
 }
 
-func (pg *SettingsPage) layoutDesktop(gtx layout.Context) layout.Dimensions {
+func (pg *SettingsPage) layoutDesktop(gtx C) D {
 	return layout.UniformInset(values.MarginPadding20).Layout(gtx, func(gtx C) D {
 		return layout.Flex{Axis: layout.Vertical}.Layout(gtx,
 			layout.Rigid(pg.pageHeaderLayout),
@@ -115,7 +115,7 @@ func (pg *SettingsPage) layoutDesktop(gtx layout.Context) layout.Dimensions {
 	})
 }
 
-func (pg *SettingsPage) pageHeaderLayout(gtx layout.Context) layout.Dimensions {
+func (pg *SettingsPage) pageHeaderLayout(gtx C) layout.Dimensions {
 	return layout.Flex{Spacing: layout.SpaceBetween}.Layout(gtx,
 		layout.Flexed(1, func(gtx C) D {
 			return layout.W.Layout(gtx, func(gtx C) D {
@@ -133,14 +133,14 @@ func (pg *SettingsPage) pageHeaderLayout(gtx layout.Context) layout.Dimensions {
 	)
 }
 
-func (pg *SettingsPage) pageContentLayout(gtx layout.Context) layout.Dimensions {
+func (pg *SettingsPage) pageContentLayout(gtx C) D {
 	pageContent := []func(gtx C) D{
 		pg.general(),
 		pg.security(),
 		pg.info(),
 	}
 	gtx.Constraints.Min.X = gtx.Constraints.Max.X
-	return layout.Center.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
+	return layout.Center.Layout(gtx, func(gtx C) D {
 		gtx.Constraints.Min.X = gtx.Dp(values.MarginPadding500)
 		gtx.Constraints.Max.X = gtx.Constraints.Min.X
 		gtx.Constraints.Min.Y = gtx.Constraints.Max.Y
@@ -150,8 +150,8 @@ func (pg *SettingsPage) pageContentLayout(gtx layout.Context) layout.Dimensions 
 	})
 }
 
-func (pg *SettingsPage) layoutMobile(gtx layout.Context) layout.Dimensions {
-	return layout.Dimensions{}
+func (pg *SettingsPage) layoutMobile(gtx C) D {
+	return D{}
 }
 
 func (pg *SettingsPage) settingLine(gtx C) D {

--- a/ui/page/wallet_settings_page.go
+++ b/ui/page/wallet_settings_page.go
@@ -282,7 +282,11 @@ func (pg *WalletSettingsPage) pageSections(gtx C, title string, body layout.Widg
 							}
 							if title == values.String(values.StrAccount) {
 								return layout.E.Layout(gtx, func(gtx C) D {
-									return pg.addAccount.Layout(gtx, pg.Theme.Icons.AddIcon.Layout24dp)
+									mGtx := gtx
+									if pg.WL.SelectedWallet.Wallet.IsWatchingOnlyWallet() {
+										mGtx = gtx.Disabled()
+									}
+									return pg.addAccount.Layout(mGtx, pg.Theme.Icons.AddIcon.Layout24dp)
 								})
 							}
 
@@ -699,6 +703,7 @@ func (pg *WalletSettingsPage) HandleUserInteractions() {
 		newPasswordModal := modal.NewCreatePasswordModal(pg.Load).
 			Title(values.String(values.StrCreateNewAccount)).
 			EnableName(true).
+			NameHint(values.String(values.StrAcctName)).
 			EnableConfirmPassword(false).
 			PasswordHint(values.String(values.StrSpendingPassword)).
 			PasswordCreated(func(accountName, password string, m *modal.CreatePasswordModal) bool {

--- a/ui/values/localizable/en.go
+++ b/ui/values/localizable/en.go
@@ -506,4 +506,5 @@ unlockWithPassword = "Unlock with password"
 "removeWalletInfo" = "%v Are you sure you want to remove %v %s%v? Enter the name of the wallet below to verify. %v"
 "confirmUmixedSpending" = "Confirm to allow spending from unmixed accounts"
 "ok" = "OK"
+"accountMixer" = "AccountMixer"
 `

--- a/ui/values/localizable/es.go
+++ b/ui/values/localizable/es.go
@@ -486,4 +486,5 @@ syncCompTime" = "Est. Sync completion time"
 "peer" = "Peer"
 "confirmUmixedSpending" = "Confirm to allow spending from unmixed accounts"
 "ok" = "OK"
+"accountMixer" = "AccountMixer"
 `

--- a/ui/values/localizable/fr.go
+++ b/ui/values/localizable/fr.go
@@ -463,4 +463,5 @@ const FR = `
 "peer" = "Peer"
 "confirmUmixedSpending" = "Confirm to allow spending from unmixed accounts"
 "ok" = "OK"
+"accountMixer" = "AccountMixer"
 `

--- a/ui/values/strings.go
+++ b/ui/values/strings.go
@@ -612,4 +612,5 @@ const (
 	StrPeer                            = "peer"
 	StrConfirmUmixedSpending           = "confirmUmixedSpending"
 	StrOK                              = "ok"
+	StrAccountMixer                    = "accountMixer"
 )


### PR DESCRIPTION
Fix #1050 

This Pr disables the send, receive, and stakeshuffle navigation option for watch only wallets. it also disables create account settings button.

watch only wallets as the name implies are for watching only and do not send or receive funds. Also since they dont send and receive funds, they cannot create new account or mix funds well.

<img width="801" alt="image" src="https://user-images.githubusercontent.com/27733432/187169667-76fdaf36-a73b-4de9-8d04-6422eddbe82c.png">
